### PR TITLE
mongodb increase batchSize to an arbitrary, high number

### DIFF
--- a/library/CM/MongoDb/Client.php
+++ b/library/CM/MongoDb/Client.php
@@ -1,6 +1,6 @@
 <?php
 
-class CM_MongoDb_Client {
+class CM_MongoDb_Client extends CM_Class_Abstract {
 
     /** @var CM_MongoDb_Client|null $_client */
     private $_client = null;
@@ -147,6 +147,9 @@ class CM_MongoDb_Client {
             $resultCursor = $collection->aggregateCursor($pipeline);
         } else {
             $resultCursor = $collection->find($criteria, $projection);
+        }
+        if (isset(self::_getConfig()->batchSize)) {
+            $resultCursor->batchSize((int) self::_getConfig()->batchSize);
         }
         return $resultCursor;
     }

--- a/library/CM/PagingSource/MongoDb.php
+++ b/library/CM/PagingSource/MongoDb.php
@@ -73,6 +73,7 @@ class CM_PagingSource_MongoDb extends CM_PagingSource_Abstract {
                 }
             }
             $cursor = $mongoDb->find($this->_collection, $this->_criteria, $this->_projection, $aggregation);
+            $cursor->batchSize(100000000);
             if (null === $this->_aggregation) {
                 /** @var MongoCursor $cursor */
                 if (null !== $this->_sort) {

--- a/library/CM/PagingSource/MongoDb.php
+++ b/library/CM/PagingSource/MongoDb.php
@@ -73,7 +73,6 @@ class CM_PagingSource_MongoDb extends CM_PagingSource_Abstract {
                 }
             }
             $cursor = $mongoDb->find($this->_collection, $this->_criteria, $this->_projection, $aggregation);
-            $cursor->batchSize(100000000);
             if (null === $this->_aggregation) {
                 /** @var MongoCursor $cursor */
                 if (null !== $this->_sort) {

--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -46,6 +46,8 @@ return function (CM_Config_Node $config) {
 
     $config->CM_Db_Db->delayedEnabled = true;
 
+    $config->CM_MongoDb_Client->batchSize = null;
+
     $config->CM_Model_User->class = 'CM_Model_User';
 
     $config->CM_Params->class = 'CM_Params';

--- a/tests/library/CM/MongoDb/ClientTest.php
+++ b/tests/library/CM/MongoDb/ClientTest.php
@@ -146,6 +146,26 @@ class CM_MongoDb_ClientTest extends CMTest_TestCase {
         $this->assertEquals([['foo' => 1], ['foo' => 1], ['foo' => 2], ['foo' => 3]], $actual);
     }
 
+    public function testFindBatchSize() {
+        $mongoDb = CM_Service_Manager::getInstance()->getMongoDb();
+        $collectionName = 'findBatchSize';
+        CM_Config::get()->CM_MongoDb_Client->batchSize = null;
+
+        $cursor = $mongoDb->find($collectionName);
+        $this->assertSame(0, $cursor->info()['batchSize']);
+        $cursor = $mongoDb->find($collectionName, null, null, ['$match' => ['foo' => 'bar']]);
+        $this->assertSame(0, $cursor->info()['batchSize']);
+        $this->assertSame(101, $cursor->info()['query']['cursor']['batchSize']);
+
+        CM_Config::get()->CM_MongoDb_Client->batchSize = 10;
+
+        $cursor = $mongoDb->find($collectionName);
+        $this->assertSame(10, $cursor->info()['batchSize']);
+        $cursor = $mongoDb->find($collectionName, null, null, ['$match' => ['foo' => 'bar']]);
+        $this->assertSame(10, $cursor->info()['batchSize']);
+        $this->assertSame(10, $cursor->info()['query']['cursor']['batchSize']);
+    }
+
     public function testFindAndModify() {
         $mongoDb = CM_Service_Manager::getInstance()->getMongoDb();
         $collectionName = 'findAndModify';


### PR DESCRIPTION
Should help us identify slow queries, as only the initial fetch-operation contains the necessary information.