### PR TITLE
include aggregation in cachekey-base for CM_PagingSource_MongoDb

### DIFF
--- a/library/CM/PagingSource/MongoDb.php
+++ b/library/CM/PagingSource/MongoDb.php
@@ -95,7 +95,7 @@ class CM_PagingSource_MongoDb extends CM_PagingSource_Abstract {
     }
 
     protected function _cacheKeyBase() {
-        return array($this->_collection, $this->_criteria, $this->_projection);
+        return array($this->_collection, $this->_criteria, $this->_projection, $this->_aggregation);
     }
 
     public function getStalenessChance() {


### PR DESCRIPTION
Was overlooked when I incorporated aggregations into our mongodb code. 
With the current implementation, pagings using the same collection, criteria and projection but different aggregation would experience cacheKey conflicts.