### PR TITLE
move persistence deletion into _onDelete()

### DIFF
--- a/library/CM/Model/Abstract.php
+++ b/library/CM/Model/Abstract.php
@@ -86,9 +86,6 @@ abstract class CM_Model_Abstract extends CM_Class_Abstract implements CM_Compara
             $asset->_onModelDelete();
         }
         $this->_onDelete();
-        if ($persistence = $this->_getPersistence()) {
-            $persistence->delete($this->getType(), $this->getIdRaw());
-        }
         if ($cache = $this->_getCache()) {
             $cache->delete($this->getType(), $this->getIdRaw());
         }
@@ -308,6 +305,9 @@ abstract class CM_Model_Abstract extends CM_Class_Abstract implements CM_Compara
     }
 
     protected function _onDelete() {
+        if ($persistence = $this->_getPersistence()) {
+            $persistence->delete($this->getType(), $this->getIdRaw());
+        }
     }
 
     protected function _onDeleteAfter() {


### PR DESCRIPTION
Provides more control over the deletion-process of simple models.
This will allow us to keep persistent data by simply overwriting _onDelete()

Needed for https://github.com/cargomedia/sk/issues/1367

This essentially forces us to adhere to the principle of only performing persistence deletion in _onDelete() and putting other deletion-related code in the _onDeleteBefore()/After()-hooks, what we already *should* be doing anyway.

This is only one of several possible solutions to the problem, but I think it's the least complex one.