### PR TITLE
Create our own custom Modernizr test 'iOS' to detect iOS devices.

### DIFF
--- a/client-vendor/after-body/modernizr/modernizr.custom.js
+++ b/client-vendor/after-body/modernizr/modernizr.custom.js
@@ -4,7 +4,7 @@
  */
 
 (function() {
-  Modernizr.addTest('inputfixed', function() {
+  Modernizr.addTest('inputinfixed', function() {
     return !navigator.userAgent.match(/(iPad|iPhone|iPod)/i);
   });
 })();

--- a/client-vendor/after-body/modernizr/modernizr.custom.js
+++ b/client-vendor/after-body/modernizr/modernizr.custom.js
@@ -1,0 +1,10 @@
+/*
+ * Author: CM
+ * Custom CM rules for Modernizr.
+ */
+
+(function() {
+  Modernizr.addTest('inputfixed', function() {
+    return !navigator.userAgent.match(/(iPad|iPhone|iPod)/i);
+  });
+})();

--- a/client-vendor/before-body/01-modernizr/modernizr.js
+++ b/client-vendor/before-body/01-modernizr/modernizr.js
@@ -26,6 +26,7 @@
     _config: {
       classPrefix : '',
       enableClasses : true,
+      enableJSClass : true,
       usePrefixes : true
     },
 
@@ -157,11 +158,13 @@
     var className = docElement.className;
     var classPrefix = Modernizr._config.classPrefix || '';
 
-    // Change `no-js` to `js` (we do this regardles of the `enableClasses`
+    // Change `no-js` to `js` (we do this independently of the `enableClasses`
     // option)
     // Handle classPrefix on this too
-    var reJS = new RegExp('(^|\\s)'+classPrefix+'no-js(\\s|$)');
-    className = className.replace(reJS, '$1'+classPrefix+'js$2');
+    if(Modernizr._config.enableJSClass) {
+      var reJS = new RegExp('(^|\\s)'+classPrefix+'no-js(\\s|$)');
+      className = className.replace(reJS, '$1'+classPrefix+'js$2');
+    }
 
     if(Modernizr._config.enableClasses) {
       // Add the new classes
@@ -172,6 +175,143 @@
   }
 
   ;
+
+  // hasOwnProperty shim by kangax needed for Safari 2.0 support
+  var hasOwnProp;
+
+  (function() {
+    var _hasOwnProperty = ({}).hasOwnProperty;
+    if ( !is(_hasOwnProperty, 'undefined') && !is(_hasOwnProperty.call, 'undefined') ) {
+      hasOwnProp = function (object, property) {
+        return _hasOwnProperty.call(object, property);
+      };
+    }
+    else {
+      hasOwnProp = function (object, property) { /* yes, this can give false positives/negatives, but most of the time we don't care about those */
+        return ((property in object) && is(object.constructor.prototype[property], 'undefined'));
+      };
+    }
+  })();
+
+  
+
+  // As far as I can think of, we shouldn't need or
+  // allow 'on' for non-async tests, and you can't do
+  // async tests without this 'addTest' module.
+
+  // Listeners for async or post-run tests
+  ModernizrProto._l = {};
+
+  // 'addTest' implies a test after the core runloop,
+  // So we'll add in the events
+  ModernizrProto.on = function( test, cb ) {
+    // Create the list of listeners if it doesn't exist
+    if (!this._l[test]) {
+      this._l[test] = [];
+    }
+
+    // Push this test on to the listener list
+    this._l[test].push(cb);
+
+    // If it's already been resolved, trigger it on next tick
+    if (Modernizr.hasOwnProperty(test)) {
+      // Next Tick
+      setTimeout(function() {
+        Modernizr._trigger(test, Modernizr[test]);
+      }, 0);
+    }
+  };
+
+  ModernizrProto._trigger = function( test, res ) {
+    if (!this._l[test]) {
+      return;
+    }
+
+    var cbs = this._l[test];
+
+    // Force async
+    setTimeout(function() {
+      var i, cb;
+      for (i = 0; i < cbs.length; i++) {
+        cb = cbs[i];
+        cb(res);
+      }
+    },0);
+
+    // Don't trigger these again
+    delete this._l[test];
+  };
+
+  /**
+   * addTest allows the user to define their own feature tests
+   * the result will be added onto the Modernizr object,
+   * as well as an appropriate className set on the html element
+   *
+   * @param feature - String naming the feature
+   * @param test - Function returning true if feature is supported, false if not
+   */
+  function addTest( feature, test ) {
+    if ( typeof feature == 'object' ) {
+      for ( var key in feature ) {
+        if ( hasOwnProp( feature, key ) ) {
+          addTest( key, feature[ key ] );
+        }
+      }
+    } else {
+
+      feature = feature.toLowerCase();
+      var featureNameSplit = feature.split('.');
+      var last = Modernizr[featureNameSplit[0]];
+
+      // Again, we don't check for parent test existence. Get that right, though.
+      if (featureNameSplit.length == 2) {
+        last = last[featureNameSplit[1]];
+      }
+
+      if ( typeof last != 'undefined' ) {
+        // we're going to quit if you're trying to overwrite an existing test
+        // if we were to allow it, we'd do this:
+        //   var re = new RegExp("\\b(no-)?" + feature + "\\b");
+        //   docElement.className = docElement.className.replace( re, '' );
+        // but, no rly, stuff 'em.
+        return Modernizr;
+      }
+
+      test = typeof test == 'function' ? test() : test;
+
+      // Set the value (this is the magic, right here).
+      if (featureNameSplit.length == 1) {
+        Modernizr[featureNameSplit[0]] = test;
+      }
+      else if (featureNameSplit.length == 2) {
+        // cast to a Boolean, if not one already
+        /* jshint -W053 */
+        if (Modernizr[featureNameSplit[0]] && !(Modernizr[featureNameSplit[0]] instanceof Boolean)) {
+          Modernizr[featureNameSplit[0]] = new Boolean(Modernizr[featureNameSplit[0]]);
+        }
+
+        Modernizr[featureNameSplit[0]][featureNameSplit[1]] = test;
+      }
+
+      // Set a single class (either `feature` or `no-feature`)
+      /* jshint -W041 */
+      setClasses([(!!test && test != false ? '' : 'no-') + featureNameSplit.join('-')]);
+      /* jshint +W041 */
+
+      // Trigger the event
+      Modernizr._trigger(feature, test);
+    }
+
+    return Modernizr; // allow chaining.
+  }
+
+  // After all the tests are run, add self
+  // to the Modernizr prototype
+  Modernizr._q.push(function() {
+    ModernizrProto.addTest = addTest;
+  });
+
+  
 
   // Take the html5 variable out of the
   // html5shiv scope so we can return it.


### PR DESCRIPTION
Currently we have already a places where we rely on this user agent detection. Those places are:
 - `jquery.iosKeyboardActive.js`
 - `SK/Component/Comments.js::ready` L32.

Now we need to add another such place at SK_Component_HeaderBar to decide whether we need to popup or toggle the Share component. So, my proposition is to add our custom `Modernizr.iOS`, reuse it at the all existing places and use in the all future cases where we need this user agent detection.

The implementation will be easy:
```js
Modernizr.addTest('iOS', function () {
  return navigator.userAgent.match(/(iPad|iPhone|iPod)/i);
});
```

@njam @christopheschwyzer ?