### PR TITLE
Mark all exceptions in http-request constructor as WARN

### DIFF
--- a/library/CM/Http/Handler.php
+++ b/library/CM/Http/Handler.php
@@ -13,10 +13,16 @@ class CM_Http_Handler implements CM_Service_ManagerAwareInterface {
 
     /**
      * @param CM_Http_Request_Abstract $request
+     * @throws CM_Exception
      * @return CM_Http_Response_Abstract
      */
     public function processRequest(CM_Http_Request_Abstract $request) {
-        $response = CM_Http_Response_Abstract::factory($request, $this->getServiceManager());
+        try {
+            $response = CM_Http_Response_Abstract::factory($request, $this->getServiceManager());
+        } catch (CM_Exception $e) {
+            $e->setSeverity(CM_Exception::WARN);
+            throw $e;
+        }
         $response->process();
         return $response;
     }

--- a/tests/library/CM/Http/HandlerTest.php
+++ b/tests/library/CM/Http/HandlerTest.php
@@ -1,0 +1,16 @@
+<?php
+
+class CM_Http_HandlerTest extends CMTest_TestCase {
+
+    public function testProcessRequestThrows() {
+        $request = new CM_Http_Request_Get('/library-css/nonexistent');
+        $handler = new CM_Http_Handler($this->getServiceManager());
+
+        try {
+            $handler->processRequest($request);
+            $this->fail('Expected to throw');
+        } catch (CM_Exception $e) {
+            $this->assertSame(CM_Exception::WARN, $e->getSeverity());
+        }
+    }
+}


### PR DESCRIPTION
@tomaszdurka @dlondero please review

There's no simple way to mock the response (because of static methods), so I'm using an actual resource-response.