### PR TITLE
make only servicemanager-dependent storage-systems ServiceManagerAware

### DIFF
--- a/library/CM/Clockwork/Manager.php
+++ b/library/CM/Clockwork/Manager.php
@@ -1,6 +1,6 @@
 <?php
 
-class CM_Clockwork_Manager extends CM_Service_ManagerAware {
+class CM_Clockwork_Manager {
 
     /** @var CM_Clockwork_Event[] */
     private $_events;
@@ -62,7 +62,6 @@ class CM_Clockwork_Manager extends CM_Service_ManagerAware {
      */
     public function setStorage(CM_Clockwork_Storage_Abstract $storage) {
         $this->_storage = $storage;
-        $this->_storage->setServiceManager($this->getServiceManager());
     }
 
     /**

--- a/library/CM/Clockwork/Storage/Abstract.php
+++ b/library/CM/Clockwork/Storage/Abstract.php
@@ -1,6 +1,6 @@
 <?php
 
-abstract class CM_Clockwork_Storage_Abstract extends CM_Service_ManagerAware {
+abstract class CM_Clockwork_Storage_Abstract {
 
     /** @var string */
     protected $_context;

--- a/library/CM/Clockwork/Storage/FileSystem.php
+++ b/library/CM/Clockwork/Storage/FileSystem.php
@@ -1,6 +1,8 @@
 <?php
 
-class CM_Clockwork_Storage_FileSystem extends CM_Clockwork_Storage_Abstract {
+class CM_Clockwork_Storage_FileSystem extends CM_Clockwork_Storage_Abstract implements CM_Service_ManagerAwareInterface {
+
+    use CM_Service_ManagerAwareTrait;
 
     protected function _load() {
         $data = [];

--- a/library/CM/Elasticsearch/Index/Cli.php
+++ b/library/CM/Elasticsearch/Index/Cli.php
@@ -85,8 +85,9 @@ class CM_Elasticsearch_Index_Cli extends CM_Cli_Runnable_Abstract {
 
     public function startMaintenance() {
         $clockwork = new CM_Clockwork_Manager();
-        $clockwork->setServiceManager(CM_Service_Manager::getInstance());
-        $clockwork->setStorage(new CM_Clockwork_Storage_FileSystem('search-maintenance'));
+        $storage = new CM_Clockwork_Storage_FileSystem('search-maintenance');
+        $storage->setServiceManager(CM_Service_Manager::getInstance());
+        $clockwork->setStorage($storage);
         $clockwork->registerCallback('search-index-update', '1 minute', array($this, 'update'));
         $clockwork->registerCallback('search-index-optimize', '1 hour', array($this, 'optimize'));
         $clockwork->start();

--- a/library/CM/Maintenance/Cli.php
+++ b/library/CM/Maintenance/Cli.php
@@ -10,16 +10,18 @@ class CM_Maintenance_Cli extends CM_Cli_Runnable_Abstract {
      */
     public function start() {
         $this->_clockworkManager = new CM_Clockwork_Manager();
-        $this->_clockworkManager->setServiceManager(CM_Service_Manager::getInstance());
-        $this->_clockworkManager->setStorage(new CM_Clockwork_Storage_FileSystem('app-maintenance'));
+        $storage = new CM_Clockwork_Storage_FileSystem('app-maintenance');
+        $storage->setServiceManager(CM_Service_Manager::getInstance());
+        $this->_clockworkManager->setStorage($storage);
         $this->_registerCallbacks();
         $this->_clockworkManager->start();
     }
 
     public function startLocal() {
         $this->_clockworkManager = new CM_Clockwork_Manager();
-        $this->_clockworkManager->setServiceManager(CM_Service_Manager::getInstance());
-        $this->_clockworkManager->setStorage(new CM_Clockwork_Storage_FileSystem('app-maintenance-local'));
+        $storage = new CM_Clockwork_Storage_FileSystem('app-maintenance-local');
+        $storage->setServiceManager(CM_Service_Manager::getInstance());
+        $this->_clockworkManager->setStorage($storage);
         $this->_registerCallbacksLocal();
         $this->_clockworkManager->start();
     }

--- a/tests/library/CM/Clockwork/ManagerTest.php
+++ b/tests/library/CM/Clockwork/ManagerTest.php
@@ -2,17 +2,6 @@
 
 class CM_Clockwork_ManagerTest extends CMTest_TestCase {
 
-    public function testSetStorage() {
-        $manager = new CM_Clockwork_Manager();
-        $serviceManager = $this->mockObject('CM_Service_Manager');
-        /** @var CM_Service_Manager $serviceManager */
-        $manager->setServiceManager($serviceManager);
-        $storage = $this->mockObject('CM_Clockwork_Storage_Abstract', ['foo']);
-        /** @var CM_Clockwork_Storage_Abstract $storage */
-        $manager->setStorage($storage);
-        $this->assertSame($serviceManager, $storage->getServiceManager());
-    }
-
     public function testRunNonBlocking() {
         $process = $this->mockClass('CM_Process')->newInstanceWithoutConstructor();
         $forkMock = $process->mockMethod('fork');
@@ -82,7 +71,6 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $currently = new DateTime('13:59:59', $timeZone);
         /** @var CM_Clockwork_Manager $manager */
         $manager = $managerMock->newInstance();
-        $manager->setServiceManager(CM_Service_Manager::getInstance());
         $manager->setStorage($storage);
         /** @var CM_Clockwork_Event $event */
         $event = new CM_Clockwork_Event('event1', '14:00');
@@ -105,7 +93,6 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $lastRuntime = null;
         $currently = new DateTime('last day of', $timeZone);
         $manager = $managerMock->newInstance();
-        $manager->setServiceManager(CM_Service_Manager::getInstance());
         $manager->setStorage($storage);
         $manager->setTimeZone($timeZone);
         $event = new CM_Clockwork_Event('event2', 'first day of 09:00');
@@ -122,7 +109,6 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $currently = new DateTime('23:59', $timeZone);
 
         $manager = $managerMock->newInstance();
-        $manager->setServiceManager(CM_Service_Manager::getInstance());
         $manager->setStorage($storage);
         $manager->setTimeZone($timeZone);
         $event = new CM_Clockwork_Event('event3', '23:59');
@@ -156,7 +142,6 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $storage = $storageClass->newInstance();
         /** @var CM_Clockwork_Manager $manager */
         $manager = $managerMock->newInstance();
-        $manager->setServiceManager(CM_Service_Manager::getInstance());
         $manager->setStorage($storage);
         $_shouldRun = CMTest_TH::getProtectedMethod('CM_Clockwork_Manager', '_shouldRun');
 
@@ -211,7 +196,6 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
 
         /** @var CM_Clockwork_Manager $manager */
         $manager = $managerMock->newInstance();
-        $manager->setServiceManager(CM_Service_Manager::getInstance());
         $manager->setStorage($storage);
         $manager->setTimeZone($timeZone);
         $_shouldRun = CMTest_TH::getProtectedMethod('CM_Clockwork_Manager', '_shouldRun');
@@ -256,7 +240,6 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
 
         /** @var CM_Clockwork_Manager $manager */
         $manager = $managerMock->newInstance();
-        $manager->setServiceManager(CM_Service_Manager::getInstance());
         $manager->setStorage($storage);
         $manager->setTimeZone($timeZone);
         $_shouldRun = CMTest_TH::getProtectedMethod('CM_Clockwork_Manager', '_shouldRun');
@@ -295,7 +278,6 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $storage = $storageClass->newInstance();
         /** @var CM_Clockwork_Manager $manager */
         $manager = $managerMock->newInstance();
-        $manager->setServiceManager(CM_Service_Manager::getInstance());
         $manager->setStorage($storage);
         $manager->setTimeZone($timeZone);
         $_shouldRun = CMTest_TH::getProtectedMethod('CM_Clockwork_Manager', '_shouldRun');
@@ -334,7 +316,6 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
 
         /** @var CM_Clockwork_Manager $manager */
         $manager = $managerMock->newInstance();
-        $manager->setServiceManager(CM_Service_Manager::getInstance());
         $manager->setStorage($storage);
         $manager->setTimeZone($timeZone);
         $_shouldRun = CMTest_TH::getProtectedMethod('CM_Clockwork_Manager', '_shouldRun');
@@ -380,7 +361,6 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $storage = $storageClass->newInstance();
         /** @var CM_Clockwork_Manager $manager */
         $manager = $managerMock->newInstance();
-        $manager->setServiceManager(CM_Service_Manager::getInstance());
         $manager->setStorage($storage);
         $manager->setTimeZone($timeZone);
         $_shouldRun = CMTest_TH::getProtectedMethod('CM_Clockwork_Manager', '_shouldRun');


### PR DESCRIPTION
Only storage systems that actually use the service manager should be ServiceManagerAware.

Previously, even when using storage system that don't use the serviceManager, setting storage with `$clockworkManager->setStorage($storage)` would throw an exception if `$clockworkManager` had no serviceManager set.