### PR TITLE
CM_Cli_Exception_InvalidArguments is not catched by Cli manager

### DIFF
--- a/library/CM/Cli/Arguments.php
+++ b/library/CM/Cli/Arguments.php
@@ -59,18 +59,6 @@ class CM_Cli_Arguments {
     }
 
     /**
-     * @throws CM_Cli_Exception_InvalidArguments
-     */
-    public function checkUnused() {
-        if ($this->getNumeric()->getParamsDecoded()) {
-            throw new CM_Cli_Exception_InvalidArguments('Too many arguments provided');
-        }
-        if ($named = $this->getNamed()->getParamsDecoded()) {
-            throw new CM_Cli_Exception_InvalidArguments('Illegal option used: `--' . key($named) . '`');
-        }
-    }
-
-    /**
      * @param string $argument
      */
     private function _parseArgument($argument) {

--- a/library/CM/Cli/Command.php
+++ b/library/CM/Cli/Command.php
@@ -18,15 +18,24 @@ class CM_Cli_Command {
     }
 
     /**
-     * @param CM_Cli_Arguments          $arguments
+     * @param array                     $parameters
      * @param CM_InputStream_Interface  $streamInput
      * @param CM_OutputStream_Interface $streamOutput
      * @param CM_OutputStream_Interface $streamError
      */
-    public function run(CM_Cli_Arguments $arguments, CM_InputStream_Interface $streamInput, CM_OutputStream_Interface $streamOutput, CM_OutputStream_Interface $streamError) {
+    public function run(array $parameters, CM_InputStream_Interface $streamInput, CM_OutputStream_Interface $streamOutput, CM_OutputStream_Interface $streamError) {
+        call_user_func_array(array($this->_class->newInstance($streamInput, $streamOutput, $streamError), $this->_method->getName()), $parameters);
+    }
+
+    /**
+     * @param CM_Cli_Arguments $arguments
+     * @return array
+     * @throws CM_Cli_Exception_InvalidArguments
+     */
+    public function extractParameters(CM_Cli_Arguments $arguments) {
         $parameters = $arguments->extractMethodParameters($this->_method);
         $arguments->checkUnused();
-        call_user_func_array(array($this->_class->newInstance($streamInput, $streamOutput, $streamError), $this->_method->getName()), $parameters);
+        return $parameters;
     }
 
     /**

--- a/library/CM/Cli/Command.php
+++ b/library/CM/Cli/Command.php
@@ -34,7 +34,6 @@ class CM_Cli_Command {
      */
     public function extractParameters(CM_Cli_Arguments $arguments) {
         $parameters = $arguments->extractMethodParameters($this->_method);
-        $arguments->checkUnused();
         return $parameters;
     }
 

--- a/library/CM/Cli/CommandManager.php
+++ b/library/CM/Cli/CommandManager.php
@@ -169,13 +169,15 @@ class CM_Cli_CommandManager {
             $streamInput = $this->_streamInput;
             $streamOutput = $this->_streamOutput;
             $streamError = $this->_streamError;
-            $workload = function () use ($transactionName, $command, $arguments, $streamInput, $streamOutput, $streamError) {
+
+            $parameters = $command->extractParameters($arguments);
+            $workload = function () use ($transactionName, $command, $parameters, $streamInput, $streamOutput, $streamError) {
                 if ($command->getKeepalive()) {
                     CMService_Newrelic::getInstance()->ignoreTransaction();
                 } else {
                     CMService_Newrelic::getInstance()->startTransaction($transactionName);
                 }
-                $command->run($arguments, $streamInput, $streamOutput, $streamError);
+                $command->run($parameters, $streamInput, $streamOutput, $streamError);
             };
 
             $forks = max($this->_forks, 1);

--- a/library/CM/Cli/CommandManager.php
+++ b/library/CM/Cli/CommandManager.php
@@ -171,6 +171,8 @@ class CM_Cli_CommandManager {
             $streamError = $this->_streamError;
 
             $parameters = $command->extractParameters($arguments);
+            $this->_checkUnusedArguments($arguments);
+
             $workload = function () use ($transactionName, $command, $parameters, $streamInput, $streamOutput, $streamError) {
                 if ($command->getKeepalive()) {
                     CMService_Newrelic::getInstance()->ignoreTransaction();
@@ -231,6 +233,19 @@ class CM_Cli_CommandManager {
         $hostId = dechex($lock['hostId']);
         $processId = (int) $lock['processId'];
         throw new CM_Cli_Exception_Internal("Command `$commandName` still running (process `$processId` on host `$hostId`)");
+    }
+
+    /**
+     * @param CM_Cli_Arguments $arguments
+     * @throws CM_Cli_Exception_InvalidArguments
+     */
+    protected function _checkUnusedArguments(CM_Cli_Arguments $arguments) {
+        if ($arguments->getNumeric()->getParamsDecoded()) {
+            throw new CM_Cli_Exception_InvalidArguments('Too many arguments provided');
+        }
+        if ($named = $arguments->getNamed()->getParamsDecoded()) {
+            throw new CM_Cli_Exception_InvalidArguments('Illegal option used: `--' . key($named) . '`');
+        }
     }
 
     /**

--- a/library/CM/Cli/CommandManager.php
+++ b/library/CM/Cli/CommandManager.php
@@ -170,7 +170,7 @@ class CM_Cli_CommandManager {
             $streamOutput = $this->_streamOutput;
             $streamError = $this->_streamError;
 
-            $workload = $this->_getProcessWorkLoad($transactionName, $command, $arguments, $streamInput, $streamOutput, $streamError);
+            $workload = $this->_getProcessWorkload($transactionName, $command, $arguments, $streamInput, $streamOutput, $streamError);
 
             $forks = max($this->_forks, 1);
             $process = $this->_getProcess();

--- a/library/CM/Process/WorkloadResult.php
+++ b/library/CM/Process/WorkloadResult.php
@@ -9,18 +9,6 @@ class CM_Process_WorkloadResult {
     private $_exception;
 
     /**
-     * @param mixed          $result
-     * @param Exception|null $exception
-     */
-    public function __construct($result, Exception $exception = null) {
-        if (null !== $exception) {
-            $exception = new CM_ExceptionHandling_SerializableException($exception);
-        }
-        $this->_result = $result;
-        $this->_exception = $exception;
-    }
-
-    /**
      * @return mixed
      */
     public function getResult() {
@@ -28,10 +16,28 @@ class CM_Process_WorkloadResult {
     }
 
     /**
+     * @param mixed $result
+     * @return $this
+     */
+    public function setResult($result) {
+        $this->_result = $result;
+        return $this;
+    }
+
+    /**
      * @return CM_ExceptionHandling_SerializableException|null
      */
     public function getException() {
         return $this->_exception;
+    }
+
+    /**
+     * @param Exception $exception
+     * @return $this
+     */
+    public function setException(Exception $exception) {
+        $this->_exception = new CM_ExceptionHandling_SerializableException($exception);
+        return $this;
     }
 
     /**

--- a/library/CM/Process/WorkloadResult.php
+++ b/library/CM/Process/WorkloadResult.php
@@ -1,5 +1,9 @@
 <?php
 
+class bla extends CM_Process_WorkloadResult {
+
+}
+
 class CM_Process_WorkloadResult {
 
     /** @var mixed */
@@ -33,7 +37,7 @@ class CM_Process_WorkloadResult {
 
     /**
      * @param Exception $exception
-     * @return $this
+     * @return static
      */
     public function setException(Exception $exception) {
         $this->_exception = new CM_ExceptionHandling_SerializableException($exception);

--- a/tests/library/CM/Cli/CommandManagerTest.php
+++ b/tests/library/CM/Cli/CommandManagerTest.php
@@ -229,7 +229,7 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
     protected function _getProcessMock($keepAliveExpected) {
         $processMock = $this->getMock('CM_Process', array('fork', 'waitForChildren'), array(), '', false);
         $processMock->expects($this->any())->method('fork')->will($this->returnCallback(function ($workload) {
-            $workload();
+            $workload(new CM_Process_WorkloadResult());
         }));
         $waitForChildrenMock = function ($keepAlive, $terminationCallback) {
             if (isset($terminationCallback)) {

--- a/tests/library/CM/Cli/CommandManagerTest.php
+++ b/tests/library/CM/Cli/CommandManagerTest.php
@@ -150,6 +150,7 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
         $command = $this->mockClass('CM_Cli_Command')->newInstanceWithoutConstructor();
         $command->mockMethod('getSynchronized');
         $command->mockMethod('getKeepalive');
+        $command->mockMethod('extractParameters');
 
         $commandManager = $this->mockObject('CM_Cli_CommandManager');
         $commandManager->mockMethod('_getCommand')->set($command);
@@ -208,13 +209,14 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
      */
     protected function _getCommandMock($synchronized, $keepAlive, $expectedRuns) {
         $commandMock = $this->getMock('CM_Cli_Command',
-            array('getPackageName', '_getMethodName', 'isAbstract', 'getSynchronized', 'getKeepalive', 'run'),
+            array('getPackageName', '_getMethodName', 'isAbstract', 'getSynchronized', 'getKeepalive', 'run', 'extractParameters'),
             array(), '', false);
         $commandMock->expects($this->any())->method('getPackageName')->will($this->returnValue('package-mock'));
         $commandMock->expects($this->any())->method('_getMethodName')->will($this->returnValue('command-mock'));
         $commandMock->expects($this->any())->method('isAbstract')->will($this->returnValue(false));
         $commandMock->expects($this->any())->method('getSynchronized')->will($this->returnValue($synchronized));
         $commandMock->expects($this->any())->method('getKeepalive')->will($this->returnValue($keepAlive));
+        $commandMock->expects($this->any())->method('extractParameters')->will($this->returnValue([]));
         $commandMock->expects($this->exactly($expectedRuns))->method('run');
         return $commandMock;
     }

--- a/tests/library/CM/Cli/CommandManagerTest.php
+++ b/tests/library/CM/Cli/CommandManagerTest.php
@@ -158,20 +158,20 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
             ->at(0, function () use ($processMock) {
                 $processSuccess = $processMock->newInstance();
                 $processSuccess->mockMethod('waitForChildren')->set([
-                    new CM_Process_WorkloadResult(true),
-                    new CM_Process_WorkloadResult(true),
-                    new CM_Process_WorkloadResult(true),
-                    new CM_Process_WorkloadResult(true),
+                    (new CM_Process_WorkloadResult())->setResult(true),
+                    (new CM_Process_WorkloadResult())->setResult(true),
+                    (new CM_Process_WorkloadResult())->setResult(true),
+                    (new CM_Process_WorkloadResult())->setResult(true),
                 ]);
                 return $processSuccess;
             })
             ->at(1, function () use ($processMock) {
                 $processFailure = $processMock->newInstance();
                 $processFailure->mockMethod('waitForChildren')->set([
-                    new CM_Process_WorkloadResult(true),
-                    new CM_Process_WorkloadResult(false, new Exception('Workload failed')),
-                    new CM_Process_WorkloadResult(true),
-                    new CM_Process_WorkloadResult(true),
+                    (new CM_Process_WorkloadResult())->setResult(true),
+                    (new CM_Process_WorkloadResult())->setResult(false)->setException(new Exception('Workload failed')),
+                    (new CM_Process_WorkloadResult())->setResult(true),
+                    (new CM_Process_WorkloadResult())->setResult(true),
                 ]);
                 return $processFailure;
             });
@@ -190,7 +190,7 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
         $keepAliveExpected = $commandMock->getKeepalive();
         $processMock = $this->_getProcessMock($keepAliveExpected);
         $commandManagerMock = $this->getMock('CM_Cli_CommandManager',
-            array('getCommands', '_getProcess', '_findLock', '_lockCommand', 'unlockCommand', '_outputError'));
+            array('getCommands', '_getProcess', '_findLock', '_lockCommand', 'unlockCommand', '_outputError', '_checkUnusedArguments'));
         $commandManagerMock->expects($this->any())->method('getCommands')->will($this->returnValue(array($commandMock)));
         if (null === $errorMessageExpected) {
             $commandManagerMock->expects($this->never())->method('_outputError');
@@ -198,6 +198,7 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
             $commandManagerMock->expects($this->once())->method('_outputError')->with($errorMessageExpected);
         }
         $commandManagerMock->expects($this->any())->method('_getProcess')->will($this->returnValue($processMock));
+        $commandManagerMock->expects($this->any())->method('_checkUnusedArguments');
         return $commandManagerMock;
     }
 

--- a/tests/library/CM/Clockwork/ManagerTest.php
+++ b/tests/library/CM/Clockwork/ManagerTest.php
@@ -27,7 +27,7 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $this->assertTrue(CMTest_TH::callProtectedMethod($manager, '_isRunning', [$event2]));
 
         // event 2 finishes
-        $process->mockMethod('listenForChildren')->set([2 => new CM_Process_WorkloadResult(null, null)]);
+        $process->mockMethod('listenForChildren')->set([2 => new CM_Process_WorkloadResult()]);
         $manager->runEvents();
         $this->assertSame(2, $forkMock->getCallCount());
         $this->assertTrue(CMTest_TH::callProtectedMethod($manager, '_isRunning', [$event1]));
@@ -41,8 +41,8 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $this->assertTrue(CMTest_TH::callProtectedMethod($manager, '_isRunning', [$event2]));
 
         // both events finish, event 2 finishes with an error
-        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_WorkloadResult(null, null),
-                                                        3 => new CM_Process_WorkloadResult(null, new CM_Exception())]);
+        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_WorkloadResult(),
+                                                        3 => (new CM_Process_WorkloadResult())->setException(new CM_Exception())]);
         $manager->runEvents();
 
         $this->assertFalse(CMTest_TH::callProtectedMethod($manager, '_isRunning', [$event1]));


### PR DESCRIPTION
```
$ bin/cm s3export create-job
CM_Cli_Exception_InvalidArguments: Missing argument `device-path` in /Users/tomasz/projects/cargomedia/s3export_backup/vendor/cargomedia/cm/library/CM/Cli/Arguments.php on line 119
    0. {main} bin/cm:0
    1. CM_Cli_CommandManager->run(CM_Cli_Arguments) /Users/tomasz/projects/cargomedia/s3export_backup/vendor/cargomedia/cm/bin/cm:18
    2. CM_Process->fork(Closure) /Users/tomasz/projects/cargomedia/s3export_backup/vendor/cargomedia/cm/library/CM/Cli/CommandManager.php:184
    3. CM_Process->_fork(Closure, 1) /Users/tomasz/projects/cargomedia/s3export_backup/vendor/cargomedia/cm/library/CM/Process.php:34
    4. CM_Process_ForkHandler->runAndSendWorkload() /Users/tomasz/projects/cargomedia/s3export_backup/vendor/cargomedia/cm/library/CM/Process.php:191
    5. CM_Cli_CommandManager->{closure}() /Users/tomasz/projects/cargomedia/s3export_backup/vendor/cargomedia/cm/library/CM/Process/ForkHandler.php:58
    6. CM_Cli_Command->run(CM_Cli_Arguments, CM_InputStream_Readline, CM_OutputStream_Stream_StandardOutput, CM_OutputStream_Stream_StandardError) /Users/tomasz/projects/cargomedia/s3export_backup/vendor/cargomedia/cm/library/CM/Cli/CommandManager.php:178
    7. CM_Cli_Arguments->extractMethodParameters(ReflectionMethod) /Users/tomasz/projects/cargomedia/s3export_backup/vendor/cargomedia/cm/library/CM/Cli/Command.php:27
    8. CM_Cli_Arguments->_getParamValue(ReflectionParameter) /Users/tomasz/projects/cargomedia/s3export_backup/vendor/cargomedia/cm/library/CM/Cli/Arguments.php:56
```

@njam I think this started to happen after adding forking mechanism.