### PR TITLE
Breaking: Change cm.window.title functionality.

### DIFF
--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -677,47 +677,7 @@ var CM_App = CM_Class_Abstract.extend({
       }
     },
 
-    title: {
-      _messageStop: function() {
-      },
-      _messageTimeout: null,
-
-      ready: function() {
-        var handler = this;
-        $(window).focus(function() {
-          handler._messageStop();
-        });
-      },
-
-      message: function(msg) {
-        if (cm.window.hasFocus()) {
-          return;
-        }
-        var handler = this;
-        var sleeper = function(offset) {
-          offset += 4;
-          if (offset >= msg.length) {
-            handler._messageStop();
-          } else {
-            document.title = msg.substring(offset, msg.length);
-            handler._messageTimeout = setTimeout(function() {
-              sleeper(offset);
-            }, 400);
-          }
-        };
-
-        this._messageStop();
-        var originalTitle = document.title;
-        document.title = msg;
-        this._messageTimeout = setTimeout(function() {
-          sleeper(0);
-        }, 1500);
-        this._messageStop = function() {
-          document.title = originalTitle;
-          clearTimeout(handler._messageTimeout);
-        };
-      }
-    }
+    title: ''
   },
 
   storage: {

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -614,7 +614,6 @@ var CM_App = CM_Class_Abstract.extend({
       }).blur(function() {
         handler._hasFocus = false;
       });
-      this.title.ready();
     },
 
     /**

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -683,7 +683,7 @@ var CM_App = CM_Class_Abstract.extend({
       _text: null,
 
       /**
-       * @param prefix
+       * @param {String|null} prefix
        */
       setPrefix: function(prefix) {
         this._prefix = prefix;
@@ -691,7 +691,7 @@ var CM_App = CM_Class_Abstract.extend({
       },
 
       /**
-       * @param text
+       * @param {String|null} text
        */
       setText: function(text) {
         this._text = text;

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -680,8 +680,8 @@ var CM_App = CM_Class_Abstract.extend({
     title: {
       /** @var {String|null} */
       _prefix: null,
-      /** @var {String|null} */
-      _text: null,
+      /** @var {String} */
+      _text: '',
 
       ready: function() {
         this.setText(document.title);
@@ -696,7 +696,7 @@ var CM_App = CM_Class_Abstract.extend({
       },
 
       /**
-       * @param {String|null} text
+       * @param {String} text
        */
       setText: function(text) {
         if (_.isString(text)) {

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -699,10 +699,8 @@ var CM_App = CM_Class_Abstract.extend({
        * @param {String} text
        */
       setText: function(text) {
-        if (_.isString(text)) {
-          this._text = text;
-          this._update();
-        }
+        this._text = text;
+        this._update();
       },
 
       _update: function() {

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -676,7 +676,32 @@ var CM_App = CM_Class_Abstract.extend({
       }
     },
 
-    title: ''
+    title: {
+      /** @var {String|null} */
+      _prefix: null,
+      /** @var {String|null} */
+      _text: null,
+
+      /**
+       * @param prefix
+       */
+      setPrefix: function(prefix) {
+        this._prefix = prefix;
+        this._update();
+      },
+
+      /**
+       * @param text
+       */
+      setText: function(text) {
+        this._text = text;
+        this._update();
+      },
+
+      _update: function() {
+        document.title = this._prefix ? this._prefix + ' ' : '' + this._text ? this._text : '';
+      }
+    }
   },
 
   storage: {

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -699,7 +699,14 @@ var CM_App = CM_Class_Abstract.extend({
       },
 
       _update: function() {
-        document.title = this._prefix ? this._prefix + ' ' : '' + this._text ? this._text : '';
+        var title = '';
+        if (this._prefix) {
+          title += this._prefix + ' ';
+        }
+        if (this._text) {
+          title += this._text;
+        }
+        document.title = title;
       }
     }
   },

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -614,7 +614,7 @@ var CM_App = CM_Class_Abstract.extend({
       }).blur(function() {
         handler._hasFocus = false;
       });
-      this.title.setText(document.title);
+      this.title.ready();
     },
 
     /**
@@ -683,6 +683,10 @@ var CM_App = CM_Class_Abstract.extend({
       /** @var {String|null} */
       _text: null,
 
+      ready: function() {
+        this.setText(document.title);
+      },
+
       /**
        * @param {String|null} prefix
        */
@@ -695,8 +699,10 @@ var CM_App = CM_Class_Abstract.extend({
        * @param {String|null} text
        */
       setText: function(text) {
-        this._text = text;
-        this._update();
+        if (_.isString(text)) {
+          this._text = text;
+          this._update();
+        }
       },
 
       _update: function() {

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -614,6 +614,7 @@ var CM_App = CM_Class_Abstract.extend({
       }).blur(function() {
         handler._hasFocus = false;
       });
+      this.title.setText(document.title);
     },
 
     /**

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -95,7 +95,7 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
    * @param {String} [jsTracking]
    */
   _onPageSetup: function(page, title, url, menuEntryHashList, jsTracking) {
-    cm.window.title = document.title = title;
+    cm.window.title.setText(title);
     $('[data-menu-entry-hash]').removeClass('active');
     var menuEntrySelectors = _.map(menuEntryHashList, function(menuEntryHash) {
       return '[data-menu-entry-hash=' + menuEntryHash + ']';

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -95,7 +95,7 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
    * @param {String} [jsTracking]
    */
   _onPageSetup: function(page, title, url, menuEntryHashList, jsTracking) {
-    document.title = title;
+    cm.window.title = document.title = title;
     $('[data-menu-entry-hash]').removeClass('active');
     var menuEntrySelectors = _.map(menuEntryHashList, function(menuEntryHash) {
       return '[data-menu-entry-hash=' + menuEntryHash + ']';


### PR DESCRIPTION
Remove Chat notification. Keep it for saving the original title of the current page.

> For changing the window's title we have cm.window.title - at the moment it's used to scroll a message "New chat message from " through the title.
I would suggest to remove this feature in favor of showing the counter.