### PR TITLE
Splittest::_getVariationFixture has wrong variations cached

### DIFF
--- a/library/CM/CacheConst.php
+++ b/library/CM/CacheConst.php
@@ -39,7 +39,7 @@ class CM_CacheConst {
     // _splitfeatureId:X_userId:X
     const SplitFeature_Fixtures = 'SplitFeature_Fixtures';
 
-    // _id:X_type:X_splittestCreated:X
+    // _id:X_type:X
     const Splittest_VariationFixtures = 'Splittest_VariationFixtures';
 
     // _id:X

--- a/library/CM/CacheConst.php
+++ b/library/CM/CacheConst.php
@@ -39,7 +39,7 @@ class CM_CacheConst {
     // _splitfeatureId:X_userId:X
     const SplitFeature_Fixtures = 'SplitFeature_Fixtures';
 
-    // _id:X_type:X
+    // _id:X_type:X_splittestCreated:X
     const Splittest_VariationFixtures = 'Splittest_VariationFixtures';
 
     // _id:X

--- a/library/CM/Model/Splittest.php
+++ b/library/CM/Model/Splittest.php
@@ -182,6 +182,15 @@ class CM_Model_Splittest extends CM_Model_Abstract implements CM_Service_Manager
 
     /**
      * @param CM_Splittest_Fixture $fixture
+     * @return string
+     */
+    protected function _getCacheKeyFixture(CM_Splittest_Fixture $fixture) {
+        return CM_CacheConst::Splittest_VariationFixtures . '_id:' . $fixture->getId() . '_type:' . $fixture->getFixtureType()
+        . '_splittestCreated:' . $this->getCreated();
+    }
+
+    /**
+     * @param CM_Splittest_Fixture $fixture
      * @param float|null           $weight
      * @throws CM_Exception_Invalid
      */
@@ -229,7 +238,7 @@ class CM_Model_Splittest extends CM_Model_Abstract implements CM_Service_Manager
                 CM_Db_Db::insert('cm_splittestVariation_fixture',
                     array('splittestId' => $this->getId(), $columnId => $fixtureId, 'variationId' => $variation->getId(), 'createStamp' => time()));
                 $variationListFixture[$this->getId()] = $variation->getName();
-                $cacheKey = CM_CacheConst::Splittest_VariationFixtures . '_id:' . $fixture->getId() . '_type:' . $fixture->getFixtureType();
+                $cacheKey = $this->_getCacheKeyFixture($fixture);
                 $cache = CM_Cache_Local::getInstance();
                 $cache->set($cacheKey, $variationListFixture);
                 $this->getServiceManager()->getTrackings()->trackSplittest($fixture, $variation);
@@ -255,7 +264,7 @@ class CM_Model_Splittest extends CM_Model_Abstract implements CM_Service_Manager
         $fixtureId = $fixture->getId();
         $updateCache = (bool) $updateCache;
 
-        $cacheKey = CM_CacheConst::Splittest_VariationFixtures . '_id:' . $fixture->getId() . '_type:' . $fixture->getFixtureType();
+        $cacheKey = $this->_getCacheKeyFixture($fixture);
         $cache = CM_Cache_Local::getInstance();
         if ($updateCache || (($variationListFixture = $cache->get($cacheKey)) === false)) {
             $variationListFixture = CM_Db_Db::exec('


### PR DESCRIPTION
As seen in a recent splittest.
Similar problem was solved here: https://github.com/cargomedia/CM/pull/1450

This is APC-cached, so difficult to debug in production. Restarting the webservers flushed the caches, and the variation was assigned correctly.

The splittest was flushed before the wrong assignment. Maybe due to the flushing the old variation was still assigned?

cc @NicolasSchmutz 