### PR TITLE
Expect openx banner to contain tracking beacon even when no banner is delivered (as of Revive 3.1.0)

### DIFF
--- a/client-vendor/after-body/jquery.openx/jquery.openx.js
+++ b/client-vendor/after-body/jquery.openx/jquery.openx.js
@@ -73,7 +73,7 @@
 
       var loadCallback = function(html) {
         $element.html(html);
-        var hasContent = $.trim(html).length > 0;
+        var hasContent = ($element.children(':not([id*=beacon])').length > 0);
         $element.trigger('openx-loaded', {hasContent: hasContent});
 
         if (hasContent) {


### PR DESCRIPTION
paired with @kris-lab
@vogdb please review