### PR TITLE
CM_Tools_Generator_CliTest changes app's internal.php

### DIFF
--- a/bin/cm
+++ b/bin/cm
@@ -10,8 +10,10 @@ if (count($autoloadPaths) === 0) {
 $autoloadPath = reset($autoloadPaths);
 
 require $autoloadPath;
-$bootloader = new CM_Bootloader(dirname(dirname(realpath($autoloadPath))) . '/');
-$bootloader->load();
+$rootPath = dirname(dirname(realpath($autoloadPath))) . '/';
+
+$application = new CM_App($rootPath);
+$application->bootstrap();
 
 $manager = new CM_Cli_CommandManager();
 $manager->autoloadCommands();

--- a/library/CM/App.php
+++ b/library/CM/App.php
@@ -188,6 +188,13 @@ class CM_App implements CM_Service_ManagerAwareInterface {
     }
 
     /**
+     * @return string
+     */
+    public function getRootPath() {
+        return $this->_rootPath;
+    }
+
+    /**
      * @return string[]
      */
     private function _getUpdateScriptPaths() {

--- a/library/CM/App.php
+++ b/library/CM/App.php
@@ -1,6 +1,11 @@
 <?php
 
-class CM_App {
+class CM_App implements CM_Service_ManagerAwareInterface {
+
+    use CM_Service_ManagerAwareTrait;
+
+    /** @var string */
+    private $_rootPath;
 
     /**
      * @var CM_App
@@ -8,11 +13,31 @@ class CM_App {
     private static $_instance;
 
     /**
+     * @param string $rootPath
+     */
+    public function __construct($rootPath) {
+        $this->_rootPath = (string) $rootPath;
+
+        if (!self::$_instance) {
+            self::$_instance = $this;
+        }
+    }
+
+    public function bootstrap() {
+        if (!CM_Bootloader::isLoaded()) {
+            $bootloader = new CM_Bootloader($this->_rootPath);
+            $bootloader->load();
+        }
+        $this->setServiceManager(CM_Service_Manager::getInstance());
+    }
+
+    /**
+     * @throws CM_Exception_Invalid
      * @return CM_App
      */
     public static function getInstance() {
         if (!self::$_instance) {
-            self::$_instance = new self();
+            throw new CM_Exception_Invalid('Cannot find CM_App instance');
         }
         return self::$_instance;
     }
@@ -113,7 +138,7 @@ class CM_App {
 
     /**
      * @param Closure|null $callbackBefore fn($version)
-     * @param Closure|null $callbackAfter  fn($version)
+     * @param Closure|null $callbackAfter fn($version)
      * @return int Number of version bumps
      */
     public function runUpdateScripts(Closure $callbackBefore = null, Closure $callbackAfter = null) {

--- a/library/CM/App/Cli.php
+++ b/library/CM/App/Cli.php
@@ -58,6 +58,8 @@ class CM_App_Cli extends CM_Cli_Runnable_Abstract {
     }
 
     public function generateConfigInternal() {
+        $rootPath = new CM_File($this->_getApplication()->getRootPath());
+
         $indentation = '    ';
         $indent = function ($content) use ($indentation) {
             return preg_replace('/(:?^|[\n])/', '$1' . $indentation, $content);
@@ -74,7 +76,7 @@ class CM_App_Cli extends CM_Cli_Runnable_Abstract {
         }
 
         // Create model class types and action verbs config PHP
-        $configPhp = new CM_File(DIR_ROOT . 'resources/config/internal.php');
+        $configPhp = $rootPath->joinPath('resources/config/internal.php');
         $configPhp->ensureParentDirectory();
         $configPhp->truncate();
         $configPhp->appendLine('<?php');
@@ -87,7 +89,7 @@ class CM_App_Cli extends CM_Cli_Runnable_Abstract {
         $this->_getStreamOutput()->writeln('Created `' . $configPhp->getPath() . '`');
 
         // Create model class types and action verbs config JS
-        $configJs = new CM_File(DIR_ROOT . 'resources/config/js/internal.js');
+        $configJs = $rootPath->joinPath('resources/config/js/internal.js');
         $configJs->ensureParentDirectory();
         $configJs->truncate();
         $classTypes = $generator->getNamespaceTypes();
@@ -100,6 +102,7 @@ class CM_App_Cli extends CM_Cli_Runnable_Abstract {
      * @param int|null $deployVersion
      */
     public function setDeployVersion($deployVersion = null) {
+        $rootPath = new CM_File($this->_getApplication()->getRootPath());
         $deployVersion = (null !== $deployVersion) ? (int) $deployVersion : time();
         $sourceCode = join(PHP_EOL, array(
             '<?php',
@@ -108,8 +111,7 @@ class CM_App_Cli extends CM_Cli_Runnable_Abstract {
             '};',
             '',
         ));
-        $targetPath = DIR_ROOT . 'resources/config/deploy.php';
-        $configFile = new CM_File($targetPath);
+        $configFile = $rootPath->joinPath('resources/config/deploy.php');
         $configFile->ensureParentDirectory();
         $configFile->write($sourceCode);
     }

--- a/library/CM/Bootloader.php
+++ b/library/CM/Bootloader.php
@@ -23,8 +23,8 @@ class CM_Bootloader {
      * @throws CM_Exception_Invalid
      */
     public function __construct($pathRoot) {
-        if (self::$_instance) {
-            throw new CM_Exception_Invalid('Bootloader already instantiated');
+        if (self::isLoaded()) {
+            throw new CM_Exception_Invalid('Bootloader already loaded');
         }
         self::$_instance = $this;
 
@@ -212,9 +212,16 @@ class CM_Bootloader {
      * @throws Exception
      */
     public static function getInstance() {
-        if (!self::$_instance) {
+        if (!self::isLoaded()) {
             throw new Exception('No bootloader instance');
         }
         return self::$_instance;
+    }
+
+    /**
+     * @return bool
+     */
+    public static function isLoaded() {
+        return (bool) self::$_instance;
     }
 }

--- a/library/CM/Cli/Command.php
+++ b/library/CM/Cli/Command.php
@@ -18,15 +18,20 @@ class CM_Cli_Command {
     }
 
     /**
+     * @param CM_App                    $application
      * @param CM_Cli_Arguments          $arguments
      * @param CM_InputStream_Interface  $streamInput
      * @param CM_OutputStream_Interface $streamOutput
      * @param CM_OutputStream_Interface $streamError
+     * @throws CM_Cli_Exception_InvalidArguments
      */
-    public function run(CM_Cli_Arguments $arguments, CM_InputStream_Interface $streamInput, CM_OutputStream_Interface $streamOutput, CM_OutputStream_Interface $streamError) {
+    public function run(CM_App $application, CM_Cli_Arguments $arguments, CM_InputStream_Interface $streamInput, CM_OutputStream_Interface $streamOutput, CM_OutputStream_Interface $streamError) {
         $parameters = $arguments->extractMethodParameters($this->_method);
         $arguments->checkUnused();
-        call_user_func_array(array($this->_class->newInstance($streamInput, $streamOutput, $streamError), $this->_method->getName()), $parameters);
+        /** @var CM_Cli_Runnable_Abstract $runnable */
+        $runnable = $this->_class->newInstance($streamInput, $streamOutput, $streamError);
+        $runnable->setApplication($application);
+        call_user_func_array(array($runnable, $this->_method->getName()), $parameters);
     }
 
     /**

--- a/library/CM/Cli/CommandManager.php
+++ b/library/CM/Cli/CommandManager.php
@@ -16,8 +16,17 @@ class CM_Cli_CommandManager {
     /** @var CM_OutputStream_Interface */
     private $_streamOutput, $_streamError;
 
-    public function __construct() {
+    /** @var CM_App */
+    private $_application;
+
+    /**
+     * @param CM_App $application
+     * @throws CM_Exception_Invalid
+     */
+    public function __construct(CM_App $application) {
+        $this->_application = $application;
         $this->_commands = array();
+
         $this->_setStreamInput(new CM_InputStream_Readline());
         $this->_setStreamOutput(new CM_OutputStream_Stream_StandardOutput());
         $this->_setStreamError(new CM_OutputStream_Stream_StandardError());
@@ -175,7 +184,7 @@ class CM_Cli_CommandManager {
                 } else {
                     CMService_Newrelic::getInstance()->startTransaction($transactionName);
                 }
-                $command->run($arguments, $streamInput, $streamOutput, $streamError);
+                $command->run($this->_application, $arguments, $streamInput, $streamOutput, $streamError);
             };
 
             $forks = max($this->_forks, 1);

--- a/library/CM/Cli/Runnable/Abstract.php
+++ b/library/CM/Cli/Runnable/Abstract.php
@@ -2,6 +2,9 @@
 
 abstract class CM_Cli_Runnable_Abstract {
 
+    /** @var CM_App|null */
+    private $_application;
+
     /** @var CM_InputStream_Interface */
     private $_streamInput;
 
@@ -14,6 +17,7 @@ abstract class CM_Cli_Runnable_Abstract {
      * @param CM_OutputStream_Interface|null $streamError
      */
     public function __construct(CM_InputStream_Interface $streamInput = null, CM_OutputStream_Interface $streamOutput = null, CM_OutputStream_Interface $streamError = null) {
+
         if (null === $streamInput) {
             $streamInput = new CM_InputStream_Null();
         }
@@ -29,7 +33,21 @@ abstract class CM_Cli_Runnable_Abstract {
         $this->_initialize();
     }
 
+    /**
+     * @param CM_App|null $application
+     */
+    public function setApplication(CM_App $application = null) {
+        $this->_application = $application;
+    }
+
     protected function _initialize() {
+    }
+
+    /**
+     * @return CM_App|null
+     */
+    protected function _getApplication() {
+        return $this->_application;
     }
 
     /**

--- a/library/CM/Db/Client.php
+++ b/library/CM/Db/Client.php
@@ -257,6 +257,17 @@ class CM_Db_Client {
         return '`' . str_replace('`', '``', $name) . '`';
     }
 
+    public function __sleep() {
+        return array(
+            '_host',
+            '_port',
+            '_username',
+            '_password',
+            '_db',
+            '_reconnectTimeout',
+        );
+    }
+
     /**
      * @return bool
      */

--- a/library/CM/Maintenance/Cli.php
+++ b/library/CM/Maintenance/Cli.php
@@ -88,7 +88,7 @@ class CM_Maintenance_Cli extends CM_Cli_Runnable_Abstract {
     protected function _registerCallbacksLocal() {
         $this->_registerClockworkCallbacks('1 minute', array(
             'CM_Cli_CommandManager::monitorSynchronizedCommands' => function () {
-                $commandManager = new CM_Cli_CommandManager();
+                $commandManager = new CM_Cli_CommandManager($this->_getApplication());
                 $commandManager->monitorSynchronizedCommands();
             },
             'CM_SVM_Model::trainChanged'                         => function () {

--- a/library/CM/Tools/Generator/Cli.php
+++ b/library/CM/Tools/Generator/Cli.php
@@ -115,7 +115,9 @@ class CM_Tools_Generator_Cli extends CM_Cli_Runnable_Abstract {
         $config->$className->urlCdn = 'http://origin-www.' . $domain;
         $generatorConfig->addEntries($file, $config);
 
-        (new CM_App_Cli())->generateConfigInternal();
+        $appCli = new CM_App_Cli();
+        $appCli->setApplication($this->_getApplication());
+        $appCli->generateConfigInternal();
     }
 
     /**

--- a/library/CM/Tools/Generator/Cli.php
+++ b/library/CM/Tools/Generator/Cli.php
@@ -77,7 +77,9 @@ class CM_Tools_Generator_Cli extends CM_Cli_Runnable_Abstract {
         $generatorPhp = new CM_Tools_Generator_Class_Php($this->_getAppInstallation(), $this->_getStreamOutput());
         $generatorPhp->createClassFile($className);
 
-        (new CM_App_Cli())->generateConfigInternal();
+        $appCli = new CM_App_Cli();
+        $appCli->setApplication($this->_getApplication());
+        $appCli->generateConfigInternal();
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,13 @@
 <?php
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
+$rootPath = dirname(__DIR__) . '/';
 
-$bootloader = new CM_Bootloader_Testing(dirname(__DIR__) . '/');
+$bootloader = new CM_Bootloader_Testing($rootPath);
 $bootloader->load();
+
+$application = new CM_App($rootPath);
+$application->bootstrap();
 
 $suite = new CMTest_TestSuite();
 $suite->setDirTestData(__DIR__ . '/data/');

--- a/tests/library/CM/Tools/Generator/CliTest.php
+++ b/tests/library/CM/Tools/Generator/CliTest.php
@@ -172,6 +172,8 @@ class CM_Tools_Generator_CliTest extends CMTest_TestCase {
     private function _mockGeneratorCli(CM_Tools_AppInstallation $appInstallation) {
         $cli = $this->mockObject('CM_Tools_Generator_Cli');
         $cli->mockMethod('_getAppInstallation')->set($appInstallation);
+        /** @var $cli CM_Tools_Generator_Cli */
+        $cli->setApplication(new CM_App($appInstallation->getDirRoot()));
         return $cli;
     }
 


### PR DESCRIPTION
```
$ git st

$ bin/phpunit tests/library/CM/Tools/Generator/CliTest.php 

$ git st
 M resources/config/internal.php

$ git diff
diff --git a/resources/config/internal.php b/resources/config/internal.php
index 2276c90..22d6682 100644
--- a/resources/config/internal.php
+++ b/resources/config/internal.php
@@ -77,8 +77,9 @@ return function (CM_Config_Node $config) {
     $config->CM_Model_Location_State->type = 29;
     $config->CM_Model_Location_Zip->type = 30;
     $config->CM_Model_LanguageKey->type = 31;
+    $config->CM_Site_Abstract_Mock32_5478a1d38278d->type = 32;

-    $config->CM_Class_Abstract->typesMaxValue = 31;
+    $config->CM_Class_Abstract->typesMaxValue = 32;

     $config->CM_Action_Abstract->verbs = array();
     $config->CM_Action_Abstract->verbs[CM_Action_Abstract::CREATE] = 1;

```
