### PR TITLE
openx.js: Add event "Impression-Clickable"

### DIFF
--- a/client-vendor/after-body/jquery.openx/jquery.openx.js
+++ b/client-vendor/after-body/jquery.openx/jquery.openx.js
@@ -78,6 +78,9 @@
 
         if (hasContent) {
           trackEvent('Banner', 'Impression', 'zone-' + zoneId);
+          if ($element.is(':visible') && $element.find('a[href]').length > 0) {
+            trackEvent('Banner', 'Impression-Clickable', 'zone-' + zoneId);
+          }
           $element.find('a[href]').on('click', function() {
             trackEvent('Banner', 'Click', 'zone-' + zoneId);
           });

--- a/client-vendor/after-body/jquery.openx/jquery.openx.js
+++ b/client-vendor/after-body/jquery.openx/jquery.openx.js
@@ -81,10 +81,10 @@
           var $link = $element.find('a[href]');
           if ($element.is(':visible') && $link.length > 0) {
             trackEvent('Banner', 'Impression-Clickable', 'zone-' + zoneId);
+            $link.on('click', function() {
+              trackEvent('Banner', 'Click', 'zone-' + zoneId);
+            });
           }
-          $link.on('click', function() {
-            trackEvent('Banner', 'Click', 'zone-' + zoneId);
-          });
         }
       };
 

--- a/client-vendor/after-body/jquery.openx/jquery.openx.js
+++ b/client-vendor/after-body/jquery.openx/jquery.openx.js
@@ -78,10 +78,11 @@
 
         if (hasContent) {
           trackEvent('Banner', 'Impression', 'zone-' + zoneId);
-          if ($element.is(':visible') && $element.find('a[href]').length > 0) {
+          var $link = $element.find('a[href]');
+          if ($element.is(':visible') && $link.length > 0) {
             trackEvent('Banner', 'Impression-Clickable', 'zone-' + zoneId);
           }
-          $element.find('a[href]').on('click', function() {
+          $link.on('click', function() {
             trackEvent('Banner', 'Click', 'zone-' + zoneId);
           });
         }


### PR DESCRIPTION
Could you add to `jquery.openx.js` another event `Impression-Clickable` which should be triggered whenever a new banner is loaded and displayed, for which we can track a `Click`. So if it contains an `a[href]`?