### PR TITLE
Refactor form / tableField layout

### DIFF
--- a/layout/default/css/form.less
+++ b/layout/default/css/form.less
@@ -367,34 +367,10 @@ input[type=checkbox].checkbox-switch {
     box-sizing: border-box;
     color: @fontColorStrong;
     padding-left: 2px;
-    .word_wrap;
-
-    @media (min-width: 600px) {
-      width: 100px;
-      float: left;
-      padding-top: (@heightInputText - @fontSize * @fontLineHeight) / 2;
-      text-align: right;
-    }
 
     &:after {
       content: ":";
     }
-
-    .CM_FormField_Abstract {
-      float: left;
-      margin-right: 3px;
-    }
-  }
-
-  > .input {
-
-    @media (min-width: 600px) {
-      margin-left: 110px;
-    }
-  }
-
-  &.noLabel > .input {
-    margin-left: 0;
   }
 }
 

--- a/layout/default/css/form.less
+++ b/layout/default/css/form.less
@@ -357,8 +357,8 @@ input[type=checkbox].checkbox-switch {
 }
 
 .formField, .formAction {
-  padding-top: 6px;
-  padding-bottom: 6px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .formField {

--- a/layout/default/css/form.less
+++ b/layout/default/css/form.less
@@ -18,7 +18,7 @@
 
 textarea.textinput {
   height: @heightInputTextarea;
-  padding-top: (@heightInputText - 2px - @fontSize*@fontLineHeight) / 2;
+  padding-top: (@heightInputText - @fontSize*@fontLineHeight) / 2;
   overflow: auto;
   resize: vertical;
 }

--- a/layout/default/css/form.less
+++ b/layout/default/css/form.less
@@ -32,12 +32,9 @@ textarea.textinput {
   ::-webkit-input-placeholder {
     color: @color;
   }
-  :-moz-placeholder {
-    // < FF 19
-    color: @color;
-  }
   ::-moz-placeholder {
     color: @color;
+    opacity: 1;
   }
   :-ms-input-placeholder {
     color: @color;

--- a/layout/default/css/form.less
+++ b/layout/default/css/form.less
@@ -357,9 +357,8 @@ input[type=checkbox].checkbox-switch {
 }
 
 .formField, .formAction {
-  box-sizing: border-box;
-  max-width: 100%;
-  padding: 6px;
+  padding-top: 6px;
+  padding-bottom: 6px;
 }
 
 .formField {

--- a/layout/default/css/tableField.less
+++ b/layout/default/css/tableField.less
@@ -1,9 +1,6 @@
 .tableField {
-  padding: 6px
-}
-
-.tableField:first-child {
-  border-width: 0;
+  padding-top: 6px;
+  padding-bottom: 6px;
 }
 
 .tableField > .label {

--- a/layout/default/css/tableField.less
+++ b/layout/default/css/tableField.less
@@ -1,6 +1,6 @@
 .tableField {
-  padding-top: 6px;
-  padding-bottom: 6px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .tableField > .label {

--- a/layout/default/css/tableField.less
+++ b/layout/default/css/tableField.less
@@ -1,5 +1,5 @@
 .tableField {
-  padding: 5px 0 5px 5px;
+  padding: 6px
 }
 
 .tableField:first-child {
@@ -7,23 +7,10 @@
 }
 
 .tableField > .label {
-  box-sizing: border-box;
   font-weight: bold;
   color: @fontColorStrong;
-
-  @media (min-width: @breakpointSmall) {
-    width: 100px;
-    float: left;
-    text-align: right;
-  }
 }
 
 .tableField > .label:after {
   content: ":";
-}
-
-.tableField > .value {
-  @media (min-width: @breakpointSmall) {
-    margin-left: 110px;
-  }
 }


### PR DESCRIPTION
As we've come to realise the current media-query approach for responsive forms / tableFields has limits (e.g. when used inside column layout). Element-queries didn't work out as expected. (See https://github.com/cargomedia/CM/pull/1673). 

New approach: 
- Always show label above field
- Use _placeholder_ where possible