### PR TITLE
Introduce CM_File_Image::freeMemory

### DIFF
--- a/library/CM/File/Image.php
+++ b/library/CM/File/Image.php
@@ -198,6 +198,10 @@ class CM_File_Image extends CM_File {
         $this->_compressionQuality = $quality;
     }
 
+    public function freeMemory() {
+        $this->_imagick = null;
+    }
+
     /**
      * @return Imagick
      * @throws CM_Exception

--- a/library/CM/File/Image.php
+++ b/library/CM/File/Image.php
@@ -44,7 +44,6 @@ class CM_File_Image extends CM_File {
      */
     public function resize($widthMax, $heightMax, $square = null, $formatNew = null, CM_File $fileNew = null) {
         $square = isset($square) ? (bool) $square : false;
-        $format = isset($formatNew) ? (int) $formatNew : $this->getFormat();
 
         $width = $this->getWidth();
         $height = $this->getHeight();
@@ -76,6 +75,24 @@ class CM_File_Image extends CM_File {
             $heightResize = $height;
             $widthResize = $width;
         }
+
+        $this->resizeSpecific($widthResize, $heightResize, $offsetX, $offsetY, $formatNew, $fileNew);
+    }
+
+    /**
+     * @param int          $widthResize
+     * @param int          $heightResize
+     * @param int|null     $offsetX
+     * @param int|null     $offsetY
+     * @param int|null     $formatNew
+     * @param CM_File|null $fileNew
+     * @throws CM_Exception
+     * @throws CM_Exception_Invalid
+     */
+    public function resizeSpecific($widthResize, $heightResize, $offsetX = null, $offsetY = null, $formatNew = null, CM_File $fileNew = null) {
+        $format = isset($formatNew) ? (int) $formatNew : $this->getFormat();
+        $width = $this->getWidth();
+        $height = $this->getHeight();
 
         $imagick = $this->_getImagickClone();
 

--- a/tests/library/CM/File/ImageTest.php
+++ b/tests/library/CM/File/ImageTest.php
@@ -306,6 +306,15 @@ class CM_File_ImageTest extends CMTest_TestCase {
         $this->assertEquals(1682, $image->getSize(), '', 100);
     }
 
+    public function testResizeSpecific() {
+        $imageOriginal = new CM_File_Image(DIR_TEST_DATA . 'img/test.jpg');
+        $image = CM_File_Image::createTmp(null, $imageOriginal->read());
+
+        $image->resizeSpecific(50, 50, 20, 20);
+        $this->assertSame(50, $image->getWidth());
+        $this->assertSame(50, $image->getHeight());
+    }
+
     public function testGetExtensionByFormat() {
         $this->assertSame('jpg', CM_File_Image::getExtensionByFormat(CM_File_Image::FORMAT_JPEG));
         $this->assertSame('gif', CM_File_Image::getExtensionByFormat(CM_File_Image::FORMAT_GIF));


### PR DESCRIPTION
How about introducing a `CM_File_Image::freeMemory()`?
Then we'd call this instead of the quirky `clone` approach which is not as straight-forward. Also we could potentially use it in different places.

@alexispeter please review