### PR TITLE
Enhance CM_Jobdistribution_Job_Abstract::_runMultipleWithoutGearman()

### DIFF
--- a/library/CM/Jobdistribution/Job/Abstract.php
+++ b/library/CM/Jobdistribution/Job/Abstract.php
@@ -123,8 +123,7 @@ abstract class CM_Jobdistribution_Job_Abstract extends CM_Class_Abstract {
     protected function _runMultipleWithoutGearman(array $paramsList) {
         $resultList = array();
         foreach ($paramsList as $params) {
-            $params = $this->_encodeParams($params);
-            $params = $this->_decodeParams($params);
+            $params = $this->_decodeParams($this->_encodeParams($params));
             $resultList[] = $this->_executeJob($params);
         }
         return $resultList;

--- a/library/CM/Jobdistribution/Job/Abstract.php
+++ b/library/CM/Jobdistribution/Job/Abstract.php
@@ -61,7 +61,7 @@ abstract class CM_Jobdistribution_Job_Abstract extends CM_Class_Abstract {
         });
 
         foreach ($paramsList as $params) {
-            $workload = CM_Params::encode($params, true);
+            $workload = $this->_encodeParams($params);
             $task = $gearmanClient->addTask($this->_getJobName(), $workload);
             if (false === $task) {
                 throw new CM_Exception('Cannot add task `' . $this->_getJobName() . '`.');
@@ -87,7 +87,7 @@ abstract class CM_Jobdistribution_Job_Abstract extends CM_Class_Abstract {
             return;
         }
 
-        $workload = CM_Params::encode($params, true);
+        $workload = $this->_encodeParams($params);
         $gearmanClient = $this->_getGearmanClient();
         $gearmanClient->doBackground($this->_getJobName(), $workload);
     }
@@ -100,13 +100,13 @@ abstract class CM_Jobdistribution_Job_Abstract extends CM_Class_Abstract {
     public function __executeGearman(GearmanJob $job) {
         $workload = $job->workload();
         try {
-            $params = CM_Params::factory(CM_Params::jsonDecode($workload), true);
+            $params = $this->_decodeParams($workload);
         } catch (CM_Exception_Nonexistent $ex) {
             throw new CM_Exception_Nonexistent(
                 'Cannot decode workload for Job `' . get_class($this) . '`: Original exception message `' . $ex->getMessage() .
                 '`', null, null, CM_Exception::WARN);
         }
-        return CM_Params::encode($this->_executeJob($params), true);
+        return $this->_encodeParams($this->_executeJob($params));
     }
 
     /**
@@ -123,7 +123,9 @@ abstract class CM_Jobdistribution_Job_Abstract extends CM_Class_Abstract {
     protected function _runMultipleWithoutGearman(array $paramsList) {
         $resultList = array();
         foreach ($paramsList as $params) {
-            $resultList[] = $this->_executeJob(CM_Params::factory($params, true));
+            $params = $this->_encodeParams($params);
+            $params = $this->_decodeParams($params);
+            $resultList[] = $this->_executeJob($params);
         }
         return $resultList;
     }
@@ -149,5 +151,22 @@ abstract class CM_Jobdistribution_Job_Abstract extends CM_Class_Abstract {
             $gearmanClient->addServer($server['host'], $server['port']);
         }
         return $gearmanClient;
+    }
+
+    /**
+     * @param array $params
+     * @return string
+     */
+    protected function _encodeParams($params) {
+        return CM_Params::encode($params, true);
+    }
+
+    /**
+     * @param string $params
+     * @return CM_Params
+     * @throws CM_Exception_Invalid
+     */
+    protected function _decodeParams($params) {
+        return CM_Params::factory(CM_Params::jsonDecode($params), true);
     }
 }

--- a/tests/library/CM/Jobdistribution/Job/AbstractTest.php
+++ b/tests/library/CM/Jobdistribution/Job/AbstractTest.php
@@ -122,18 +122,14 @@ class CM_Jobdistribution_Job_AbstractTest extends CMTest_TestCase {
         }
     }
 
-    public function testRunGearmanDisabledWithNotSerializableObject() {
+    public function testRunGearmanDisabledEncodesObjects() {
         CM_Config::get()->CM_Jobdistribution_Job_Abstract->gearmanEnabled = false;
-
         $foo = new stdClass();
-        $foo->closure = function() {
-            echo 'bar';
-        };
 
         $job = $this->getMockForAbstractClass('CM_Jobdistribution_Job_Abstract', array(), '', true, true, true, array('_execute'));
-        $job->expects($this->exactly(1))->method('_execute')->with($this->callback(function (CM_Params $params) use ($foo) {
+        $job->expects($this->exactly(1))->method('_execute')->with($this->callback(function (CM_Params $params) {
             $fooParam = $params->get('foo');
-            if ($fooParam['closure'] === $foo->closure) {
+            if ($fooParam instanceof stdClass) {
                 return false;
             }
             return true;

--- a/tests/library/CM/Jobdistribution/Job/AbstractTest.php
+++ b/tests/library/CM/Jobdistribution/Job/AbstractTest.php
@@ -126,16 +126,14 @@ class CM_Jobdistribution_Job_AbstractTest extends CMTest_TestCase {
         CM_Config::get()->CM_Jobdistribution_Job_Abstract->gearmanEnabled = false;
         $foo = new stdClass();
 
-        $job = $this->getMockForAbstractClass('CM_Jobdistribution_Job_Abstract', array(), '', true, true, true, array('_execute'));
-        $job->expects($this->exactly(1))->method('_execute')->with($this->callback(function (CM_Params $params) {
-            $fooParam = $params->get('foo');
-            if ($fooParam instanceof stdClass) {
-                return false;
-            }
-            return true;
-        }));
+        $job = $this->mockObject('CM_Jobdistribution_Job_Abstract');
+        $executeMethod = $job->mockMethod('_execute')->set(function (CM_Params $params) {
+            $this->assertNotInstanceOf('stdClass', $params->get('foo'));
+        });
 
         /** @var CM_Jobdistribution_Job_Abstract $job */
         $job->queue(array('foo' => $foo));
+
+        $this->assertSame(1, $executeMethod->getCallCount());
     }
 }


### PR DESCRIPTION
It should behave in the same way in tests and when running real code.

```php
$params = CM_Params::encode($params, true);
$params = CM_Params::factory(CM_Params::jsonDecode($params), true);
```

Maybe also introduce `CM_Jobdistribution_Job_Abstract::encodeParams()` and `CM_Jobdistribution_Job_Abstract::decodeParams()` to avoid duplication.