### PR TITLE
do not test query-batchSize when using default batchSize

### DIFF
--- a/tests/library/CM/MongoDb/ClientTest.php
+++ b/tests/library/CM/MongoDb/ClientTest.php
@@ -155,7 +155,6 @@ class CM_MongoDb_ClientTest extends CMTest_TestCase {
         $this->assertSame(0, $cursor->info()['batchSize']);
         $cursor = $mongoDb->find($collectionName, null, null, ['$match' => ['foo' => 'bar']]);
         $this->assertSame(0, $cursor->info()['batchSize']);
-        $this->assertSame(101, $cursor->info()['query']['cursor']['batchSize']);
 
         CM_Config::get()->CM_MongoDb_Client->batchSize = 10;
 


### PR DESCRIPTION
Fixes `PHP Fatal error:  Cannot use object of type stdClass as array in /home/travis/build/alexispeter/CM/tests/library/CM/MongoDb/ClientTest.php on line 158` occurring on boxes running  mongodb driver v1.6.x