### PR TITLE
Migrate to GA Universal Analytics

### DIFF
--- a/library/CM/Http/Handler.php
+++ b/library/CM/Http/Handler.php
@@ -16,7 +16,7 @@ class CM_Http_Handler implements CM_Service_ManagerAwareInterface {
      * @return CM_Http_Response_Abstract
      */
     public function processRequest(CM_Http_Request_Abstract $request) {
-        $response = CM_Http_Response_Abstract::factory($request);
+        $response = CM_Http_Response_Abstract::factory($request, $this->getServiceManager());
         $response->process();
         return $response;
     }

--- a/library/CM/Http/Response/Page.php
+++ b/library/CM/Http/Response/Page.php
@@ -11,10 +11,12 @@ class CM_Http_Response_Page extends CM_Http_Response_Abstract {
     /** @var string|null */
     private $_redirectUrl;
 
-    public function __construct(CM_Http_Request_Abstract $request) {
+    public function __construct(CM_Http_Request_Abstract $request, CM_Service_Manager $serviceManager) {
         $this->_request = $request;
         $this->_site = CM_Site_Abstract::findByRequest($this->_request);
         $this->_request->popPathLanguage();
+
+        $this->setServiceManager($serviceManager);
     }
 
     /**

--- a/library/CM/Http/Response/Page.php
+++ b/library/CM/Http/Response/Page.php
@@ -89,17 +89,19 @@ class CM_Http_Response_Page extends CM_Http_Response_Abstract {
     }
 
     protected function _processContentOrRedirect() {
+        $render = $this->getRender();
         if ($this->_site->getHost() !== $this->_request->getHost()) {
             $path = CM_Util::link($this->_request->getPath(), $this->_request->getQuery());
-            $this->redirectUrl($this->getRender()->getUrl($path, $this->_site));
+            $this->redirectUrl($render->getUrl($path, $this->_site));
         }
         if ($this->_request->getLanguageUrl() && $this->getViewer()) {
             $path = CM_Util::link($this->_request->getPath(), $this->_request->getQuery());
-            $this->redirectUrl($this->getRender()->getUrl($path, $this->_site));
+            $this->redirectUrl($render->getUrl($path, $this->_site));
             $this->_request->setLanguageUrl(null);
         }
         if (!$this->getRedirectUrl()) {
-            $this->getRender()->getServiceManager()->getTrackings()->trackPageView($this->getRender()->getEnvironment());
+            $path = CM_Util::link($this->_request->getPath(), $this->_request->getQuery());
+            $render->getServiceManager()->getTrackings()->trackPageView($render->getEnvironment(), $path);
             $html = $this->_processPageLoop($this->getRequest());
             $this->_setContent($html);
         }

--- a/library/CM/Http/Response/Resource/Abstract.php
+++ b/library/CM/Http/Response/Resource/Abstract.php
@@ -2,8 +2,8 @@
 
 abstract class CM_Http_Response_Resource_Abstract extends CM_Http_Response_Abstract {
 
-    public function __construct(CM_Http_Request_Abstract $request) {
-        parent::__construct($request);
+    public function __construct(CM_Http_Request_Abstract $request, CM_Service_Manager $serviceManager) {
+        parent::__construct($request, $serviceManager);
         $timestamp = $this->_request->popPathPart();
     }
 

--- a/library/CM/Http/Response/Upload.php
+++ b/library/CM/Http/Response/Upload.php
@@ -22,8 +22,8 @@ class CM_Http_Response_Upload extends CM_Http_Response_Abstract {
         UPLOAD_ERR_EXTENSION  => 'File upload stopped by extension.',
     );
 
-    public function __construct(CM_Http_Request_Post $request) {
-        parent::__construct($request);
+    public function __construct(CM_Http_Request_Post $request, CM_Service_Manager $serviceManager) {
+        parent::__construct($request, $serviceManager);
         $this->_request->setBodyEncoding(CM_Http_Request_Post::ENCODING_NONE);
     }
 

--- a/library/CM/Http/Response/View/Abstract.php
+++ b/library/CM/Http/Response/View/Abstract.php
@@ -87,7 +87,7 @@ abstract class CM_Http_Response_View_Abstract extends CM_Http_Response_Abstract 
 
         $frontend = $responsePage->getRender()->getGlobalResponse();
         $html = $responsePage->getContent();
-        $js = implode(PHP_EOL, array_filter([$frontend->getJs(), $response->getRender()->getServiceManager()->getTrackings()->getJs()]));
+        $js = $frontend->getJs();
         $autoId = $frontend->getTreeRoot()->getValue()->getAutoId();
 
         $frontend->clear();
@@ -96,6 +96,7 @@ abstract class CM_Http_Response_View_Abstract extends CM_Http_Response_Abstract 
         $layoutClass = get_class($page->getLayout($this->getRender()->getEnvironment()));
         $menuList = array_merge($this->getSite()->getMenus(), $responsePage->getRender()->getMenuList());
         $menuEntryHashList = $this->_getMenuEntryHashList($menuList, get_class($page), $responsePage->getPageParams());
+        $jsTracking = $responsePage->getRender()->getServiceManager()->getTrackings()->getJs();
 
         return array(
             'autoId'            => $autoId,
@@ -105,6 +106,7 @@ abstract class CM_Http_Response_View_Abstract extends CM_Http_Response_Abstract 
             'url'               => $url,
             'layoutClass'       => $layoutClass,
             'menuEntryHashList' => $menuEntryHashList,
+            'jsTracking'        => $jsTracking,
         );
     }
 

--- a/library/CM/Http/Response/View/Abstract.php
+++ b/library/CM/Http/Response/View/Abstract.php
@@ -66,7 +66,7 @@ abstract class CM_Http_Response_View_Abstract extends CM_Http_Response_Abstract 
             if ($count++ > 10) {
                 throw new CM_Exception_Invalid('Page redirect loop detected (' . implode(' -> ', $paths) . ').');
             }
-            $responsePage = new CM_Http_Response_Page_Embed($request);
+            $responsePage = new CM_Http_Response_Page_Embed($request, $this->getServiceManager());
             $responsePage->process();
             $paths[] = $request->getPath();
 

--- a/library/CM/Http/Response/View/Abstract.php
+++ b/library/CM/Http/Response/View/Abstract.php
@@ -44,14 +44,14 @@ abstract class CM_Http_Response_View_Abstract extends CM_Http_Response_Abstract 
         $data = array(
             'autoId' => $frontend->getTreeRoot()->getValue()->getAutoId(),
             'html'   => $html,
-            'js'     => $frontend->getJs()
+            'js'     => $frontend->getJs(),
         );
         $frontend->clear();
         return $data;
     }
 
     /**
-     * @param CM_Params             $params
+     * @param CM_Params                  $params
      * @param CM_Http_Response_View_Ajax $response
      * @throws CM_Exception_Invalid
      * @return array
@@ -97,9 +97,15 @@ abstract class CM_Http_Response_View_Abstract extends CM_Http_Response_Abstract 
         $menuList = array_merge($this->getSite()->getMenus(), $responsePage->getRender()->getMenuList());
         $menuEntryHashList = $this->_getMenuEntryHashList($menuList, get_class($page), $responsePage->getPageParams());
 
-        return array('autoId'            => $autoId, 'html' => $html, 'js' => $js, 'title' => $title, 'url' => $url,
-                     'layoutClass'       => $layoutClass,
-                     'menuEntryHashList' => $menuEntryHashList);
+        return array(
+            'autoId'            => $autoId,
+            'html'              => $html,
+            'js'                => $js,
+            'title'             => $title,
+            'url'               => $url,
+            'layoutClass'       => $layoutClass,
+            'menuEntryHashList' => $menuEntryHashList,
+        );
     }
 
     public function popinComponent() {

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -68,7 +68,7 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
           layout._$pagePlaceholder.replaceWith(this.$el);
           layout._$pagePlaceholder = null;
           window.history.replaceState(null, null, fragment);
-          layout._onPageSetup(this, response.title, response.url, response.menuEntryHashList);
+          layout._onPageSetup(this, response.title, response.url, response.menuEntryHashList, response.jsTracking);
         });
       },
       error: function(msg, type, isPublic) {
@@ -92,14 +92,18 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
    * @param {String} title
    * @param {String} url
    * @param {String[]} menuEntryHashList
+   * @param {String} [jsTracking]
    */
-  _onPageSetup: function(page, title, url, menuEntryHashList) {
+  _onPageSetup: function(page, title, url, menuEntryHashList, jsTracking) {
     document.title = title;
     $('[data-menu-entry-hash]').removeClass('active');
     var menuEntrySelectors = _.map(menuEntryHashList, function(menuEntryHash) {
       return '[data-menu-entry-hash=' + menuEntryHash + ']';
     });
     $(menuEntrySelectors.join(',')).addClass('active');
+    if (jsTracking) {
+      new Function(jsTracking).call(this);
+    }
   },
 
   _onPageError: function() {

--- a/library/CM/Service/Tracking/ClientInterface.php
+++ b/library/CM/Service/Tracking/ClientInterface.php
@@ -26,9 +26,9 @@ interface CM_Service_Tracking_ClientInterface {
 
     /**
      * @param CM_Frontend_Environment $environment
-     * @param string|null             $path
+     * @param string                  $path
      */
-    public function trackPageView(CM_Frontend_Environment $environment, $path = null);
+    public function trackPageView(CM_Frontend_Environment $environment, $path);
 
     /**
      * @param CM_Splittest_Fixture        $fixture

--- a/library/CM/Service/Trackings.php
+++ b/library/CM/Service/Trackings.php
@@ -40,7 +40,7 @@ class CM_Service_Trackings extends CM_Service_ManagerAware implements CM_Service
         }
     }
 
-    public function trackPageView(CM_Frontend_Environment $environment, $path = null) {
+    public function trackPageView(CM_Frontend_Environment $environment, $path) {
         foreach ($this->_getTrackingServiceList() as $trackingService) {
             $trackingService->trackPageView($environment, $path);
         }

--- a/library/CMService/GoogleAnalytics/Client.php
+++ b/library/CMService/GoogleAnalytics/Client.php
@@ -6,7 +6,7 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
     protected $_code;
 
     /** @var array */
-    protected $_customVarList = array(), $_eventList = array(), $_transactionList = array(), $_pageViewList = array();
+    protected $_eventList = array(), $_transactionList = array(), $_pageViewList = array(), $_dimensionList = array(), $_metricList = array();
 
     /**
      * @param string $code
@@ -16,17 +16,23 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
     }
 
     /**
-     * @param int    $index 1-5
-     * @param string $name
+     * @param int    $index
      * @param string $value
-     * @param int    $scope 1 (visitor-level), 2 (session-level), or 3 (page-level)
      */
-    public function addCustomVar($index, $name, $value, $scope) {
+    public function setCustomDimension($index, $value) {
         $index = (int) $index;
-        $name = (string) $name;
         $value = (string) $value;
-        $scope = (int) $scope;
-        $this->_customVarList[$index] = array('index' => $index, 'name' => $name, 'value' => $value, 'scope' => $scope);
+        $this->_dimensionList[$index] = $value;
+    }
+
+    /**
+     * @param int       $index
+     * @param int|float $value
+     */
+    public function setCustomMetric($index, $value) {
+        $index = (int) $index;
+        $value = (float) $value;
+        $this->_metricList[$index] = $value;
     }
 
     /**
@@ -83,63 +89,65 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
      */
     public function getJs() {
         $js = '';
+        foreach ($this->_dimensionList as $dimensionIndex => $dimensionValue) {
+            $js .= 'ga("set", "dimension' . $dimensionIndex . '", "' . $dimensionValue . '");';
+        }
+        foreach ($this->_metricList as $metricIndex => $metricValue) {
+            $js .= 'ga("set", "metric' . $metricIndex . '", ' . $metricValue . ');';
+        }
         foreach ($this->_pageViewList as $pageView) {
             if (null === $pageView) {
-                $js .= "_gaq.push(['_trackPageview']);";
+                $js .= 'ga("send", "pageview");';
             } else {
-                $js .= "_gaq.push(['_trackPageview', '" . $pageView . "']);";
+                $js .= 'ga("send", "pageview", "' . $pageView . '");';
             }
-        }
-        foreach ($this->_customVarList as $customVar) {
-            $index = (string) $customVar['index'];
-            $name = "'" . $customVar['name'] . "'";
-            $value = "'" . $customVar['value'] . "'";
-            $scope = (string) $customVar['scope'];
-            $js .= "_gaq.push(['_setCustomVar', $index, $name, $value, $scope]);";
         }
         foreach ($this->_eventList as $event) {
-            $category = "'" . $event['category'] . "'";
-            $action = "'" . $event['action'] . "'";
-            $label = isset($event['label']) ? "'" . $event['label'] . "'" : 'undefined';
-            $value = isset($event['value']) ? (string) $event['value'] : 'undefined';
-            $nonInteraction = $event['nonInteraction'] ? 'true' : 'undefined';
-            $js .= "_gaq.push(['_trackEvent', $category, $action, $label, $value, $nonInteraction]);";
-        }
-        foreach ($this->_transactionList as $transactionId => $productList) {
-            $amountTotal = 0;
-            foreach ($productList as $productId => $amount) {
-                $amountTotal += $amount;
-            }
-            $transactionId = "'" . $transactionId . "'";
-            $amountTotal = "'" . $amountTotal . "'";
-            $js .= "_gaq.push(['_addTrans', $transactionId, '', $amountTotal, '', '', '', '', '']);";
-            foreach ($productList as $productId => $amount) {
-                $productCode = "'" . $productId . "'";
-                $productName = "'product-" . $productId . "'";
-                $amount = "'" . $amount . "'";
-                $js .= "_gaq.push(['_addItem', $transactionId, $productCode, $productName, '', $amount, '1']);";
-            }
+            $js .= 'ga("send", ' . CM_Params::jsonEncode(array_filter([
+                    'hitType'        => 'event',
+                    'eventCategory'  => $event['category'],
+                    'eventAction'    => $event['action'],
+                    'eventLabel'     => $event['label'],
+                    'eventValue'     => $event['value'],
+                    'nonInteraction' => $event['nonInteraction'],
+                ])) . ');';
         }
         if (!empty($this->_transactionList)) {
-            $js .= "_gaq.push(['_trackTrans']);";
+            $js .= 'ga("require", "ecommerce");';
+            foreach ($this->_transactionList as $transactionId => $productList) {
+                $amountTotal = 0;
+                foreach ($productList as $productId => $amount) {
+                    $amountTotal += $amount;
+                }
+                $js .= 'ga("ecommerce:addTransaction", ' . CM_Params::jsonEncode(array_filter([
+                        'id'      => $transactionId,
+                        'revenue' => $amountTotal,
+                    ])) . ');';
+                foreach ($productList as $productId => $amount) {
+                    $js .= 'ga("ecommerce:addItem", ' . CM_Params::jsonEncode(array_filter([
+                            'id'       => $transactionId,
+                            'name'     => 'product-' . $productId,
+                            'sku'      => $productId,
+                            'price'    => $amount,
+                            'quantity' => 1,
+                        ])) . ');';
+                }
+            }
+            $js .= 'ga("ecommerce:send");';
         }
         return $js;
     }
 
     public function getHtml(CM_Frontend_Environment $environment) {
         $html = '<script type="text/javascript">';
-        $html .= 'var _gaq = _gaq || [];';
-        $html .= "_gaq.push(['_setAccount', '" . $this->_getCode() . "']);";
-        $html .= "_gaq.push(['_setDomainName', '" . $environment->getSite()->getHost() . "']);";
-        $html .= $this->getJs();
-
         $html .= <<<EOF
-(function() {
-var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
-var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-})();
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 EOF;
+        $html .= 'ga("create", "' . $this->_getCode() . '", "auto");';
+        $html .= $this->getJs();
         $html .= '</script>';
 
         return $html;

--- a/library/CMService/GoogleAnalytics/Client.php
+++ b/library/CMService/GoogleAnalytics/Client.php
@@ -6,7 +6,7 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
     protected $_code;
 
     /** @var array */
-    protected $_eventList = array(), $_transactionList = array(), $_pageViewList = array(), $_dimensionList = array(), $_metricList = array();
+    protected $_eventList = array(), $_transactionList = array(), $_pageViewList = array(), $_fieldList = array();
 
     /**
      * @param string $code
@@ -22,7 +22,7 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
     public function setCustomDimension($index, $value) {
         $index = (int) $index;
         $value = (string) $value;
-        $this->_dimensionList[$index] = $value;
+        $this->_setField('dimension' . $index, $value);
     }
 
     /**
@@ -32,7 +32,7 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
     public function setCustomMetric($index, $value) {
         $index = (int) $index;
         $value = (float) $value;
-        $this->_metricList[$index] = $value;
+        $this->_setField('metric' . $index, $value);
     }
 
     /**
@@ -90,11 +90,8 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
      */
     public function getJs() {
         $js = '';
-        foreach ($this->_dimensionList as $dimensionIndex => $dimensionValue) {
-            $js .= 'ga("set", "dimension' . $dimensionIndex . '", "' . $dimensionValue . '");';
-        }
-        foreach ($this->_metricList as $metricIndex => $metricValue) {
-            $js .= 'ga("set", "metric' . $metricIndex . '", ' . $metricValue . ');';
+        foreach ($this->_fieldList as $fieldName => $fieldValue) {
+            $js .= 'ga("set", "' . $fieldName . '", "' . $fieldValue . '");';
         }
         foreach ($this->_pageViewList as $pageView) {
             $js .= 'ga("send", "pageview", "' . $pageView . '");';
@@ -174,6 +171,16 @@ EOF;
     }
 
     public function trackSplittest(CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation) {
+    }
+
+    /**
+     * @param string $name
+     * @param string $value
+     */
+    protected function _setField($name, $value) {
+        $name = (string) $name;
+        $value = (string) $value;
+        $this->_fieldList[$name] = $value;
     }
 
     /**

--- a/library/CMService/GoogleAnalytics/Client.php
+++ b/library/CMService/GoogleAnalytics/Client.php
@@ -148,7 +148,15 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/${scriptName}','ga');
 EOF;
-        $html .= 'ga("create", "' . $this->_getCode() . '", "auto");';
+
+        $fieldList = [
+            'cookieDomain' => $environment->getSite()->getHost(),
+        ];
+        if (CM_Http_Request_Abstract::hasInstance()) {
+            $fieldList['clientId'] = (string) CM_Http_Request_Abstract::getInstance()->getClientId();
+        }
+
+        $html .= 'ga("create", "' . $this->_getCode() . '", ' . CM_Params::jsonEncode(array_filter($fieldList)) . ');';
         $html .= $this->getJs();
         $html .= '</script>';
 

--- a/library/CMService/GoogleAnalytics/Client.php
+++ b/library/CMService/GoogleAnalytics/Client.php
@@ -73,6 +73,16 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
     }
 
     /**
+     * @param string|null $path
+     */
+    public function setPageView($path = null) {
+        if (null !== $path) {
+            $path = (string) $path;
+        }
+        $this->_pageViewList = [$path];
+    }
+
+    /**
      * @param string $transactionId
      * @param string $productId
      * @param float  $amount
@@ -160,7 +170,7 @@ EOF;
     }
 
     public function trackPageView(CM_Frontend_Environment $environment, $path = null) {
-        $this->addPageView($path);
+        $this->setPageView($path);
     }
 
     public function trackSplittest(CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation) {

--- a/library/CMService/GoogleAnalytics/Client.php
+++ b/library/CMService/GoogleAnalytics/Client.php
@@ -149,12 +149,17 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
     }
 
     public function getHtml(CM_Frontend_Environment $environment) {
+        $scriptName = 'analytics.js';
+        if ($environment->isDebug()) {
+            $scriptName = 'analytics_debug.js';
+        }
+
         $html = '<script type="text/javascript">';
         $html .= <<<EOF
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+})(window,document,'script','//www.google-analytics.com/${scriptName}','ga');
 EOF;
         $html .= 'ga("create", "' . $this->_getCode() . '", "auto");';
         $html .= $this->getJs();

--- a/library/CMService/GoogleAnalytics/Client.php
+++ b/library/CMService/GoogleAnalytics/Client.php
@@ -58,27 +58,18 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
     }
 
     /**
-     * @param string|null $path
+     * @param string $path
      */
-    public function addPageView($path = null) {
-        if (null !== $path) {
-            $path = (string) $path;
-        }
-        if ($this->_pageViewList === array(null)) {
-            $this->_pageViewList = array();
-        }
-        if (null !== $path || 0 === count($this->_pageViewList)) {
-            $this->_pageViewList[] = $path;
-        }
+    public function addPageView($path) {
+        $path = (string) $path;
+        $this->_pageViewList[] = $path;
     }
 
     /**
-     * @param string|null $path
+     * @param string $path
      */
-    public function setPageView($path = null) {
-        if (null !== $path) {
-            $path = (string) $path;
-        }
+    public function setPageView($path) {
+        $path = (string) $path;
         $this->_pageViewList = [$path];
     }
 
@@ -106,11 +97,7 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
             $js .= 'ga("set", "metric' . $metricIndex . '", ' . $metricValue . ');';
         }
         foreach ($this->_pageViewList as $pageView) {
-            if (null === $pageView) {
-                $js .= 'ga("send", "pageview");';
-            } else {
-                $js .= 'ga("send", "pageview", "' . $pageView . '");';
-            }
+            $js .= 'ga("send", "pageview", "' . $pageView . '");';
         }
         foreach ($this->_eventList as $event) {
             $js .= 'ga("send", ' . CM_Params::jsonEncode(array_filter([

--- a/library/CMService/KissMetrics/Client.php
+++ b/library/CMService/KissMetrics/Client.php
@@ -127,7 +127,7 @@ EOF;
         $kissMetrics->submit();
     }
 
-    public function trackPageView(CM_Frontend_Environment $environment, $path = null) {
+    public function trackPageView(CM_Frontend_Environment $environment, $path) {
         if ($viewer = $environment->getViewer()) {
             $this->setUserId($viewer->getId());
         }

--- a/tests/helpers/CMTest/library/CMTest/TH.php
+++ b/tests/helpers/CMTest/library/CMTest/TH.php
@@ -74,6 +74,13 @@ class CMTest_TH {
     }
 
     /**
+     * @return CM_Service_Manager
+     */
+    public static function getServiceManager() {
+        return CM_Service_Manager::getInstance();
+    }
+
+    /**
      * @return CM_Model_User
      */
     public static function createUser() {
@@ -203,7 +210,7 @@ class CMTest_TH {
             $headers = array('host' => $site->getHost());
         }
         $request = new CM_Http_Request_Get($uri, $headers, null, $viewer);
-        return new CM_Http_Response_Page($request);
+        return new CM_Http_Response_Page($request, self::getServiceManager());
     }
 
     /**
@@ -218,7 +225,7 @@ class CMTest_TH {
             $headers = array('host' => $site->getHost());
         }
         $request = new CM_Http_Request_Get($uri, $headers, null, $viewer);
-        return new CM_Http_Response_Page_Embed($request);
+        return new CM_Http_Response_Page_Embed($request, self::getServiceManager());
     }
 
     /**

--- a/tests/helpers/CMTest/library/CMTest/TestCase.php
+++ b/tests/helpers/CMTest/library/CMTest/TestCase.php
@@ -17,7 +17,7 @@ abstract class CMTest_TestCase extends PHPUnit_Framework_TestCase implements CM_
             CM_Config::get()->CM_Site_Abstract->class = get_class($siteDefault);
         }
 
-        $this->setServiceManager(CM_Service_Manager::getInstance());
+        $this->setServiceManager(CMTest_TH::getServiceManager());
 
         parent::runBare();
     }

--- a/tests/helpers/CMTest/library/CMTest/TestCase.php
+++ b/tests/helpers/CMTest/library/CMTest/TestCase.php
@@ -17,7 +17,7 @@ abstract class CMTest_TestCase extends PHPUnit_Framework_TestCase implements CM_
             CM_Config::get()->CM_Site_Abstract->class = get_class($siteDefault);
         }
 
-        $this->setServiceManager(new CM_Service_Manager());
+        $this->setServiceManager(CM_Service_Manager::getInstance());
 
         parent::runBare();
     }
@@ -186,7 +186,7 @@ abstract class CMTest_TestCase extends PHPUnit_Framework_TestCase implements CM_
      */
     public function getResponse(CM_Http_Request_Abstract $request) {
         $className = CM_Http_Response_Abstract::getResponseClassName($request);
-        $serviceManager = CM_Service_Manager::getInstance();
+        $serviceManager = self::getServiceManager();
         return $this->mockClass($className)->newInstance([$request, $serviceManager]);
     }
 

--- a/tests/helpers/CMTest/library/CMTest/TestCase.php
+++ b/tests/helpers/CMTest/library/CMTest/TestCase.php
@@ -1,8 +1,10 @@
 <?php
 
-abstract class CMTest_TestCase extends PHPUnit_Framework_TestCase {
+abstract class CMTest_TestCase extends PHPUnit_Framework_TestCase implements CM_Service_ManagerAwareInterface {
 
     use \Mocka\MockaTrait;
+
+    use CM_Service_ManagerAwareTrait;
 
     public function runBare() {
         if (!isset(CM_Config::get()->CM_Site_Abstract->class)) {
@@ -14,6 +16,9 @@ abstract class CMTest_TestCase extends PHPUnit_Framework_TestCase {
             ));
             CM_Config::get()->CM_Site_Abstract->class = get_class($siteDefault);
         }
+
+        $this->setServiceManager(new CM_Service_Manager());
+
         parent::runBare();
     }
 
@@ -181,7 +186,8 @@ abstract class CMTest_TestCase extends PHPUnit_Framework_TestCase {
      */
     public function getResponse(CM_Http_Request_Abstract $request) {
         $className = CM_Http_Response_Abstract::getResponseClassName($request);
-        return $this->mockClass($className)->newInstance([$request]);
+        $serviceManager = CM_Service_Manager::getInstance();
+        return $this->mockClass($className)->newInstance([$request, $serviceManager]);
     }
 
     /**
@@ -298,10 +304,9 @@ abstract class CMTest_TestCase extends PHPUnit_Framework_TestCase {
         }
         $host = parse_url($site->getUrl(), PHP_URL_HOST);
         $request = new CM_Http_Request_Get('?' . http_build_query($page->getParams()->getParamsEncoded()), array('host' => $host), null, $viewer);
-        $response = new CM_Http_Response_Page($request);
-        $render = new CM_Frontend_Render(new CM_Frontend_Environment($site, $viewer));
-        $page->prepareResponse($render->getEnvironment(), $response);
-        $renderAdapter = new CM_RenderAdapter_Page($render, $page);
+        $response = new CM_Http_Response_Page($request, $this->getServiceManager());
+        $page->prepareResponse($response->getRender()->getEnvironment(), $response);
+        $renderAdapter = new CM_RenderAdapter_Page($response->getRender(), $page);
         $html = $renderAdapter->fetch();
         return new CM_Dom_NodeList($html, true);
     }

--- a/tests/library/CM/FormField/BirthdateTest.php
+++ b/tests/library/CM/FormField/BirthdateTest.php
@@ -8,7 +8,7 @@ class CM_FormField_BirthdateTest extends CMTest_TestCase {
     public function testValidate() {
         $formField = new CM_FormField_Birthdate(['name' => 'foo', 'minAge' => 18, 'maxAge' => 30]);
         $request = CM_Http_Request_Abstract::factory('get', '/foo');
-        $response = CM_Http_Response_Abstract::factory($request);
+        $response = CM_Http_Response_Abstract::factory($request, CM_Service_Manager::getInstance());
         $environment = new CM_Frontend_Environment();
         $value = $formField->validate($environment, array('year' => 1995, 'month' => 1, 'day' => 1));
         $this->assertEquals(new DateTime('1995-01-01'), $value);

--- a/tests/library/CM/FormField/BirthdateTest.php
+++ b/tests/library/CM/FormField/BirthdateTest.php
@@ -8,7 +8,7 @@ class CM_FormField_BirthdateTest extends CMTest_TestCase {
     public function testValidate() {
         $formField = new CM_FormField_Birthdate(['name' => 'foo', 'minAge' => 18, 'maxAge' => 30]);
         $request = CM_Http_Request_Abstract::factory('get', '/foo');
-        $response = CM_Http_Response_Abstract::factory($request, CM_Service_Manager::getInstance());
+        $response = CM_Http_Response_Abstract::factory($request, $this->getServiceManager());
         $environment = new CM_Frontend_Environment();
         $value = $formField->validate($environment, array('year' => 1995, 'month' => 1, 'day' => 1));
         $this->assertEquals(new DateTime('1995-01-01'), $value);

--- a/tests/library/CM/Http/Request/AbstractTest.php
+++ b/tests/library/CM/Http/Request/AbstractTest.php
@@ -74,13 +74,13 @@ class CM_Http_Request_AbstractTest extends CMTest_TestCase {
 
     public function testGetLanguageByUrl() {
         $request = $this->_prepareRequest('/de/home');
-        CM_Http_Response_Abstract::factory($request, CM_Service_Manager::getInstance());
+        CM_Http_Response_Abstract::factory($request, $this->getServiceManager());
         $this->assertNull($request->getLanguage());
 
         CMTest_TH::createLanguage('en'); // default language
         $urlLanguage = CMTest_TH::createLanguage('de');
         $request = $this->_prepareRequest('/de/home');
-        CM_Http_Response_Abstract::factory($request, CM_Service_Manager::getInstance());
+        CM_Http_Response_Abstract::factory($request, $this->getServiceManager());
         $this->assertEquals($request->getLanguage(), $urlLanguage);
     }
 

--- a/tests/library/CM/Http/Request/AbstractTest.php
+++ b/tests/library/CM/Http/Request/AbstractTest.php
@@ -74,13 +74,13 @@ class CM_Http_Request_AbstractTest extends CMTest_TestCase {
 
     public function testGetLanguageByUrl() {
         $request = $this->_prepareRequest('/de/home');
-        CM_Http_Response_Abstract::factory($request);
+        CM_Http_Response_Abstract::factory($request, CM_Service_Manager::getInstance());
         $this->assertNull($request->getLanguage());
 
         CMTest_TH::createLanguage('en'); // default language
         $urlLanguage = CMTest_TH::createLanguage('de');
         $request = $this->_prepareRequest('/de/home');
-        CM_Http_Response_Abstract::factory($request);
+        CM_Http_Response_Abstract::factory($request, CM_Service_Manager::getInstance());
         $this->assertEquals($request->getLanguage(), $urlLanguage);
     }
 
@@ -177,7 +177,7 @@ class CM_Http_Request_AbstractTest extends CMTest_TestCase {
         $request = new CM_Http_Request_Post('/foo/null/');
         $clientId = $request->getClientId();
         /** @var CM_Http_Response_Abstract $response */
-        $response = $this->getMock('CM_Http_Response_Abstract', array('_process', 'setCookie'), array($request));
+        $response = $this->getMock('CM_Http_Response_Abstract', array('_process', 'setCookie'), array($request, $this->getServiceManager()));
         $response->expects($this->once())->method('setCookie')->with('clientId', (string) $clientId);
         $response->process();
     }

--- a/tests/library/CM/Http/Response/AbstractTest.php
+++ b/tests/library/CM/Http/Response/AbstractTest.php
@@ -23,13 +23,13 @@ class CM_Http_Response_AbstractTest extends CMTest_TestCase {
 
         foreach ($responses as $path => $expectedResponse) {
             $request = new CM_Http_Request_Post($path . '/null/timestamp', null, null, '');
-            $this->assertInstanceOf($expectedResponse, CM_Http_Response_Abstract::factory($request, CM_Service_Manager::getInstance()));
+            $this->assertInstanceOf($expectedResponse, CM_Http_Response_Abstract::factory($request, $this->getServiceManager()));
         }
     }
 
     public function testSetDeleteCookie() {
         $request = new CM_Http_Request_Post('/foo/null');
-        $response = CM_Http_Response_Abstract::factory($request, CM_Service_Manager::getInstance());
+        $response = CM_Http_Response_Abstract::factory($request, $this->getServiceManager());
         $time = time();
         $timeString = date('D\, d\-M\-Y h:i:s e', $time);
 

--- a/tests/library/CM/Http/Response/AbstractTest.php
+++ b/tests/library/CM/Http/Response/AbstractTest.php
@@ -23,13 +23,13 @@ class CM_Http_Response_AbstractTest extends CMTest_TestCase {
 
         foreach ($responses as $path => $expectedResponse) {
             $request = new CM_Http_Request_Post($path . '/null/timestamp', null, null, '');
-            $this->assertInstanceOf($expectedResponse, CM_Http_Response_Abstract::factory($request));
+            $this->assertInstanceOf($expectedResponse, CM_Http_Response_Abstract::factory($request, CM_Service_Manager::getInstance()));
         }
     }
 
     public function testSetDeleteCookie() {
         $request = new CM_Http_Request_Post('/foo/null');
-        $response = CM_Http_Response_Abstract::factory($request);
+        $response = CM_Http_Response_Abstract::factory($request, CM_Service_Manager::getInstance());
         $time = time();
         $timeString = date('D\, d\-M\-Y h:i:s e', $time);
 

--- a/tests/library/CM/Http/Response/EmailTrackingTest.php
+++ b/tests/library/CM/Http/Response/EmailTrackingTest.php
@@ -14,7 +14,7 @@ class CM_Http_Response_EmailTrackingTest extends CMTest_TestCase {
         $headers = array('host' => $site->getHost());
         $render = new CM_Frontend_Render(new CM_Frontend_Environment($site));
         $request = new CM_Http_Request_Get($render->getUrlEmailTracking($mail), $headers);
-        $response = new CM_Http_Response_EmailTracking($request);
+        $response = new CM_Http_Response_EmailTracking($request, $this->getServiceManager());
 
         $response->process();
 
@@ -30,7 +30,7 @@ class CM_Http_Response_EmailTrackingTest extends CMTest_TestCase {
         $headers = array('host' => $site->getHost());
         $render = new CM_Frontend_Render(new CM_Frontend_Environment($site));
         $request = new CM_Http_Request_Get($render->getUrlEmailTracking($mail), $headers);
-        $response = new CM_Http_Response_EmailTracking($request);
+        $response = new CM_Http_Response_EmailTracking($request, $this->getServiceManager());
 
         $user->delete();
         try {
@@ -45,7 +45,7 @@ class CM_Http_Response_EmailTrackingTest extends CMTest_TestCase {
         $site = CM_Site_Abstract::factory();
         $headers = array('host' => $site->getHost());
         $request = new CM_Http_Request_Get('/emailtracking/' . $site->getId(), $headers);
-        $response = new CM_Http_Response_EmailTracking($request);
+        $response = new CM_Http_Response_EmailTracking($request, $this->getServiceManager());
 
         try {
             $response->process();

--- a/tests/library/CM/Http/Response/PageTest.php
+++ b/tests/library/CM/Http/Response/PageTest.php
@@ -125,10 +125,9 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
      */
     protected function _getServiceManager($codeGoogleAnalytics, $codeKissMetrics) {
         $serviceManager = new CM_Service_Manager();
-        $serviceManager->register('tracking-googleanalytics-test', 'CMService_GoogleAnalytics_Client', array($codeGoogleAnalytics));
-        $serviceManager->register('tracking-kissmetrics-test', 'CMService_KissMetrics_Client', array($codeKissMetrics));
-        $serviceManager->unregister('trackings');
-        $serviceManager->register('trackings', 'CM_Service_Trackings', array(array('tracking-googleanalytics-test', 'tracking-kissmetrics-test')));
+        $serviceManager->register('googleanalytics', 'CMService_GoogleAnalytics_Client', [$codeGoogleAnalytics]);
+        $serviceManager->register('kissmetrics', 'CMService_KissMetrics_Client', array($codeKissMetrics));
+        $serviceManager->register('trackings', 'CM_Service_Trackings', [['googleanalytics', 'kissmetrics']]);
         return $serviceManager;
     }
 }

--- a/tests/library/CM/Http/Response/PageTest.php
+++ b/tests/library/CM/Http/Response/PageTest.php
@@ -76,7 +76,7 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $response->process();
         $html = $response->getContent();
 
-        $this->assertNotContains("_gaq.push(['_trackPageview'", $html);
+        $this->assertNotContains('ga("send", "pageview"', $html);
         $this->assertNotContains("_kmq.push(['identify'", $html);
         $this->assertNotContains("_kmq.push(['alias'", $html);
     }
@@ -88,10 +88,8 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $response->process();
         $html = $response->getContent();
 
-        $this->assertContains('var _gaq = _gaq || [];', $html);
-        $this->assertContains("_gaq.push(['_setAccount', 'ga123']);", $html);
-        $this->assertContains("_gaq.push(['_setDomainName', 'www.default.dev']);", $html);
-        $this->assertContains("_gaq.push(['_trackPageview']);", $html);
+        $this->assertContains('ga("create", "ga123"', $html);
+        $this->assertContains('ga("send", "pageview"', $html);
         $this->assertContains('var _kmq = _kmq || [];', $html);
         $this->assertContains("var _kmk = _kmk || 'km123';", $html);
         $clientId = CM_Http_Request_Abstract::getInstance()->getClientId();
@@ -110,10 +108,8 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $response->process();
         $html = $response->getContent();
 
-        $this->assertContains('var _gaq = _gaq || [];', $html);
-        $this->assertContains("_gaq.push(['_setAccount', 'ga123']);", $html);
-        $this->assertContains("_gaq.push(['_setDomainName', 'www.default.dev']);", $html);
-        $this->assertContains("_gaq.push(['_trackPageview']);", $html);
+        $this->assertContains('ga("create", "ga123"', $html);
+        $this->assertContains('ga("send", "pageview"', $html);
         $this->assertContains('var _kmq = _kmq || [];', $html);
         $this->assertContains("var _kmk = _kmk || 'km123';", $html);
         $clientId = CM_Http_Request_Abstract::getInstance()->getClientId();

--- a/tests/library/CM/Http/Response/PageTest.php
+++ b/tests/library/CM/Http/Response/PageTest.php
@@ -76,7 +76,7 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $response->process();
         $html = $response->getContent();
 
-        $this->assertNotContains('ga("send", "pageview"', $html);
+        $this->assertNotContains('ga("send", "pageview", "/mock5")', $html);
         $this->assertNotContains("_kmq.push(['identify'", $html);
         $this->assertNotContains("_kmq.push(['alias'", $html);
     }
@@ -89,7 +89,7 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $html = $response->getContent();
 
         $this->assertContains('ga("create", "ga123"', $html);
-        $this->assertContains('ga("send", "pageview"', $html);
+        $this->assertContains('ga("send", "pageview", "/mock5")', $html);
         $this->assertContains('var _kmq = _kmq || [];', $html);
         $this->assertContains("var _kmk = _kmk || 'km123';", $html);
         $clientId = CM_Http_Request_Abstract::getInstance()->getClientId();
@@ -109,7 +109,7 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $html = $response->getContent();
 
         $this->assertContains('ga("create", "ga123"', $html);
-        $this->assertContains('ga("send", "pageview"', $html);
+        $this->assertContains('ga("send", "pageview", "/mock5")', $html);
         $this->assertContains('var _kmq = _kmq || [];', $html);
         $this->assertContains("var _kmk = _kmk || 'km123';", $html);
         $clientId = CM_Http_Request_Abstract::getInstance()->getClientId();

--- a/tests/library/CM/Http/Response/Resource/Css/LibraryTest.php
+++ b/tests/library/CM/Http/Response/Resource/Css/LibraryTest.php
@@ -5,7 +5,7 @@ class CM_Http_Response_Resource_Css_LibraryTest extends CMTest_TestCase {
     public function testProcess() {
         $render = new CM_Frontend_Render(new CM_Frontend_Environment());
         $request = new CM_Http_Request_Get($render->getUrlResource('library-css', 'all.css'));
-        $response = new CM_Http_Response_Resource_Css_Library($request);
+        $response = new CM_Http_Response_Resource_Css_Library($request, $this->getServiceManager());
         $response->process();
         $this->assertContains('body{', $response->getContent());
     }

--- a/tests/library/CM/Http/Response/Resource/Css/VendorTest.php
+++ b/tests/library/CM/Http/Response/Resource/Css/VendorTest.php
@@ -5,7 +5,7 @@ class CM_Http_Response_Resource_Css_VendorTest extends CMTest_TestCase {
     public function testProcess() {
         $render = new CM_Frontend_Render(new CM_Frontend_Environment());
         $request = new CM_Http_Request_Get($render->getUrlResource('vendor-css', 'all.css'));
-        $response = new CM_Http_Response_Resource_Css_Vendor($request);
+        $response = new CM_Http_Response_Resource_Css_Vendor($request, $this->getServiceManager());
         $response->process();
         $this->assertContains('body{', $response->getContent());
     }

--- a/tests/library/CM/Http/Response/Resource/Javascript/LibraryTest.php
+++ b/tests/library/CM/Http/Response/Resource/Javascript/LibraryTest.php
@@ -22,7 +22,7 @@ class CM_Http_Response_Resource_Javascript_LibraryTest extends CMTest_TestCase {
     public function testProcessLibrary() {
         $render = new CM_Frontend_Render(new CM_Frontend_Environment());
         $request = new CM_Http_Request_Get($render->getUrlResource('library-js', 'library.js'));
-        $response = new CM_Http_Response_Resource_Javascript_Library($request);
+        $response = new CM_Http_Response_Resource_Javascript_Library($request, $this->getServiceManager());
         $response->process();
         $this->assertContains('function()', $response->getContent());
     }
@@ -30,7 +30,7 @@ class CM_Http_Response_Resource_Javascript_LibraryTest extends CMTest_TestCase {
     public function testProcessTranslations() {
         $render = new CM_Frontend_Render(new CM_Frontend_Environment());
         $request = new CM_Http_Request_Get($render->getUrlResource('library-js', 'translations/123.js'));
-        $response = new CM_Http_Response_Resource_Javascript_Library($request);
+        $response = new CM_Http_Response_Resource_Javascript_Library($request, $this->getServiceManager());
         $response->process();
         $this->assertContains('cm.language.setAll', $response->getContent());
     }

--- a/tests/library/CM/Http/Response/Resource/Javascript/VendorTest.php
+++ b/tests/library/CM/Http/Response/Resource/Javascript/VendorTest.php
@@ -5,7 +5,7 @@ class CM_Http_Response_Resource_Javascript_VendorTest extends CMTest_TestCase {
     public function testProcessBeforeBody() {
         $render = new CM_Frontend_Render(new CM_Frontend_Environment());
         $request = new CM_Http_Request_Get($render->getUrlResource('vendor-js', 'before-body.js'));
-        $response = new CM_Http_Response_Resource_Javascript_Vendor($request);
+        $response = new CM_Http_Response_Resource_Javascript_Vendor($request, $this->getServiceManager());
         $response->process();
         $this->assertContains('function()', $response->getContent());
         $this->assertContains('Modernizr', $response->getContent());
@@ -14,7 +14,7 @@ class CM_Http_Response_Resource_Javascript_VendorTest extends CMTest_TestCase {
     public function testProcessAfterBody() {
         $render = new CM_Frontend_Render(new CM_Frontend_Environment());
         $request = new CM_Http_Request_Get($render->getUrlResource('vendor-js', 'after-body.js'));
-        $response = new CM_Http_Response_Resource_Javascript_Vendor($request);
+        $response = new CM_Http_Response_Resource_Javascript_Vendor($request, $this->getServiceManager());
         $response->process();
         $this->assertContains('function()', $response->getContent());
         $this->assertContains('jQuery', $response->getContent());

--- a/tests/library/CM/Http/Response/UploadTest.php
+++ b/tests/library/CM/Http/Response/UploadTest.php
@@ -21,7 +21,7 @@ class CM_Http_Response_UploadTest extends CMTest_TestCase {
         $_FILES = array('file' => array('name' => $filename, 'tmp_name' => $fileTmp->getPath()));
 
         $request = new CM_Http_Request_Post('/upload/null');
-        $upload = new CM_Http_Response_Upload($request);
+        $upload = new CM_Http_Response_Upload($request, $this->getServiceManager());
         $upload->process();
         $data = json_decode($upload->getContent(), true);
 
@@ -41,7 +41,7 @@ class CM_Http_Response_UploadTest extends CMTest_TestCase {
         $_FILES = array('file' => array('name' => $filename, 'tmp_name' => $fileTmp->getPath()));
 
         $request = new CM_Http_Request_Post('/upload/null?field=CM_FormField_FileImage');
-        $upload = new CM_Http_Response_Upload($request);
+        $upload = new CM_Http_Response_Upload($request, $this->getServiceManager());
         $upload->process();
         $data = json_decode($upload->getContent(), true);
 
@@ -58,7 +58,7 @@ class CM_Http_Response_UploadTest extends CMTest_TestCase {
         $_FILES = array('file' => array('name' => $filename, 'tmp_name' => $fileTmp->getPath()));
 
         $request = new CM_Http_Request_Post('/upload/null?field=CM_FormField_FileImage');
-        $upload = new CM_Http_Response_Upload($request);
+        $upload = new CM_Http_Response_Upload($request, $this->getServiceManager());
         $upload->process();
         $data = json_decode($upload->getContent(), true);
 
@@ -73,7 +73,7 @@ class CM_Http_Response_UploadTest extends CMTest_TestCase {
         $_FILES = array('file' => array('name' => $filename, 'tmp_name' => $fileTmp->getPath()));
 
         $request = new CM_Http_Request_Post('/upload/null?field=CM_FormField_File');
-        $upload = new CM_Http_Response_Upload($request);
+        $upload = new CM_Http_Response_Upload($request, $this->getServiceManager());
         $upload->process();
         $data = json_decode($upload->getContent(), true);
 
@@ -88,7 +88,7 @@ class CM_Http_Response_UploadTest extends CMTest_TestCase {
         $_FILES = array('file' => array('name' => $filename, 'tmp_name' => $fileTmp->getPath()));
 
         $request = new CM_Http_Request_Post('/upload/null?field=CM_FormField_FileImage');
-        $upload = new CM_Http_Response_Upload($request);
+        $upload = new CM_Http_Response_Upload($request, $this->getServiceManager());
         $upload->process();
         $data = json_decode($upload->getContent(), true);
 
@@ -103,7 +103,7 @@ class CM_Http_Response_UploadTest extends CMTest_TestCase {
         $_FILES = array('file' => array('name' => $filename, 'tmp_name' => $fileTmp->getPath()));
 
         $request = new CM_Http_Request_Post('/upload/null?field=CM_FormField_File');
-        $upload = new CM_Http_Response_Upload($request);
+        $upload = new CM_Http_Response_Upload($request, $this->getServiceManager());
         $upload->process();
         $data = json_decode($upload->getContent(), true);
 
@@ -118,7 +118,7 @@ class CM_Http_Response_UploadTest extends CMTest_TestCase {
         $_FILES = array('file' => array('name' => $filename, 'tmp_name' => $fileTmp->getPath()));
 
         $request = new CM_Http_Request_Post('/upload/null?field=nonexistent');
-        $upload = new CM_Http_Response_Upload($request);
+        $upload = new CM_Http_Response_Upload($request, $this->getServiceManager());
 
         try {
             $upload->process();

--- a/tests/library/CM/Layout/AbstractTest.php
+++ b/tests/library/CM/Layout/AbstractTest.php
@@ -81,10 +81,9 @@ class CM_Layout_AbstractTest extends CMTest_TestCase {
      */
     protected function _getServiceManager($codeGoogleAnalytics, $codeKissMetrics) {
         $serviceManager = new CM_Service_Manager();
-        $serviceManager->register('tracking-googleanalytics-test', 'CMService_GoogleAnalytics_Client', array($codeGoogleAnalytics));
-        $serviceManager->register('tracking-kissmetrics-test', 'CMService_KissMetrics_Client', array($codeKissMetrics));
-        $serviceManager->unregister('trackings');
-        $serviceManager->register('trackings', 'CM_Service_Trackings', array(array('tracking-googleanalytics-test', 'tracking-kissmetrics-test')));
+        $serviceManager->register('googleanalytics', 'CMService_GoogleAnalytics_Client', [$codeGoogleAnalytics]);
+        $serviceManager->register('kissmetrics', 'CMService_KissMetrics_Client', array($codeKissMetrics));
+        $serviceManager->register('trackings', 'CM_Service_Trackings', [['googleanalytics', 'kissmetrics']]);
         return $serviceManager;
     }
 }

--- a/tests/library/CM/Layout/AbstractTest.php
+++ b/tests/library/CM/Layout/AbstractTest.php
@@ -11,7 +11,7 @@ class CM_Layout_AbstractTest extends CMTest_TestCase {
         $renderAdapter = new CM_RenderAdapter_Layout($render, $pageMock);
         $html = $renderAdapter->fetch();
 
-        $this->assertNotContains('var _gaq = _gaq || [];', $html);
+        $this->assertNotContains('ga("create", "key"', $html);
         $this->assertNotContains('var _kmq = _kmq || [];', $html);
     }
 
@@ -25,10 +25,8 @@ class CM_Layout_AbstractTest extends CMTest_TestCase {
         $renderAdapter = new CM_RenderAdapter_Layout($render, $pageMock);
         $html = $renderAdapter->fetch();
 
-        $this->assertContains('var _gaq = _gaq || [];', $html);
-        $this->assertContains("_gaq.push(['_setAccount', 'ga123']);", $html);
-        $this->assertContains("_gaq.push(['_setDomainName', 'www.example.com']);", $html);
-        $this->assertNotContains("_gaq.push(['_trackPageview'", $html);
+        $this->assertContains('ga("create", "ga123"', $html);
+        $this->assertNotContains('ga("send", "pageview"', $html);
         $this->assertContains('var _kmq = _kmq || [];', $html);
         $this->assertContains("var _kmk = _kmk || 'km123';", $html);
         $this->assertNotContains("_kmq.push(['identify'", $html);
@@ -50,10 +48,8 @@ class CM_Layout_AbstractTest extends CMTest_TestCase {
         $renderAdapter = new CM_RenderAdapter_Layout($render, $pageMock);
         $html = $renderAdapter->fetch();
 
-        $this->assertContains('var _gaq = _gaq || [];', $html);
-        $this->assertContains("_gaq.push(['_setAccount', 'ga123']);", $html);
-        $this->assertContains("_gaq.push(['_setDomainName', 'www.example.com']);", $html);
-        $this->assertNotContains("_gaq.push(['_trackPageview'", $html);
+        $this->assertContains('ga("create", "ga123"', $html);
+        $this->assertNotContains('ga("send", "pageview"', $html);
         $this->assertContains('var _kmq = _kmq || [];', $html);
         $this->assertContains("var _kmk = _kmk || 'km123';", $html);
         $this->assertNotContains("_kmq.push(['identify'", $html);

--- a/tests/library/CM/Model/SplittestTest.php
+++ b/tests/library/CM/Model/SplittestTest.php
@@ -119,10 +119,8 @@ class CM_Model_SplittestTest extends CMTest_TestCase {
         $kissMetrics->expects($this->once())->method('trackSplittest')->with($fixture, $this->equalTo($variation));
 
         $serviceManager = new CM_Service_Manager();
-        $serviceManager->registerInstance('tracking-kissmetrics-test', $kissMetrics);
-        $serviceManager->unregister('trackings');
-        $serviceManager->register('trackings', 'CM_Service_Trackings', array(array('tracking-kissmetrics-test')));
-
+        $serviceManager->registerInstance('kissmetrics', $kissMetrics);
+        $serviceManager->register('trackings', 'CM_Service_Trackings', [['kissmetrics']]);
         $test->setServiceManager($serviceManager);
 
         $test->getVariationFixture($fixture);

--- a/tests/library/CMService/GoogleAnalytics/ClientTest.php
+++ b/tests/library/CMService/GoogleAnalytics/ClientTest.php
@@ -69,33 +69,6 @@ class CMService_GoogleAnalytics_ClientTest extends CMTest_TestCase {
         $this->assertSame(1, substr_count($js, 'ga("send", "pageview", " / bar");'));
     }
 
-    public function testAddPageView_withoutPath() {
-        $googleAnalytics = new CMService_GoogleAnalytics_Client('');
-        $environment = new CM_Frontend_Environment();
-        $js = $googleAnalytics->getJs($environment);
-        $this->assertNotContains('ga("send", "pageview"', $js);
-
-        $googleAnalytics->addPageView();
-        $js = $googleAnalytics->getJs($environment);
-        $this->assertSame(1, substr_count($js, 'ga("send", "pageview"'));
-        $this->assertSame(1, substr_count($js, 'ga("send", "pageview");'));
-
-        $googleAnalytics->addPageView();
-        $js = $googleAnalytics->getJs($environment);
-        $this->assertSame(1, substr_count($js, 'ga("send", "pageview"'));
-        $this->assertSame(1, substr_count($js, 'ga("send", "pageview");'));
-
-        $googleAnalytics->addPageView(' / foo');
-        $js = $googleAnalytics->getJs($environment);
-        $this->assertSame(1, substr_count($js, 'ga("send", "pageview"'));
-        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", " / foo");'));
-
-        $googleAnalytics->addPageView();
-        $js = $googleAnalytics->getJs($environment);
-        $this->assertSame(1, substr_count($js, 'ga("send", "pageview"'));
-        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", " / foo");'));
-    }
-
     public function testSetPageView() {
         $googleAnalytics = new CMService_GoogleAnalytics_Client('');
         $environment = new CM_Frontend_Environment();

--- a/tests/library/CMService/GoogleAnalytics/ClientTest.php
+++ b/tests/library/CMService/GoogleAnalytics/ClientTest.php
@@ -6,127 +6,132 @@ class CMService_GoogleAnalytics_ClientTest extends CMTest_TestCase {
         $googleAnalytics = new CMService_GoogleAnalytics_Client('key');
         $environment = new CM_Frontend_Environment();
         $html = $googleAnalytics->getHtml($environment);
-        $this->assertContains("_gaq.push(['_setAccount', 'key']);", $html);
+        $this->assertContains('ga("create", "key"', $html);
     }
 
-    public function testAddCustomVar() {
+    public function testSetCustomMetric() {
         $googleAnalytics = new CMService_GoogleAnalytics_Client('');
         $environment = new CM_Frontend_Environment();
         $js = $googleAnalytics->getJs($environment);
-        $this->assertNotContains("_gaq.push(['_setCustomVar'", $js);
+        $this->assertNotContains('ga("set", "metric', $js);
 
-        $googleAnalytics->addCustomVar(2, 'premium', 'yes', 1);
+        $googleAnalytics->setCustomMetric(2, 23.34);
         $js = $googleAnalytics->getJs($environment);
-        $this->assertContains("_gaq.push(['_setCustomVar', 2, 'premium', 'yes', 1]);", $js);
+        $this->assertContains('ga("set", "metric2", 23.34)', $js);
+    }
+
+    public function testSetCustomDimension() {
+        $googleAnalytics = new CMService_GoogleAnalytics_Client('');
+        $environment = new CM_Frontend_Environment();
+        $js = $googleAnalytics->getJs($environment);
+        $this->assertNotContains('ga("set", "dimension', $js);
+
+        $googleAnalytics->setCustomDimension(3, 'foo');
+        $js = $googleAnalytics->getJs($environment);
+        $this->assertContains('ga("set", "dimension3", "foo")', $js);
     }
 
     public function testAddEvent() {
         $googleAnalytics = new CMService_GoogleAnalytics_Client('');
         $environment = new CM_Frontend_Environment();
         $js = $googleAnalytics->getJs($environment);
-        $this->assertNotContains("_gaq.push(['_trackEvent'", $js);
+        $this->assertNotContains('"hitType":"event"', $js);
 
         $googleAnalytics->addEvent('Sign Up', 'Click');
         $js = $googleAnalytics->getJs($environment);
-        $this->assertContains("_gaq.push(['_trackEvent', 'Sign Up', 'Click', undefined, undefined, undefined]);", $js);
+        $this->assertContains('ga("send", {"hitType":"event","eventCategory":"Sign Up","eventAction":"Click"});', $js);
 
         $googleAnalytics->addEvent('Subscription', 'Click', 'Label', 123, true);
         $js = $googleAnalytics->getJs($environment);
-        $this->assertContains("_gaq.push(['_trackEvent', 'Sign Up', 'Click', undefined, undefined, undefined]);", $js);
-        $this->assertContains("_gaq.push(['_trackEvent', 'Subscription', 'Click', 'Label', 123, true]);", $js);
+        $this->assertContains('ga("send", {"hitType":"event","eventCategory":"Subscription","eventAction":"Click","eventLabel":"Label","eventValue":123,"nonInteraction":true});', $js);
     }
 
     public function testAddPageView() {
         $googleAnalytics = new CMService_GoogleAnalytics_Client('');
         $environment = new CM_Frontend_Environment();
         $js = $googleAnalytics->getJs($environment);
-        $this->assertNotContains("_gaq.push(['_trackPageview'", $js);
+        $this->assertNotContains('ga("send", "pageview"', $js);
 
-        $googleAnalytics->addPageView('/foo');
+        $googleAnalytics->addPageView(' / foo');
         $js = $googleAnalytics->getJs($environment);
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_trackPageview'"));
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_trackPageview', '/foo']);"));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview"'));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", " / foo");'));
 
-        $googleAnalytics->addPageView('/foo');
+        $googleAnalytics->addPageView(' / foo');
         $js = $googleAnalytics->getJs($environment);
-        $this->assertSame(2, substr_count($js, "_gaq.push(['_trackPageview'"));
-        $this->assertSame(2, substr_count($js, "_gaq.push(['_trackPageview', '/foo']);"));
+        $this->assertSame(2, substr_count($js, 'ga("send", "pageview"'));
+        $this->assertSame(2, substr_count($js, 'ga("send", "pageview", " / foo");'));
 
-        $googleAnalytics->addPageView('/bar');
+        $googleAnalytics->addPageView(' / bar');
         $js = $googleAnalytics->getJs($environment);
-        $this->assertSame(3, substr_count($js, "_gaq.push(['_trackPageview'"));
-        $this->assertSame(2, substr_count($js, "_gaq.push(['_trackPageview', '/foo']);"));
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_trackPageview', '/bar']);"));
+        $this->assertSame(3, substr_count($js, 'ga("send", "pageview"'));
+        $this->assertSame(2, substr_count($js, 'ga("send", "pageview", " / foo");'));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", " / bar");'));
     }
 
     public function testAddPageView_withoutPath() {
         $googleAnalytics = new CMService_GoogleAnalytics_Client('');
         $environment = new CM_Frontend_Environment();
         $js = $googleAnalytics->getJs($environment);
-        $this->assertNotContains("_gaq.push(['_trackPageview'", $js);
+        $this->assertNotContains('ga("send", "pageview"', $js);
 
         $googleAnalytics->addPageView();
         $js = $googleAnalytics->getJs($environment);
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_trackPageview'"));
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_trackPageview']);"));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview"'));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview");'));
 
         $googleAnalytics->addPageView();
         $js = $googleAnalytics->getJs($environment);
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_trackPageview'"));
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_trackPageview']);"));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview"'));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview");'));
 
-        $googleAnalytics->addPageView('/foo');
+        $googleAnalytics->addPageView(' / foo');
         $js = $googleAnalytics->getJs($environment);
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_trackPageview'"));
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_trackPageview', '/foo']);"));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview"'));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", " / foo");'));
 
         $googleAnalytics->addPageView();
         $js = $googleAnalytics->getJs($environment);
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_trackPageview'"));
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_trackPageview', '/foo']);"));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview"'));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", " / foo");'));
     }
 
     public function testAddSale() {
         $googleAnalytics = new CMService_GoogleAnalytics_Client('');
         $environment = new CM_Frontend_Environment();
         $js = $googleAnalytics->getJs($environment);
-        $this->assertNotContains("_gaq.push(['_addTrans'", $js);
-        $this->assertNotContains("_gaq.push(['_addItem'", $js);
-        $this->assertNotContains("_gaq.push(['_trackTrans']);", $js);
+        $this->assertNotContains('ga("require", "ecommerce")', $js);
+        $this->assertNotContains('ecommerce:addTransaction', $js);
+        $this->assertNotContains('ecommerce:addItem', $js);
+        $this->assertNotContains('ecommerce:send', $js);
 
         $googleAnalytics->addSale('t123', 'p123', 1.23);
         $js = $googleAnalytics->getJs($environment);
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_addTrans'"));
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_addItem'"));
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_trackTrans']);"));
-        $this->assertContains("_gaq.push(['_addTrans', 't123', '', '1.23', '', '', '', '', '']);", $js);
-        $this->assertContains("_gaq.push(['_addItem', 't123', 'p123', 'product-p123', '', '1.23', '1']);", $js);
+        $this->assertContains('ga("require", "ecommerce")', $js);
+        $this->assertSame(1, substr_count($js, 'ga("ecommerce:addTransaction"'));
+        $this->assertSame(1, substr_count($js, 'ga("ecommerce:addItem"'));
+        $this->assertSame(1, substr_count($js, 'ga("ecommerce:send");'));
+        $this->assertContains('ga("ecommerce:addTransaction", {"id":"t123","revenue":1.23});', $js);
+        $this->assertContains('ga("ecommerce:addItem", {"id":"t123","name":"product-p123","sku":"p123","price":1.23,"quantity":1});', $js);
 
         $googleAnalytics->addSale('t123', 'p456', 4.56);
         $js = $googleAnalytics->getJs($environment);
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_addTrans'"));
-        $this->assertSame(2, substr_count($js, "_gaq.push(['_addItem'"));
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_trackTrans']);"));
-        $this->assertContains("_gaq.push(['_addTrans', 't123', '', '5.79', '', '', '', '', '']);", $js);
-        $this->assertContains("_gaq.push(['_addItem', 't123', 'p123', 'product-p123', '', '1.23', '1']);", $js);
-        $this->assertContains("_gaq.push(['_addItem', 't123', 'p456', 'product-p456', '', '4.56', '1']);", $js);
+        $this->assertSame(1, substr_count($js, 'ga("ecommerce:addTransaction"'));
+        $this->assertSame(2, substr_count($js, 'ga("ecommerce:addItem"'));
+        $this->assertSame(1, substr_count($js, 'ga("ecommerce:send");'));
+        $this->assertContains('ga("ecommerce:addTransaction", {"id":"t123","revenue":5.79});', $js);
+        $this->assertContains('ga("ecommerce:addItem", {"id":"t123","name":"product-p123","sku":"p123","price":1.23,"quantity":1});', $js);
+        $this->assertContains('ga("ecommerce:addItem", {"id":"t123","name":"product-p456","sku":"p456","price":4.56,"quantity":1});', $js);
 
         $googleAnalytics->addSale('t789', 'p789', 7.89);
         $js = $googleAnalytics->getJs($environment);
-        $this->assertSame(2, substr_count($js, "_gaq.push(['_addTrans'"));
-        $this->assertSame(3, substr_count($js, "_gaq.push(['_addItem'"));
-        $this->assertSame(1, substr_count($js, "_gaq.push(['_trackTrans']);"));
-        $this->assertContains("_gaq.push(['_addTrans', 't123', '', '5.79', '', '', '', '', '']);", $js);
-        $this->assertContains("_gaq.push(['_addItem', 't123', 'p123', 'product-p123', '', '1.23', '1']);", $js);
-        $this->assertContains("_gaq.push(['_addItem', 't123', 'p456', 'product-p456', '', '4.56', '1']);", $js);
-        $this->assertContains("_gaq.push(['_addTrans', 't789', '', '7.89', '', '', '', '', '']);", $js);
-        $this->assertContains("_gaq.push(['_addItem', 't789', 'p789', 'product-p789', '', '7.89', '1']);", $js);
-    }
-
-    public function testDomainName() {
-        $googleAnalytics = new CMService_GoogleAnalytics_Client('');
-        $environment = new CM_Frontend_Environment();
-        $html = $googleAnalytics->getHtml($environment);
-        $this->assertContains("_gaq.push(['_setDomainName', 'www.default.dev']);", $html);
+        $this->assertSame(2, substr_count($js, 'ga("ecommerce:addTransaction"'));
+        $this->assertSame(3, substr_count($js, 'ga("ecommerce:addItem"'));
+        $this->assertSame(1, substr_count($js, 'ga("ecommerce:send");'));
+        $this->assertContains('ga("ecommerce:addTransaction", {"id":"t123","revenue":5.79});', $js);
+        $this->assertContains('ga("ecommerce:addItem", {"id":"t123","name":"product-p123","sku":"p123","price":1.23,"quantity":1});', $js);
+        $this->assertContains('ga("ecommerce:addItem", {"id":"t123","name":"product-p456","sku":"p456","price":4.56,"quantity":1});', $js);
+        $this->assertContains('ga("ecommerce:addTransaction", {"id":"t789","revenue":7.89});', $js);
+        $this->assertContains('ga("ecommerce:addItem", {"id":"t789","name":"product-p789","sku":"p789","price":7.89,"quantity":1});', $js);
     }
 }

--- a/tests/library/CMService/GoogleAnalytics/ClientTest.php
+++ b/tests/library/CMService/GoogleAnalytics/ClientTest.php
@@ -20,7 +20,7 @@ class CMService_GoogleAnalytics_ClientTest extends CMTest_TestCase {
 
         $googleAnalytics->setCustomMetric(2, 23.34);
         $js = $googleAnalytics->getJs($environment);
-        $this->assertContains('ga("set", "metric2", 23.34)', $js);
+        $this->assertContains('ga("set", "metric2", "23.34")', $js);
     }
 
     public function testSetCustomDimension() {

--- a/tests/library/CMService/GoogleAnalytics/ClientTest.php
+++ b/tests/library/CMService/GoogleAnalytics/ClientTest.php
@@ -96,6 +96,23 @@ class CMService_GoogleAnalytics_ClientTest extends CMTest_TestCase {
         $this->assertSame(1, substr_count($js, 'ga("send", "pageview", " / foo");'));
     }
 
+    public function testSetPageView() {
+        $googleAnalytics = new CMService_GoogleAnalytics_Client('');
+        $environment = new CM_Frontend_Environment();
+        $js = $googleAnalytics->getJs($environment);
+        $this->assertNotContains('ga("send", "pageview"', $js);
+
+        $googleAnalytics->addPageView('/foo');
+        $js = $googleAnalytics->getJs($environment);
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview"'));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", "/foo");'));
+
+        $googleAnalytics->setPageView('/bar');
+        $js = $googleAnalytics->getJs($environment);
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview"'));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", "/bar");'));
+    }
+
     public function testAddSale() {
         $googleAnalytics = new CMService_GoogleAnalytics_Client('');
         $environment = new CM_Frontend_Environment();

--- a/tests/library/CMService/GoogleAnalytics/ClientTest.php
+++ b/tests/library/CMService/GoogleAnalytics/ClientTest.php
@@ -3,10 +3,13 @@
 class CMService_GoogleAnalytics_ClientTest extends CMTest_TestCase {
 
     public function testAccount() {
-        $googleAnalytics = new CMService_GoogleAnalytics_Client('key');
-        $environment = new CM_Frontend_Environment();
+        $site = $this->getMockSite(null, null, ['url' => 'http://www.my-website.net']);
+        $googleAnalytics = new CMService_GoogleAnalytics_Client('key123');
+        $environment = new CM_Frontend_Environment($site);
+        $request = new CM_Http_Request_Get('/pseudo-request', ['Cookie' => 'clientId=222']);
+
         $html = $googleAnalytics->getHtml($environment);
-        $this->assertContains('ga("create", "key"', $html);
+        $this->assertContains('ga("create", "key123", {"cookieDomain":"www.my-website.net","clientId":"222"}', $html);
     }
 
     public function testSetCustomMetric() {


### PR DESCRIPTION
@moby86 @fauvel 

Docu: https://developers.google.com/analytics/devguides/collection/upgrade/reference/gajs-analyticsjs

Things to consider:
- [**Cross Domain Tracking**](https://developers.google.com/analytics/devguides/collection/upgrade/reference/gajs-analyticsjs#cross-domain): I will drop it, because we don't need to track sessions across domains. It would require us to list all linked domains on on every website.
- [**Custom Dimensions/Metrics**](https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets): These replace the previous *custom variables*. Dimensions are strings, Metrics are numbers.
 - We will need to configure them in GA Admin: "Property > Custom Definitions"
- [**Ajax Navigation Tracking**](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications): We need to set the `page` whenever we track a new *pageview*, otherwise the tracker object would reuse the *page* from its initialization.

PR changes:
- `CM_Http_Response_*`: Are now service-manager aware, mandatory second argument
- `CMTest_TestCase`: Is now service-manager aware
- `CMService_GoogleAnalytics_Client::addPageView()`:  Path now mandatory
- `CM_Service_Tracking_ClientInterface::trackPageView()`: Path now mandatory