### PR TITLE
Streamline exception catching in Http Responses

### DIFF
--- a/library/CM/Http/Response/Abstract.php
+++ b/library/CM/Http/Response/Abstract.php
@@ -231,15 +231,21 @@ abstract class CM_Http_Response_Abstract extends CM_Class_Abstract implements CM
     /**
      * @param callable $regularCode
      * @param callable $errorCode
-     * @return mixed|null
+     * @return mixed
+     * @throws CM_Exception
      */
     protected function _runWithCatching(Closure $regularCode, Closure $errorCode) {
         try {
             return $regularCode();
         } catch(CM_Exception $ex) {
             $exceptionClass = get_class($ex);
-            $exceptionsToCatch = self::_getConfig()->exceptionsToCatch;
+            $config = self::_getConfig();
+            $exceptionsToCatch = $config->exceptionsToCatch;
+            $catchPublicExceptions = !empty($config->catchPublicExceptions);
+            $catchException = false;
+            $errorOptions = [];
             if (array_key_exists($exceptionClass, $exceptionsToCatch)) {
+                $catchException = true;
                 $errorOptions = $exceptionsToCatch[$exceptionClass];
                 if (isset($errorOptions['log'])) {
                     $formatter = new CM_ExceptionHandling_Formatter_Plain_Log();
@@ -247,9 +253,14 @@ abstract class CM_Http_Response_Abstract extends CM_Class_Abstract implements CM
                     $log = new $errorOptions['log']();
                     $log->add($formatter->formatException($ex), $ex->getMetaInfo());
                 }
+            }
+            if ($catchPublicExceptions && $ex->isPublic()) {
+                $catchException = true;
+            }
+            if ($catchException) {
                 return $errorCode($ex, $errorOptions);
             }
-            return null;
+            throw $ex;
         }
     }
 

--- a/library/CM/Http/Response/Page.php
+++ b/library/CM/Http/Response/Page.php
@@ -156,8 +156,8 @@ class CM_Http_Response_Page extends CM_Http_Response_Abstract {
         }, function (CM_Exception $ex, array $errorOptions) use ($request) {
             $this->getRender()->getGlobalResponse()->clear();
             /** @var CM_Page_Abstract $errorPage */
-            $errorPage =  new $errorOptions['errorPage']();
-            $request->setPath($errorPage->getPath());
+            $errorPage =  $errorOptions['errorPage'];
+            $request->setPath($errorPage::getPath());
             $request->setQuery(array());
             return false;
         });

--- a/library/CM/Http/Response/Page.php
+++ b/library/CM/Http/Response/Page.php
@@ -132,7 +132,7 @@ class CM_Http_Response_Page extends CM_Http_Response_Abstract {
      * @return string|null|boolean
      */
     private function _processPage(CM_Http_Request_Abstract $request) {
-        try {
+        return $this->_runWithCatching(function () use ($request) {
             $this->getSite()->rewrite($request);
             $pageParams = CM_Params::factory($request->getQuery(), true);
 
@@ -153,23 +153,13 @@ class CM_Http_Response_Page extends CM_Http_Response_Abstract {
             $this->_page = $page;
             $this->_pageParams = $pageParams;
             return $html;
-        } catch (CM_Exception $e) {
-            $exceptionClass = get_class($e);
-            $configCatch = $this->_getConfig()->catch;
-            if (!array_key_exists($exceptionClass, $configCatch)) {
-                throw $e;
-            } else {
-                $options = $configCatch[$exceptionClass];
-                $this->getRender()->getGlobalResponse()->clear();
-                $request->setPath($options['path']);
-                $request->setQuery(array());
-                if (true === $options['log']) {
-                    $formatter = new CM_ExceptionHandling_Formatter_Plain_Log();
-                    $log = new CM_Paging_Log_NotFound();
-                    $log->add($formatter->formatException($e), $e->getMetaInfo());
-                }
-            }
-        }
-        return false;
+        }, function (CM_Exception $ex, array $errorOptions) use ($request) {
+            $this->getRender()->getGlobalResponse()->clear();
+            /** @var CM_Page_Abstract $errorPage */
+            $errorPage =  new $errorOptions['errorPage']();
+            $request->setPath($errorPage->getPath());
+            $request->setQuery(array());
+            return false;
+        });
     }
 }

--- a/library/CM/Http/Response/RPC.php
+++ b/library/CM/Http/Response/RPC.php
@@ -4,7 +4,7 @@ class CM_Http_Response_RPC extends CM_Http_Response_Abstract {
 
     protected function _process() {
         $output = array();
-        try {
+        $this->_runWithCatching(function () use (&$output) {
             $query = $this->_request->getQuery();
             if (!isset($query['method']) || 1 != substr_count($query['method'], '.') || !preg_match('/^[\w_\.]+$/i', $query['method'])) {
                 throw new CM_Exception_Invalid('Illegal method: `' . $query['method'] . '`', null, array('severity' => CM_Exception::WARN));
@@ -15,12 +15,9 @@ class CM_Http_Response_RPC extends CM_Http_Response_Abstract {
             $params = $query['params'];
             list($class, $function) = explode('.', $query['method']);
             $output['success'] = array('result' => call_user_func_array(array($class, 'rpc_' . $function), $params));
-        } catch (CM_Exception $e) {
-            if (!($e->isPublic() || in_array(get_class($e), self::_getConfig()->catch))) {
-                throw $e;
-            }
+        }, function (CM_Exception $e) use (&$output) {
             $output['error'] = array('type' => get_class($e), 'msg' => $e->getMessagePublic($this->getRender()), 'isPublic' => $e->isPublic());
-        }
+        });
 
         $this->setHeader('Content-Type', 'application/json');
         $this->_setContent(json_encode($output));

--- a/library/CM/Http/Response/View/Ajax.php
+++ b/library/CM/Http/Response/View/Ajax.php
@@ -2,52 +2,42 @@
 
 class CM_Http_Response_View_Ajax extends CM_Http_Response_View_Abstract {
 
-    protected function _process() {
-        $output = array();
-        try {
-            $success = array();
-            $query = $this->_request->getQuery();
-            if (!isset($query['method'])) {
-                throw new CM_Exception_Invalid('No method specified', null, array('severity' => CM_Exception::WARN));
-            }
-            if (!preg_match('/^[\w_]+$/i', $query['method'])) {
-                throw new CM_Exception_Invalid('Illegal method: `' . $query['method'] . '`', null, array('severity' => CM_Exception::WARN));
-            }
-            if (!isset($query['params']) || !is_array($query['params'])) {
-                throw new CM_Exception_Invalid('Illegal params', null, array('severity' => CM_Exception::WARN));
-            }
-
-            $view = $this->_getView();
-            if ($view instanceof CM_View_CheckAccessibleInterface) {
-                $view->checkAccessible($this->getRender()->getEnvironment());
-            }
-
-            $ajaxMethodName = 'ajax_' . $query['method'];
-            $params = CM_Params::factory($query['params'], true);
-
-            $componentHandler = new CM_Frontend_JavascriptContainer_View();
-
-            $this->_setStringRepresentation(get_class($view) . '::' . $ajaxMethodName);
-            $data = $view->$ajaxMethodName($params, $componentHandler, $this);
-            $success['data'] = CM_Params::encode($data);
-
-            $frontend = $this->getRender()->getGlobalResponse();
-            $frontend->getOnloadReadyJs()->append($componentHandler->compile('this'));
-            $jsCode = $frontend->getJs();
-
-            if (strlen($jsCode)) {
-                $success['exec'] = $jsCode;
-            }
-            $output['success'] = $success;
-        } catch (CM_Exception $e) {
-            if (!($e->isPublic() || in_array(get_class($e), self::_getConfig()->catch))) {
-                throw $e;
-            }
-            $output['error'] = array('type' => get_class($e), 'msg' => $e->getMessagePublic($this->getRender()), 'isPublic' => $e->isPublic());
+    protected function _processView(array $output) {
+        $success = array();
+        $query = $this->_request->getQuery();
+        if (!isset($query['method'])) {
+            throw new CM_Exception_Invalid('No method specified', null, array('severity' => CM_Exception::WARN));
+        }
+        if (!preg_match('/^[\w_]+$/i', $query['method'])) {
+            throw new CM_Exception_Invalid('Illegal method: `' . $query['method'] . '`', null, array('severity' => CM_Exception::WARN));
+        }
+        if (!isset($query['params']) || !is_array($query['params'])) {
+            throw new CM_Exception_Invalid('Illegal params', null, array('severity' => CM_Exception::WARN));
         }
 
-        $this->setHeader('Content-Type', 'application/json');
-        $this->_setContent(json_encode($output));
+        $view = $this->_getView();
+        if ($view instanceof CM_View_CheckAccessibleInterface) {
+            $view->checkAccessible($this->getRender()->getEnvironment());
+        }
+
+        $ajaxMethodName = 'ajax_' . $query['method'];
+        $params = CM_Params::factory($query['params'], true);
+
+        $componentHandler = new CM_Frontend_JavascriptContainer_View();
+
+        $this->_setStringRepresentation(get_class($view) . '::' . $ajaxMethodName);
+        $data = $view->$ajaxMethodName($params, $componentHandler, $this);
+        $success['data'] = CM_Params::encode($data);
+
+        $frontend = $this->getRender()->getGlobalResponse();
+        $frontend->getOnloadReadyJs()->append($componentHandler->compile('this'));
+        $jsCode = $frontend->getJs();
+
+        if (strlen($jsCode)) {
+            $success['exec'] = $jsCode;
+        }
+        $output['success'] = $success;
+        return $output;
     }
 
     public static function match(CM_Http_Request_Abstract $request) {

--- a/library/CM/Http/Response/View/Form.php
+++ b/library/CM/Http/Response/View/Form.php
@@ -38,45 +38,35 @@ class CM_Http_Response_View_Form extends CM_Http_Response_View_Abstract {
         return (bool) count($this->errors);
     }
 
-    protected function _process() {
-        $output = array();
-        try {
-            $success = array();
-            $form = $this->_getView();
-            $className = get_class($form);
-            if (!$form instanceof CM_Form_Abstract) {
-                throw new CM_Exception_Invalid('`' . $className . '`is not `CM_Form_Abstract` instance');
-            }
-
-            $query = $this->_request->getQuery();
-            $actionName = (string) $query['actionName'];
-            $data = (array) $query['data'];
-
-            $this->_setStringRepresentation($className . '::' . $actionName);
-            $success['data'] = CM_Params::encode($form->process($data, $actionName, $this));
-
-            if (!empty($this->errors)) {
-                $success['errors'] = $this->errors;
-            }
-
-            $jsCode = $this->getRender()->getGlobalResponse()->getJs();
-            if (!empty($jsCode)) {
-                $success['exec'] = $jsCode;
-            }
-
-            if (!empty($this->messages)) {
-                $success['messages'] = $this->messages;
-            }
-            $output['success'] = $success;
-        } catch (CM_Exception $e) {
-            if (!($e->isPublic() || in_array(get_class($e), self::_getConfig()->catch))) {
-                throw $e;
-            }
-            $output['error'] = array('type' => get_class($e), 'msg' => $e->getMessagePublic($this->getRender()), 'isPublic' => $e->isPublic());
+    protected function _processView(array $output) {
+        $success = array();
+        $form = $this->_getView();
+        $className = get_class($form);
+        if (!$form instanceof CM_Form_Abstract) {
+            throw new CM_Exception_Invalid('`' . $className . '`is not `CM_Form_Abstract` instance');
         }
 
-        $this->setHeader('Content-Type', 'application/json');
-        $this->_setContent(json_encode($output));
+        $query = $this->_request->getQuery();
+        $actionName = (string) $query['actionName'];
+        $data = (array) $query['data'];
+
+        $this->_setStringRepresentation($className . '::' . $actionName);
+        $success['data'] = CM_Params::encode($form->process($data, $actionName, $this));
+
+        if (!empty($this->errors)) {
+            $success['errors'] = $this->errors;
+        }
+
+        $jsCode = $this->getRender()->getGlobalResponse()->getJs();
+        if (!empty($jsCode)) {
+            $success['exec'] = $jsCode;
+        }
+
+        if (!empty($this->messages)) {
+            $success['messages'] = $this->messages;
+        }
+        $output['success'] = $success;
+        return $output;
     }
 
     public static function match(CM_Http_Request_Abstract $request) {

--- a/library/CM/Mail.php
+++ b/library/CM/Mail.php
@@ -415,6 +415,6 @@ class CM_Mail extends CM_View_Abstract implements CM_Typed {
         $msg = '* ' . $subject . ' *' . PHP_EOL . PHP_EOL;
         $msg .= $text . PHP_EOL;
         $log = new CM_Paging_Log_Mail();
-        $log->add($this, $msg);
+        $log->addMail($this, $msg);
     }
 }

--- a/library/CM/Paging/Log/Abstract.php
+++ b/library/CM/Paging/Log/Abstract.php
@@ -3,6 +3,15 @@
 abstract class CM_Paging_Log_Abstract extends CM_Paging_Abstract implements CM_Typed {
 
     /**
+     * @param string     $msg
+     * @param array|null $metaInfo
+     */
+    public function add($msg, array $metaInfo = null) {
+        $metaInfo = array_merge((array) $metaInfo, $this->_getDefaultMetaInfo());
+        $this->_add($msg, $metaInfo);
+    }
+
+    /**
      * @param boolean $aggregate
      * @param int     $ageMax
      */

--- a/library/CM/Paging/Log/Error.php
+++ b/library/CM/Paging/Log/Error.php
@@ -2,12 +2,4 @@
 
 class CM_Paging_Log_Error extends CM_Paging_Log_Abstract {
 
-    /**
-     * @param string     $msg
-     * @param array|null $metaInfo
-     */
-    public function add($msg, array $metaInfo = null) {
-        $metaInfo = array_merge((array) $metaInfo, $this->_getDefaultMetaInfo());
-        $this->_add($msg, $metaInfo);
-    }
 }

--- a/library/CM/Paging/Log/Fatal.php
+++ b/library/CM/Paging/Log/Fatal.php
@@ -2,15 +2,6 @@
 
 class CM_Paging_Log_Fatal extends CM_Paging_Log_Abstract {
 
-    /**
-     * @param string     $msg
-     * @param array|null $metaInfo
-     */
-    public function add($msg, array $metaInfo = null) {
-        $metaInfo = array_merge((array) $metaInfo, $this->_getDefaultMetaInfo());
-        $this->_add($msg, $metaInfo);
-    }
-
     public function cleanUp() {
         $this->_deleteOlderThan(30 * 86400);
     }

--- a/library/CM/Paging/Log/JsError.php
+++ b/library/CM/Paging/Log/JsError.php
@@ -2,12 +2,4 @@
 
 class CM_Paging_Log_JsError extends CM_Paging_Log_Abstract {
 
-    /**
-     * @param string     $msg
-     * @param array|null $metaInfo
-     */
-    public function add($msg, array $metaInfo = null) {
-        $metaInfo = array_merge((array) $metaInfo, $this->_getDefaultMetaInfo());
-        $this->_add($msg, $metaInfo);
-    }
 }

--- a/library/CM/Paging/Log/Mail.php
+++ b/library/CM/Paging/Log/Mail.php
@@ -2,11 +2,15 @@
 
 class CM_Paging_Log_Mail extends CM_Paging_Log_Abstract {
 
+    public function add($msg, array $metaInfo = null) {
+        throw new CM_Exception_NotImplemented;
+    }
+
     /**
      * @param CM_Mail $mail
      * @param string  $msg
      */
-    public function add(CM_Mail $mail, $msg) {
+    public function addMail(CM_Mail $mail, $msg) {
         $this->_add($msg, array(
             'sender'  => $mail->getSender(),
             'replyTo' => $mail->getReplyTo(),

--- a/library/CM/Paging/Log/NotFound.php
+++ b/library/CM/Paging/Log/NotFound.php
@@ -2,12 +2,4 @@
 
 class CM_Paging_Log_NotFound extends CM_Paging_Log_Abstract {
 
-    /**
-     * @param string     $msg
-     * @param array|null $metaInfo
-     */
-    public function add($msg, array $metaInfo = null) {
-        $metaInfo = array_merge((array) $metaInfo, $this->_getDefaultMetaInfo());
-        $this->_add($msg, $metaInfo);
-    }
 }

--- a/library/CM/Paging/Log/Warn.php
+++ b/library/CM/Paging/Log/Warn.php
@@ -2,12 +2,4 @@
 
 class CM_Paging_Log_Warn extends CM_Paging_Log_Abstract {
 
-    /**
-     * @param string     $msg
-     * @param array|null $metaInfo
-     */
-    public function add($msg, array $metaInfo = null) {
-        $metaInfo = array_merge((array) $metaInfo, $this->_getDefaultMetaInfo());
-        $this->_add($msg, $metaInfo);
-    }
 }

--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -56,7 +56,7 @@ return function (CM_Config_Node $config) {
 
     $config->CM_Http_Response_Page->exceptionsToCatch = array(
         'CM_Exception_Nonexistent'  => ['errorPage' => 'CM_Page_Error_NotFound', 'log' => 'CM_Paging_Log_NotFound'],
-        'CM_Exception_InvalidParam' => ['errorPage' => 'CM_Page_Error_NotFound', 'log' => 'CM_Paging_Log_Error'],
+        'CM_Exception_InvalidParam' => ['errorPage' => 'CM_Page_Error_NotFound', 'log' => 'CM_Paging_Log_NotFound'],
         'CM_Exception_AuthRequired' => ['errorPage' => 'CM_Page_Error_AuthRequired', 'log' => null],
         'CM_Exception_NotAllowed'   => ['errorPage' => 'CM_Page_Error_NotAllowed', 'log' => null],
     );

--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -54,11 +54,11 @@ return function (CM_Config_Node $config) {
 
     $config->CM_Usertext_Usertext->class = 'CM_Usertext_Usertext';
 
-    $config->CM_Http_Response_Page->catch = array(
-        'CM_Exception_Nonexistent'  => ['path' => '/error/not-found', 'log' => true],
-        'CM_Exception_InvalidParam' => ['path' => '/error/not-found', 'log' => true],
-        'CM_Exception_AuthRequired' => ['path' => '/error/auth-required', 'log' => false],
-        'CM_Exception_NotAllowed'   => ['path' => '/error/not-allowed', 'log' => false],
+    $config->CM_Http_Response_Page->exceptionsToCatch = array(
+        'CM_Exception_Nonexistent'  => ['errorPage' => 'CM_Page_Error_NotFound', 'log' => 'CM_Paging_Log_NotFound'],
+        'CM_Exception_InvalidParam' => ['errorPage' => 'CM_Page_Error_NotFound', 'log' => 'CM_Paging_Log_Error'],
+        'CM_Exception_AuthRequired' => ['errorPage' => 'CM_Page_Error_AuthRequired', 'log' => null],
+        'CM_Exception_NotAllowed'   => ['errorPage' => 'CM_Page_Error_NotAllowed', 'log' => null],
     );
 
     $config->CM_Http_Response_View_Abstract->catch = array(

--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -61,7 +61,7 @@ return function (CM_Config_Node $config) {
         'CM_Exception_NotAllowed'   => ['errorPage' => 'CM_Page_Error_NotAllowed', 'log' => null],
     );
 
-    $config->CM_Http_Response_View_Abstract->catch = array(
+    $config->CM_Http_Response_View_Abstract->exceptionsToCatch = array(
         'CM_Exception_Nonexistent'  => [],
         'CM_Exception_AuthRequired' => [],
         'CM_Exception_NotAllowed'   => [],

--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -70,10 +70,11 @@ return function (CM_Config_Node $config) {
     );
     $config->CM_Http_Response_View_Abstract->catchPublicExceptions = true;
 
-    $config->CM_Http_Response_RPC->catch = array(
-        'CM_Exception_AuthRequired',
-        'CM_Exception_NotAllowed',
+    $config->CM_Http_Response_RPC->exceptionsToCatch = array(
+        'CM_Exception_AuthRequired' => [],
+        'CM_Exception_NotAllowed'   => [],
     );
+    $config->CM_Http_Response_RPC->catchPublicExceptions = true;
 
     $config->CM_Stream_Video->adapter = 'CM_Stream_Adapter_Video_Wowza';
     $config->CM_Stream_Video->servers = array(

--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -62,12 +62,13 @@ return function (CM_Config_Node $config) {
     );
 
     $config->CM_Http_Response_View_Abstract->catch = array(
-        'CM_Exception_Nonexistent',
-        'CM_Exception_AuthRequired',
-        'CM_Exception_NotAllowed',
-        'CM_Exception_Blocked',
-        'CM_Exception_ActionLimit',
+        'CM_Exception_Nonexistent'  => [],
+        'CM_Exception_AuthRequired' => [],
+        'CM_Exception_NotAllowed'   => [],
+        'CM_Exception_Blocked'      => [],
+        'CM_Exception_ActionLimit'  => [],
     );
+    $config->CM_Http_Response_View_Abstract->catchPublicExceptions = true;
 
     $config->CM_Http_Response_RPC->catch = array(
         'CM_Exception_AuthRequired',

--- a/tests/library/CM/Http/Response/AbstractTest.php
+++ b/tests/library/CM/Http/Response/AbstractTest.php
@@ -51,40 +51,50 @@ class CM_Http_Response_AbstractTest extends CMTest_TestCase {
         // test logging and errorCallback-execution
         CM_Config::get()->$className = new stdClass();
         CM_Config::get()->$className->exceptionsToCatch = [
-            'CM_Exception_Nonexistent' => ['log' => 'CM_Paging_Log_NotFound', 'foo' => 'bar'],
+            'CM_Exception_Nonexistent'  => ['log' => 'CM_Paging_Log_NotFound', 'foo' => 'bar'],
             'CM_Exception_InvalidParam' => ['log' => null]
         ];
         $exceptionCodeExecutionCounter = 0;
-        $errorCode = function(CM_Exception_Nonexistent $ex, $errorOptions) use (&$exceptionCodeExecutionCounter) {
+        $errorCode = function (CM_Exception_Nonexistent $ex, $errorOptions) use (&$exceptionCodeExecutionCounter) {
             $this->assertSame('bar', $errorOptions['foo']);
             $exceptionCodeExecutionCounter++;
         };
         $this->assertSame(0, $exceptionCodeExecutionCounter);
         $this->assertCount(0, new CM_Paging_Log_NotFound());
-        CMTest_TH::callProtectedMethod($response, '_runWithCatching', [function() {}, $errorCode]);
+        CMTest_TH::callProtectedMethod($response, '_runWithCatching', [
+            function () {
+            }, $errorCode]);
         $this->assertSame(0, $exceptionCodeExecutionCounter);
         $this->assertCount(0, new CM_Paging_Log_NotFound());
-        CMTest_TH::callProtectedMethod($response, '_runWithCatching', [function() {throw new CM_Exception_Nonexistent();}, $errorCode]);
+        CMTest_TH::callProtectedMethod($response, '_runWithCatching', [
+            function () {
+                throw new CM_Exception_Nonexistent();
+            }, $errorCode]);
         $this->assertSame(1, $exceptionCodeExecutionCounter);
         $this->assertCount(1, new CM_Paging_Log_NotFound());
 
-        $errorCode = function(CM_Exception_InvalidParam $ex, $errorOptions) use (&$exceptionCodeExecutionCounter) {
+        $errorCode = function (CM_Exception_InvalidParam $ex, $errorOptions) use (&$exceptionCodeExecutionCounter) {
             $exceptionCodeExecutionCounter++;
         };
-        CMTest_TH::callProtectedMethod($response, '_runWithCatching', [function() {throw new CM_Exception_InvalidParam();}, $errorCode]);
+        CMTest_TH::callProtectedMethod($response, '_runWithCatching', [
+            function () {
+                throw new CM_Exception_InvalidParam();
+            }, $errorCode]);
         $this->assertSame(2, $exceptionCodeExecutionCounter);
         $this->assertCount(1, new CM_Paging_Log_NotFound());
-
 
         // test public/non-public exceptions not marked for catching
         // public exception, no public exception catching
         CM_Config::get()->$className->exceptionsToCatch = [];
-        $errorCode = function(CM_Exception_Nonexistent $ex, $errorOptions) use (&$exceptionCodeExecutionCounter) {
+        $errorCode = function (CM_Exception_Nonexistent $ex, $errorOptions) use (&$exceptionCodeExecutionCounter) {
             $exceptionCodeExecutionCounter++;
             $this->assertTrue($ex->isPublic());
         };
         try {
-            CMTest_TH::callProtectedMethod($response, '_runWithCatching', [function() {throw new CM_Exception_Nonexistent('foo', null, ['messagePublic' => 'bar']);}, $errorCode]);
+            CMTest_TH::callProtectedMethod($response, '_runWithCatching', [
+                function () {
+                    throw new CM_Exception_Nonexistent('foo', null, ['messagePublic' => 'bar']);
+                }, $errorCode]);
             $this->fail('Caught public exception with public exception catching disabled');
         } catch (CM_Exception_Nonexistent $ex) {
             $this->assertTrue($ex->isPublic());
@@ -95,7 +105,10 @@ class CM_Http_Response_AbstractTest extends CMTest_TestCase {
         // non-public exception, public exception catching
         CM_Config::get()->$className->catchPublicExceptions = true;
         try {
-            CMTest_TH::callProtectedMethod($response, '_runWithCatching', [function() {throw new CM_Exception_Nonexistent('foo');}, $errorCode]);
+            CMTest_TH::callProtectedMethod($response, '_runWithCatching', [
+                function () {
+                    throw new CM_Exception_Nonexistent('foo');
+                }, $errorCode]);
             $this->fail('Caught non-public exception that was not configured to be caught');
         } catch (CM_Exception_Nonexistent $ex) {
             $this->assertFalse($ex->isPublic());
@@ -105,7 +118,10 @@ class CM_Http_Response_AbstractTest extends CMTest_TestCase {
 
         // public exception, public exception catching
         try {
-            $returnValue = CMTest_TH::callProtectedMethod($response, '_runWithCatching', [function() {throw new CM_Exception_Nonexistent('foo', null, ['messagePublic' => 'bar']);}, $errorCode]);
+            $returnValue = CMTest_TH::callProtectedMethod($response, '_runWithCatching', [
+                function () {
+                    throw new CM_Exception_Nonexistent('foo', null, ['messagePublic' => 'bar']);
+                }, $errorCode]);
             $this->assertNull($returnValue);
         } catch (CM_Exception_Nonexistent $ex) {
             $this->fail('Caught non-public exception');

--- a/tests/library/CM/Http/Response/AbstractTest.php
+++ b/tests/library/CM/Http/Response/AbstractTest.php
@@ -47,6 +47,8 @@ class CM_Http_Response_AbstractTest extends CMTest_TestCase {
     public function testRunWithCatching() {
         $response = $this->mockClass('CM_Http_Response_Abstract')->newInstanceWithoutConstructor();
         $className = get_class($response);
+
+        // test logging and errorCallback-execution
         CM_Config::get()->$className = new stdClass();
         CM_Config::get()->$className->exceptionsToCatch = [
             'CM_Exception_Nonexistent' => ['log' => 'CM_Paging_Log_NotFound', 'foo' => 'bar'],
@@ -72,5 +74,42 @@ class CM_Http_Response_AbstractTest extends CMTest_TestCase {
         CMTest_TH::callProtectedMethod($response, '_runWithCatching', [function() {throw new CM_Exception_InvalidParam();}, $errorCode]);
         $this->assertSame(2, $exceptionCodeExecutionCounter);
         $this->assertCount(1, new CM_Paging_Log_NotFound());
+
+
+        // test public/non-public exceptions not marked for catching
+        // public exception, no public exception catching
+        CM_Config::get()->$className->exceptionsToCatch = [];
+        $errorCode = function(CM_Exception_Nonexistent $ex, $errorOptions) use (&$exceptionCodeExecutionCounter) {
+            $exceptionCodeExecutionCounter++;
+            $this->assertTrue($ex->isPublic());
+        };
+        try {
+            CMTest_TH::callProtectedMethod($response, '_runWithCatching', [function() {throw new CM_Exception_Nonexistent('foo', null, ['messagePublic' => 'bar']);}, $errorCode]);
+            $this->fail('Caught public exception with public exception catching disabled');
+        } catch (CM_Exception_Nonexistent $ex) {
+            $this->assertTrue($ex->isPublic());
+            $this->assertSame('foo', $ex->getMessage());
+        }
+        $this->assertSame(2, $exceptionCodeExecutionCounter);
+
+        // non-public exception, public exception catching
+        CM_Config::get()->$className->catchPublicExceptions = true;
+        try {
+            CMTest_TH::callProtectedMethod($response, '_runWithCatching', [function() {throw new CM_Exception_Nonexistent('foo');}, $errorCode]);
+            $this->fail('Caught non-public exception that was not configured to be caught');
+        } catch (CM_Exception_Nonexistent $ex) {
+            $this->assertFalse($ex->isPublic());
+            $this->assertSame('foo', $ex->getMessage());
+        }
+        $this->assertSame(2, $exceptionCodeExecutionCounter);
+
+        // public exception, public exception catching
+        try {
+            $returnValue = CMTest_TH::callProtectedMethod($response, '_runWithCatching', [function() {throw new CM_Exception_Nonexistent('foo', null, ['messagePublic' => 'bar']);}, $errorCode]);
+            $this->assertNull($returnValue);
+        } catch (CM_Exception_Nonexistent $ex) {
+            $this->fail('Caught non-public exception');
+        }
+        $this->assertSame(3, $exceptionCodeExecutionCounter);
     }
 }

--- a/tests/library/CM/Http/Response/PageTest.php
+++ b/tests/library/CM/Http/Response/PageTest.php
@@ -118,16 +118,24 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $this->assertContains("_kmq.push(['alias', 'Guest {$clientId}', '1']);", $html);
     }
 
-    public function testNotFoundErrorLogging() {
-        $log = new CM_Paging_Log_NotFound();
-        $this->assertCount(0, $log);
-
+    public function testProcessExceptionCatching() {
+        CM_Config::get()->CM_Http_Response_Page->exceptionsToCatch = [
+            'CM_Exception_InvalidParam' => ['errorPage' => 'CM_Page_Error_NotFound', 'log' => null],
+        ];
         $this->getMock('CM_Layout_Abstract', null, [], 'CM_Layout_Default');
-        $response = CMTest_TH::createResponsePage('/NotExists');
-        $response->process();
+        $request = CMTest_TH::createResponsePage('/example')->getRequest();
+        $response = $this->mockObject('CM_Http_Response_Page', [$request, CMTest_TH::getServiceManager()]);
+        $response->mockMethod('_renderPage')->set(function () {
+            static $counter = 0;
+            if ($counter++ === 0) { // don't throw when rendering the error-page the request was redirected to
+                throw new CM_Exception_InvalidParam();
+            }
+        });
+        /** @var CM_Http_Response_Page $response */
 
-        $log = new CM_Paging_Log_NotFound();
-        $this->assertCount(1, $log);
+        $this->assertSame('/example', $response->getRequest()->getPath());
+        $response->process();
+        $this->assertSame('/error/not-found', $response->getRequest()->getPath());
     }
 
     /**

--- a/tests/library/CM/Http/Response/RPCTest.php
+++ b/tests/library/CM/Http/Response/RPCTest.php
@@ -1,0 +1,42 @@
+<?php
+
+class CM_Http_Response_RPCTest extends CMTest_TestCase {
+
+    public function testProcessExceptionCatching() {
+        CM_Config::get()->CM_Http_Response_RPC->catchPublicExceptions = true;
+        CM_Config::get()->CM_Http_Response_RPC->exceptionsToCatch = ['CM_Exception_Nonexistent' => []];
+        $request = $this->mockObject('CM_Http_Request_Abstract', ['/rpc/' . CM_Site_Abstract::factory()->getType() . '/foo']);
+        $request->mockMethod('getQuery')->set(function () {
+            throw new CM_Exception_Invalid('foo', null, ['messagePublic' => 'bar']);
+        });
+        /** @var CM_Http_Request_Abstract $response */
+        $response = new CM_Http_Response_RPC($request, CMTest_TH::getServiceManager());
+
+        CMTest_TH::callProtectedMethod($response, '_process');
+        $responseData = CM_Params::jsonDecode($response->getContent());
+
+        $this->assertSame(
+            ['error' =>
+                 ['type'     => 'CM_Exception_Invalid',
+                  'msg'      => 'bar',
+                  'isPublic' => true
+                 ]
+            ], $responseData);
+
+        $request->mockMethod('getQuery')->set(function () {
+            throw new CM_Exception_Nonexistent('foo');
+        });
+        $response = new CM_Http_Response_RPC($request, CMTest_TH::getServiceManager());
+
+        CMTest_TH::callProtectedMethod($response, '_process');
+        $responseData = CM_Params::jsonDecode($response->getContent());
+
+        $this->assertSame(
+            ['error' =>
+                 ['type'     => 'CM_Exception_Nonexistent',
+                  'msg'      => 'Internal server error',
+                  'isPublic' => false
+                 ]
+            ], $responseData);
+    }
+}

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -23,24 +23,6 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
         $this->assertSame('CM_Layout_Mock1', $responseContent['success']['data']['layoutClass']);
     }
 
-    public function testNotFoundErrorLogging() {
-        CM_Config::get()->CM_Http_Response_Page->exceptionsToCatch['CM_Exception_Nonexistent'] = [
-            'errorPage' => 'CM_Page_View_Ajax_Test_Mock',
-            'log'       => 'CM_Paging_Log_NotFound',
-        ];
-
-        $log = new CM_Paging_Log_NotFound();
-        $this->assertCount(0, $log);
-
-        $viewer = CMTest_TH::createUser();
-        $environment = new CM_Frontend_Environment(null, $viewer);
-        $component = new CM_Page_View_Ajax_Test_Mock();
-        $this->getResponseAjax($component, 'loadPage', ['path' => CM_Page_View_Ajax_Test_Mock::getPath() . '/NotExist'], $environment);
-
-        $log = new CM_Paging_Log_NotFound();
-        $this->assertCount(1, $log);
-    }
-
     public function testProcessExceptionCatching() {
         CM_Config::get()->CM_Http_Response_View_Abstract->catchPublicExceptions = true;
         CM_Config::get()->CM_Http_Response_View_Abstract->exceptionsToCatch = ['CM_Exception_Nonexistent' => []];

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -114,9 +114,8 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
     }
 
     public function testLoadPageTrackingError() {
-        CM_Config::get()->CM_Http_Response_Page->catch['CM_Exception_Nonexistent'] = [
-            'path' => CM_Page_View_Ajax_Test_Mock::getPath(),
-            'log'  => true,
+        CM_Config::get()->CM_Http_Response_Page->exceptionsToCatch['CM_Exception_Nonexistent'] = [
+            'errorPage' => 'CM_Page_View_Ajax_Test_Mock',
         ];
 
         $page = new CM_Page_View_Ajax_Test_Mock();

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -28,7 +28,7 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
         CM_Config::get()->CM_Http_Response_View_Abstract->exceptionsToCatch = ['CM_Exception_Nonexistent' => []];
         $response = $this->mockClass('CM_Http_Response_View_Abstract')->newInstanceWithoutConstructor();
         $response->mockMethod('_processView')->set(function () {
-            throw new CM_Exception_Invalid('foo', null, ['messagePublic' => 'bar']);;
+            throw new CM_Exception_Invalid('foo', null, ['messagePublic' => 'bar']);
         });
         $response->mockMethod('getRender')->set(new CM_Frontend_Render());
         /** @var CM_Http_Response_View_Abstract $response */

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -24,9 +24,9 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
     }
 
     public function testNotFoundErrorLogging() {
-        CM_Config::get()->CM_Http_Response_Page->catch['CM_Exception_Nonexistent'] = [
-            'path' => CM_Page_View_Ajax_Test_Mock::getPath(),
-            'log'  => true,
+        CM_Config::get()->CM_Http_Response_Page->exceptionsToCatch['CM_Exception_Nonexistent'] = [
+            'errorPage' => 'CM_Page_View_Ajax_Test_Mock',
+            'log'       => 'CM_Paging_Log_NotFound',
         ];
 
         $log = new CM_Paging_Log_NotFound();
@@ -39,6 +39,40 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
 
         $log = new CM_Paging_Log_NotFound();
         $this->assertCount(1, $log);
+    }
+
+    public function testProcessExceptionCatching() {
+        CM_Config::get()->CM_Http_Response_View_Abstract->catchPublicExceptions = true;
+        CM_Config::get()->CM_Http_Response_View_Abstract->exceptionsToCatch = ['CM_Exception_Nonexistent' => []];
+        $response = $this->mockClass('CM_Http_Response_View_Abstract')->newInstanceWithoutConstructor();
+        $response->mockMethod('_processView')->set(function () {
+            throw new CM_Exception_Invalid('foo', null, ['messagePublic' => 'bar']);;
+        });
+        $response->mockMethod('getRender')->set(new CM_Frontend_Render());
+        /** @var CM_Http_Response_View_Abstract $response */
+        CMTest_TH::callProtectedMethod($response, '_process');
+        $responseData = CM_Params::jsonDecode($response->getContent());
+        $this->assertSame(
+            ['error' =>
+                 ['type'     => 'CM_Exception_Invalid',
+                  'msg'      => 'bar',
+                  'isPublic' => true
+                 ]
+            ], $responseData);
+
+        $response->mockMethod('_processView')->set(function () {
+            throw new CM_Exception_Nonexistent('foo');
+        });
+
+        CMTest_TH::callProtectedMethod($response, '_process');
+        $responseData = CM_Params::jsonDecode($response->getContent());
+        $this->assertSame(
+            ['error' =>
+                 ['type'     => 'CM_Exception_Nonexistent',
+                  'msg'      => 'Internal server error',
+                  'isPublic' => false
+                 ]
+            ], $responseData);
     }
 
     public function testLoadPageRedirectExternal() {


### PR DESCRIPTION
Idea: Streamline the configuration and code of catching exceptions in Responses' `process()`.

Current config:
```php
    $config->CM_Http_Response_Page->catch = array(
        'CM_Exception_Nonexistent'  => ['path' => '/error/not-found', 'log' => true],
        'CM_Exception_InvalidParam' => ['path' => '/error/not-found', 'log' => true],
        'CM_Exception_AuthRequired' => ['path' => '/error/auth-required', 'log' => false],
        'CM_Exception_NotAllowed'   => ['path' => '/error/not-allowed', 'log' => false],
    );

    $config->CM_Http_Response_View_Abstract->catch = array(
        'CM_Exception_Nonexistent',
        'CM_Exception_AuthRequired',
        'CM_Exception_NotAllowed',
        'CM_Exception_Blocked',
        'CM_Exception_ActionLimit',
    );

    $config->CM_Http_Response_RPC->catch = array(
        'CM_Exception_AuthRequired',
        'CM_Exception_NotAllowed',
    );
```

Idea:
```php
    $config->CM_Http_Response_Abstract->exceptionsToCatch = array(
        'CM_Exception_Nonexistent'  => ['errorPage' => 'CM_Page_Error_NotFound', 'log' => 'CM_Paging_Log_NotFound'],
        'CM_Exception_InvalidParam' => ['errorPage' => 'CM_Page_Error_NotFound', 'log' => 'CM_Paging_Log_NotFound'],
        'CM_Exception_AuthRequired' => ['errorPage' => 'CM_Page_Error_AuthRequired', 'log' => null],
        'CM_Exception_NotAllowed'   => ['errorPage' => 'CM_Page_Error_NotAllowed', 'log' => null],
        'CM_Exception_Blocked'      => ['errorPage' => 'CM_Page_Error_NotFound', 'log' => null],
        'CM_Exception_ActionLimit'  => ['errorPage' => 'CM_Page_Error_NotFound', 'log' => null],
    );
```

@tomaszdurka @dlondero @mariansollmann thoughts?