### PR TITLE
Make Tracking::getTrackings() public

### DIFF
--- a/library/CM/Service/Trackings.php
+++ b/library/CM/Service/Trackings.php
@@ -14,7 +14,7 @@ class CM_Service_Trackings extends CM_Service_ManagerAware implements CM_Service
 
     public function getHtml(CM_Frontend_Environment $environment) {
         $html = '';
-        foreach ($this->_getTrackingServiceList() as $trackingService) {
+        foreach ($this->getTrackingServiceList() as $trackingService) {
             $html .= $trackingService->getHtml($environment);
         }
         return $html;
@@ -22,32 +22,32 @@ class CM_Service_Trackings extends CM_Service_ManagerAware implements CM_Service
 
     public function getJs() {
         $js = '';
-        foreach ($this->_getTrackingServiceList() as $trackingService) {
+        foreach ($this->getTrackingServiceList() as $trackingService) {
             $js .= $trackingService->getJs();
         }
         return $js;
     }
 
     public function trackAction(CM_Action_Abstract $action) {
-        foreach ($this->_getTrackingServiceList() as $trackingService) {
+        foreach ($this->getTrackingServiceList() as $trackingService) {
             $trackingService->trackAction($action);
         }
     }
 
     public function trackAffiliate($requestClientId, $affiliateName) {
-        foreach ($this->_getTrackingServiceList() as $trackingService) {
+        foreach ($this->getTrackingServiceList() as $trackingService) {
             $trackingService->trackAffiliate($requestClientId, $affiliateName);
         }
     }
 
     public function trackPageView(CM_Frontend_Environment $environment, $path) {
-        foreach ($this->_getTrackingServiceList() as $trackingService) {
+        foreach ($this->getTrackingServiceList() as $trackingService) {
             $trackingService->trackPageView($environment, $path);
         }
     }
 
     public function trackSplittest(CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation) {
-        foreach ($this->_getTrackingServiceList() as $trackingService) {
+        foreach ($this->getTrackingServiceList() as $trackingService) {
             $trackingService->trackSplittest($fixture, $variation);
         }
     }
@@ -55,7 +55,7 @@ class CM_Service_Trackings extends CM_Service_ManagerAware implements CM_Service
     /**
      * @return CM_Service_Tracking_ClientInterface[]
      */
-    protected function _getTrackingServiceList() {
+    public function getTrackingServiceList() {
         return array_map(function ($trackingServiceName) {
             return $this->getServiceManager()->get($trackingServiceName, 'CM_Service_Tracking_ClientInterface');
         }, $this->_trackingServiceNameList);

--- a/library/CMService/GoogleAnalytics/MeasurementProtocol/Client.php
+++ b/library/CMService/GoogleAnalytics/MeasurementProtocol/Client.php
@@ -42,6 +42,13 @@ class CMService_GoogleAnalytics_MeasurementProtocol_Client {
     }
 
     /**
+     * @return string
+     */
+    public function getRandomClientId() {
+        return rand() . uniqid();
+    }
+
+    /**
      * @param array $parameterList
      */
     public function _submitHit(array $parameterList) {

--- a/tests/library/CMService/GoogleAnalytics/MeasurementProtocol/ClientTest.php
+++ b/tests/library/CMService/GoogleAnalytics/MeasurementProtocol/ClientTest.php
@@ -68,4 +68,12 @@ class CMService_GoogleAnalytics_MeasurementProtocol_ClientTest extends CMTest_Te
             'exd' => 'My exception',
         ]);
     }
+
+    public function testGetRandomClientId() {
+        $client = new CMService_GoogleAnalytics_MeasurementProtocol_Client('foo');
+
+        $this->assertInternalType('string', $client->getRandomClientId());
+        $this->assertGreaterThan(5, strlen($client->getRandomClientId()));
+        $this->assertNotEquals($client->getRandomClientId(), $client->getRandomClientId());
+    }
 }


### PR DESCRIPTION
@fauvel please review

I added `CMService_GoogleAnalytics_MeasurementProtocol_Client::getRandomClientId()` so we can wrap this logic here?