### PR TITLE
Update jquery.cookie.js from 1.1 to 1.4.1.

### DIFF
--- a/client-vendor/after-body/jquery.cookie/jquery.cookie.js
+++ b/client-vendor/after-body/jquery.cookie/jquery.cookie.js
@@ -1,42 +1,71 @@
-/*jshint eqnull:true */
 /*!
- * jQuery Cookie Plugin v1.1
+ * jQuery Cookie Plugin v1.4.1
  * https://github.com/carhartl/jquery-cookie
  *
- * Copyright 2011, Klaus Hartl
- * Dual licensed under the MIT or GPL Version 2 licenses.
- * http://www.opensource.org/licenses/mit-license.php
- * http://www.opensource.org/licenses/GPL-2.0
+ * Copyright 2013 Klaus Hartl
+ * Released under the MIT license
  */
-(function($, document) {
+(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD
+		define(['jquery'], factory);
+	} else if (typeof exports === 'object') {
+		// CommonJS
+		factory(require('jquery'));
+	} else {
+		// Browser globals
+		factory(jQuery);
+	}
+}(function ($) {
 
 	var pluses = /\+/g;
-	function raw(s) {
-		return s;
-	}
-	function decoded(s) {
-		return decodeURIComponent(s.replace(pluses, ' '));
+
+	function encode(s) {
+		return config.raw ? s : encodeURIComponent(s);
 	}
 
-	$.cookie = function(key, value, options) {
+	function decode(s) {
+		return config.raw ? s : decodeURIComponent(s);
+	}
 
-		// key and at least value given, set cookie...
-		if (arguments.length > 1 && (!/Object/.test(Object.prototype.toString.call(value)) || value == null)) {
-			options = $.extend({}, $.cookie.defaults, options);
+	function stringifyCookieValue(value) {
+		return encode(config.json ? JSON.stringify(value) : String(value));
+	}
 
-			if (value == null) {
-				options.expires = -1;
-			}
+	function parseCookieValue(s) {
+		if (s.indexOf('"') === 0) {
+			// This is a quoted cookie as according to RFC2068, unescape...
+			s = s.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+		}
+
+		try {
+			// Replace server-side written pluses with spaces.
+			// If we can't decode the cookie, ignore it, it's unusable.
+			// If we can't parse the cookie, ignore it, it's unusable.
+			s = decodeURIComponent(s.replace(pluses, ' '));
+			return config.json ? JSON.parse(s) : s;
+		} catch(e) {}
+	}
+
+	function read(s, converter) {
+		var value = config.raw ? s : parseCookieValue(s);
+		return $.isFunction(converter) ? converter(value) : value;
+	}
+
+	var config = $.cookie = function (key, value, options) {
+
+		// Write
+
+		if (value !== undefined && !$.isFunction(value)) {
+			options = $.extend({}, config.defaults, options);
 
 			if (typeof options.expires === 'number') {
 				var days = options.expires, t = options.expires = new Date();
-				t.setDate(t.getDate() + days);
+				t.setTime(+t + days * 864e+5);
 			}
 
-			value = String(value);
-
 			return (document.cookie = [
-				encodeURIComponent(key), '=', options.raw ? value : encodeURIComponent(value),
+				encode(key), '=', stringifyCookieValue(value),
 				options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
 				options.path    ? '; path=' + options.path : '',
 				options.domain  ? '; domain=' + options.domain : '',
@@ -44,18 +73,45 @@
 			].join(''));
 		}
 
-		// key and possibly options given, get cookie...
-		options = value || $.cookie.defaults || {};
-		var decode = options.raw ? raw : decoded;
-		var cookies = document.cookie.split('; ');
-		for (var i = 0, parts; (parts = cookies[i] && cookies[i].split('=')); i++) {
-			if (decode(parts.shift()) === key) {
-				return decode(parts.join('='));
+		// Read
+
+		var result = key ? undefined : {};
+
+		// To prevent the for loop in the first place assign an empty array
+		// in case there are no cookies at all. Also prevents odd result when
+		// calling $.cookie().
+		var cookies = document.cookie ? document.cookie.split('; ') : [];
+
+		for (var i = 0, l = cookies.length; i < l; i++) {
+			var parts = cookies[i].split('=');
+			var name = decode(parts.shift());
+			var cookie = parts.join('=');
+
+			if (key && key === name) {
+				// If second argument (value) is a function it's a converter...
+				result = read(cookie, value);
+				break;
+			}
+
+			// Prevent storing a cookie that we couldn't decode.
+			if (!key && (cookie = read(cookie)) !== undefined) {
+				result[name] = cookie;
 			}
 		}
-		return null;
+
+		return result;
 	};
 
-	$.cookie.defaults = {};
+	config.defaults = {};
 
-})(jQuery, document);
+	$.removeCookie = function (key, options) {
+		if ($.cookie(key) === undefined) {
+			return false;
+		}
+
+		// Must not alter options, thus extending a fresh object...
+		$.cookie(key, '', $.extend({}, options, { expires: -1 }));
+		return !$.cookie(key);
+	};
+
+}));


### PR DESCRIPTION
The child of #1476.

- jquery.cookie. from 1.1 (Jul 2012) to 1.4.1 (Apr 2014). Changelog is here: https://github.com/carhartl/jquery-cookie/blob/master/CHANGELOG.md. Quick research showed that we don't rely on these changes but still it'd be better to make this update thoroughly.
  - 1.4.0. `$.cookie('name')` now returns `undefined` in case such cookie does not exist (was `null`). Because the return value is still falsy, testing for existence of a cookie like `if ( $.cookie('foo') )` keeps working without change.
  - 1.4.0. Badly encoded cookies no longer throw exception upon reading but do return `undefined` (similar to how we handle JSON parse errors with `json = true`).
  - 1.4.0. Dropped `$.cookie('name', null)`. Replaced with `$.removeCookie('name')`.
