### PR TITLE
Adjust navigation to page anchors.

### DIFF
--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -118,6 +118,7 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
       }
       if (anchor) {
         anchor.scrollIntoView();
+        $(document).scrollTop($(document).scrollTop() - page.$el.offset().top);
       }
     }
   },

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -117,8 +117,7 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
         }
       }
       if (anchor) {
-        anchor.scrollIntoView();
-        $(document).scrollTop($(document).scrollTop() - page.$el.offset().top);
+        $(document).scrollTop($(anchor).offset().top - page.$el.offset().top);
       }
     }
   },

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -109,15 +109,9 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
     }
     if (window.location.hash) {
       var hash = window.location.hash.substring(1);
-      var anchor = document.getElementById(hash);
-      if (!anchor) {
-        var anchorList = document.getElementsByName(hash);
-        if (anchorList.length) {
-          anchor = anchorList[0];
-        }
-      }
-      if (anchor) {
-        $(document).scrollTop($(anchor).offset().top - page.$el.offset().top);
+      var $anchor = $('#' + hash).add('[name=' + hash + ']');
+      if ($anchor.length) {
+        $(document).scrollTop($anchor.offset().top - page.$el.offset().top);
       }
     }
   },


### PR DESCRIPTION
The problem comes when page has a position fixed header. The action `anchor.scrollIntoView();` does not count in the header and the anchor line gets hidden under the header.

The fix would be just to scroll up on the volume of the header's height. Will be this artificial solution inside CM acceptable to us? I'm asking because it is dictated by the integration of CM rather than the CM itself.

@njam @fauvel please share your thoughts.