### PR TITLE
Track banner impressions and clicks with GA events

### DIFF
--- a/client-vendor/after-body/jquery.openx/jquery.openx.js
+++ b/client-vendor/after-body/jquery.openx/jquery.openx.js
@@ -15,6 +15,22 @@
     return parts.join('&');
   }
 
+  /**
+   * @param {String} category
+   * @param {String} action
+   * @param {String} label
+   */
+  function trackEvent(category, action, label) {
+    if (ga) {
+      ga('send', {
+        'hitType': 'event',
+        'eventCategory': category,
+        'eventAction': action,
+        'eventLabel': label,
+      });
+    }
+  }
+
   $.fn.openx = function() {
     return this.each(function() {
       var zoneId = $(this).data('zone-id');
@@ -54,10 +70,21 @@
       }
 
       var $element = $(this);
-      $.getJSON(src + '&callback=?', function(html) {
+
+      var loadCallback = function(html) {
         $element.html(html);
-        $element.trigger('openx-loaded', {hasContent: $.trim(html).length > 0});
-      });
+        var hasContent = $.trim(html).length > 0;
+        $element.trigger('openx-loaded', {hasContent: hasContent});
+
+        if (hasContent) {
+          trackEvent('Banner', 'Impression', 'zone-' + zoneId);
+          $element.find('a[href]').on('click', function() {
+            trackEvent('Banner', 'Click', 'zone-' + zoneId);
+          });
+        }
+      };
+
+      $.getJSON(src + '&callback=?', loadCallback);
     });
   };
 })(jQuery);


### PR DESCRIPTION
Depends on https://github.com/cargomedia/CM/pull/1613

This will allow us to continuously monitor ad impressions and CTR, and segment by device, geo, gender etc in GA.
(Click tracking will only work for image banners.)

Event parameters:
- **Category, Action, Label**
- 'Banner', 'Click', '[zone-id]'
- 'Banner', 'Click', '[zone-id]'

See:
- http://www.statstory.com/tracking-clicks-and-impressions-in-google-analytics/
- http://www.opensidedigital.com/how-track-outbound-links-google-analytics

cc @moby86 @j-dalrymple @fauvel 