### PR TITLE
Add link tag: hreflang for language and regional URLs

### DIFF
--- a/layout/default/Layout/Abstract/default.tpl
+++ b/layout/default/Layout/Abstract/default.tpl
@@ -43,6 +43,11 @@
     <!-- favicon.ico used for IE9: -->
     <!--[if IE]><link rel="shortcut icon" href="{resourceUrl path='img/favicon.ico' type='layout'}"><![endif]-->
 
+    <link rel="alternate" href="{$renderDefault->getUrlPage($page, $page->getParams()->getParamsEncoded())|escape}" hreflang="x-default">
+    {foreach $languageList as $language}
+      <link rel="alternate" href="{$renderDefault->getUrlPage($page, $page->getParams()->getParamsEncoded(), null, $language)|escape}" hreflang="{$language->getAbbreviation()}">
+    {/foreach}
+
     <title>{$pageTitle|escape}</title>
     {resourceCss file='all.css' type="vendor"}
     {resourceCss file='all.css' type="library"}

--- a/library/CM/Component/Example.php
+++ b/library/CM/Component/Example.php
@@ -18,7 +18,7 @@ class CM_Component_Example extends CM_Component_Abstract {
     }
 
     public function checkAccessible(CM_Frontend_Environment $environment) {
-        if (!CM_Bootloader::getInstance()->isDebug()) {
+        if (!$environment->isDebug()) {
             throw new CM_Exception_NotAllowed();
         }
     }

--- a/library/CM/Form/Example.php
+++ b/library/CM/Form/Example.php
@@ -23,9 +23,11 @@ class CM_Form_Example extends CM_Form_Abstract {
     }
 
     public function prepare(CM_Frontend_Environment $environment) {
-        $ip = CM_Http_Request_Abstract::getInstance()->getIp();
-        if ($locationGuess = CM_Model_Location::findByIp($ip)) {
-            $this->getField('location')->setValue($locationGuess);
+        if (CM_Http_Request_Abstract::hasInstance()) {
+            $ip = CM_Http_Request_Abstract::getInstance()->getIp();
+            if ($locationGuess = CM_Model_Location::findByIp($ip)) {
+                $this->getField('location')->setValue($locationGuess);
+            }
         }
     }
 }

--- a/library/CM/RenderAdapter/Layout.php
+++ b/library/CM/RenderAdapter/Layout.php
@@ -34,6 +34,11 @@ class CM_RenderAdapter_Layout extends CM_RenderAdapter_Abstract {
         $viewResponse->set('pageKeywords', $this->fetchKeywords());
         $viewResponse->set('renderAdapter', $this);
 
+        $environmentDefault = new CM_Frontend_Environment($this->getRender()->getEnvironment()->getSite());
+        $renderDefault = new CM_Frontend_Render($environmentDefault);
+        $viewResponse->set('renderDefault', $renderDefault);
+        $viewResponse->set('languageList', new CM_Paging_Language_Enabled());
+
         $options = array();
         $options['deployVersion'] = CM_App::getInstance()->getDeployVersion();
         $options['renderStamp'] = floor(microtime(true) * 1000);

--- a/tests/library/CM/Layout/AbstractTest.php
+++ b/tests/library/CM/Layout/AbstractTest.php
@@ -60,6 +60,24 @@ class CM_Layout_AbstractTest extends CMTest_TestCase {
         $this->assertNotContains("_kmq.push(['alias'", $html);
     }
 
+    public function testLanguageAlternatives() {
+        $site = $this->getMockSite('CM_Site_Abstract', null, array('url' => 'http://www.example.com'));
+        $language1 = CMTest_TH::createLanguage('en');
+        $language2 = CMTest_TH::createLanguage('de');
+
+        $environment = new CM_Frontend_Environment($site, null, $language2, null, true);
+        $render = new CM_Frontend_Render($environment, true);
+
+        $this->getMockForAbstractClass('CM_Layout_Abstract', array(), 'CM_Layout_Default');
+        $page = new CM_Page_Example();
+        $renderAdapter = new CM_RenderAdapter_Layout($render, $page);
+        $html = $renderAdapter->fetch();
+
+        $this->assertContains('<link rel="alternate" href="http://www.example.com/example" hreflang="x-default">', $html);
+        $this->assertContains('<link rel="alternate" href="http://www.example.com/en/example" hreflang="en">', $html);
+        $this->assertContains('<link rel="alternate" href="http://www.example.com/de/example" hreflang="de">', $html);
+    }
+
     /**
      * @param string $codeGoogleAnalytics
      * @param string $codeKissMetrics


### PR DESCRIPTION
See https://support.google.com/webmasters/answer/189077

Meta information for Google to understand that a page has multiple versions in different languages. E.g.:
```html
<link rel="alternate" href="http://example.com/en" hreflang="en" />
```

cc @fauvel @moby86 @NicolasSchmutz 