### PR TITLE
Update split test createStamp after flushing data

### DIFF
--- a/library/CM/Model/Splittest.php
+++ b/library/CM/Model/Splittest.php
@@ -111,6 +111,7 @@ class CM_Model_Splittest extends CM_Model_Abstract implements CM_Service_Manager
 
     public function flush() {
         CM_Db_Db::delete('cm_splittestVariation_fixture', array('splittestId' => $this->getId()));
+        CM_Db_Db::update('cm_splittest', array('createStamp' => time()), array('id' => $this->getId()));
     }
 
     /**


### PR DESCRIPTION
`CM_Model_Splittest::flush()` should update the split test's `createStamp` to the current time. This is needed for our RJMetrics integration.