### PR TITLE
unittests: only generate internals if necessary

### DIFF
--- a/tests/helpers/CMTest/library/CMTest/TestSuite.php
+++ b/tests/helpers/CMTest/library/CMTest/TestSuite.php
@@ -15,6 +15,9 @@ class CMTest_TestSuite {
     }
 
     public function generateInternalConfig() {
+        if (isset(CM_Config::get()->CM_Class_Abstract->typesMaxValue)) {
+            return;
+        }
         $generator = new CM_Config_Generator();
         $config = new CM_Config_Node();
         $config->extendWithConfig($generator->getConfigClassTypes());


### PR DESCRIPTION
Only generate internals if they aren't already defined.
Derived codebases should have their internals predefined anyway, not needing to autogenerate them for tests, which can take a long time. 