### PR TITLE
FB-293 Remove request singleton

### DIFF
--- a/layout/default/Layout/Abstract/default.tpl
+++ b/layout/default/Layout/Abstract/default.tpl
@@ -56,7 +56,7 @@
   </head>
   <body id="{$viewResponse->getAutoId()}" class="{$viewResponse->getCssClasses()|implode:' '}">
 
-    {if CM_Http_Request_Abstract::hasInstance() && !CM_Http_Request_Abstract::getInstance()->isSupported()}
+    {if $request && !$request->isSupported()}
       <div id="browserNotSupported">
         <h2><span class="icon-warning"></span> {translate 'Your browser is no longer supported.'}</h2>
         <p>{translate 'We recommend upgrading to the latest Internet Explorer, Google Chrome, Firefox, or Opera. Click here for <a href="{$url}">more information</a>.' url='http://whatbrowser.org'}

--- a/library/CM/Form/Example.php
+++ b/library/CM/Form/Example.php
@@ -23,11 +23,8 @@ class CM_Form_Example extends CM_Form_Abstract {
     }
 
     public function prepare(CM_Frontend_Environment $environment, CM_Frontend_ViewResponse $viewResponse) {
-        if (CM_Http_Request_Abstract::hasInstance()) {
-            $ip = CM_Http_Request_Abstract::getInstance()->getIp();
-            if ($locationGuess = CM_Model_Location::findByIp($ip)) {
-                $this->getField('location')->setValue($locationGuess);
-            }
+        if ($location = $environment->getLocation()) {
+            $this->getField('location')->setValue($location);
         }
     }
 }

--- a/library/CM/FormField/Location.php
+++ b/library/CM/FormField/Location.php
@@ -22,7 +22,7 @@ class CM_FormField_Location extends CM_FormField_SuggestOne {
             'id'   => $location->getLevel() . '.' . $location->getId(),
             'name' => implode(', ', array_filter($names)),
             'img'  => $render->getUrlResource('layout',
-                    'img/flags/' . strtolower($location->getAbbreviation(CM_Model_Location::LEVEL_COUNTRY)) . '.png'),
+                'img/flags/' . strtolower($location->getAbbreviation(CM_Model_Location::LEVEL_COUNTRY)) . '.png'),
         );
     }
 
@@ -70,8 +70,7 @@ class CM_FormField_Location extends CM_FormField_SuggestOne {
     }
 
     protected function _getSuggestions($term, array $options, CM_Frontend_Render $render) {
-        $ip = CM_Http_Request_Abstract::getInstance()->getIp();
-        $locations = new CM_Paging_Location_Suggestions($term, $options['levelMin'], $options['levelMax'], CM_Model_Location::findByIp($ip), $options['scopeLocation']);
+        $locations = new CM_Paging_Location_Suggestions($term, $options['levelMin'], $options['levelMax'], $render->getEnvironment()->getLocation(), $options['scopeLocation']);
         $locations->setPage(1, 15);
         $out = array();
         foreach ($locations as $location) {

--- a/library/CM/Frontend/Render.php
+++ b/library/CM/Frontend/Render.php
@@ -19,19 +19,24 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
     /** @var CM_Frontend_Environment */
     private $_environment;
 
+    /** @var CM_Http_Request_Abstract|null */
+    private $_request;
+
     /** @var Smarty|null */
     private static $_smarty;
 
     /**
-     * @param CM_Frontend_Environment|null $environment
-     * @param boolean|null                 $languageRewrite
-     * @param CM_Service_Manager|null      $serviceManager
+     * @param CM_Frontend_Environment|null  $environment
+     * @param CM_Http_Request_Abstract|null $request
+     * @param boolean|null                  $languageRewrite
+     * @param CM_Service_Manager|null       $serviceManager
      */
-    public function __construct(CM_Frontend_Environment $environment = null, $languageRewrite = null, CM_Service_Manager $serviceManager = null) {
+    public function __construct(CM_Frontend_Environment $environment = null, CM_Http_Request_Abstract $request = null, $languageRewrite = null, CM_Service_Manager $serviceManager = null) {
         if (!$environment) {
             $environment = new CM_Frontend_Environment();
         }
         $this->_environment = $environment;
+        $this->_request = $request;
         $this->_languageRewrite = (bool) $languageRewrite;
         if (null === $serviceManager) {
             $serviceManager = CM_Service_Manager::getInstance();
@@ -64,6 +69,13 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
     }
 
     /**
+     * @return CM_Http_Request_Abstract|null
+     */
+    public function getRequest() {
+        return $this->_request;
+    }
+
+    /**
      * @param string        $path
      * @param array|null    $variables
      * @param string[]|null $compileId
@@ -79,6 +91,7 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
         $template = $this->_getSmarty()->createTemplate($path, null, join('_', $compileId));
         $template->assignGlobal('render', $this);
         $template->assignGlobal('viewer', $this->getViewer());
+        $template->assignGlobal('request', $this->getRequest());
         if ($variables) {
             $template->assign($variables);
         }

--- a/library/CM/Http/Response/Abstract.php
+++ b/library/CM/Http/Response/Abstract.php
@@ -104,7 +104,7 @@ abstract class CM_Http_Response_Abstract extends CM_Class_Abstract implements CM
         if (!$this->_render) {
             $languageRewrite = !$this->getViewer() && $this->getRequest()->getLanguageUrl();
             $environment = new CM_Frontend_Environment($this->getSite(), $this->getRequest()->getViewer(), $this->getRequest()->getLanguage(), null, null, $this->getRequest()->getLocation());
-            $this->_render = new CM_Frontend_Render($environment, $languageRewrite, $this->getServiceManager());
+            $this->_render = new CM_Frontend_Render($environment, $this->getRequest(), $languageRewrite, $this->getServiceManager());
         }
         return $this->_render;
     }

--- a/library/CM/Http/Response/Page.php
+++ b/library/CM/Http/Response/Page.php
@@ -90,18 +90,18 @@ class CM_Http_Response_Page extends CM_Http_Response_Abstract {
 
     protected function _processContentOrRedirect() {
         $render = $this->getRender();
-        if ($this->_site->getHost() !== $this->_request->getHost()) {
-            $path = CM_Util::link($this->_request->getPath(), $this->_request->getQuery());
-            $this->redirectUrl($render->getUrl($path, $this->_site));
+        if ($this->getSite()->getHost() !== $this->getRequest()->getHost()) {
+            $path = CM_Util::link($this->getRequest()->getPath(), $this->getRequest()->getQuery());
+            $this->redirectUrl($render->getUrl($path, $this->getSite()));
         }
-        if ($this->_request->getLanguageUrl() && $this->getViewer()) {
-            $path = CM_Util::link($this->_request->getPath(), $this->_request->getQuery());
-            $this->redirectUrl($render->getUrl($path, $this->_site));
-            $this->_request->setLanguageUrl(null);
+        if ($this->getRequest()->getLanguageUrl() && $this->getViewer()) {
+            $path = CM_Util::link($this->getRequest()->getPath(), $this->getRequest()->getQuery());
+            $this->redirectUrl($render->getUrl($path, $this->getSite()));
+            $this->getRequest()->setLanguageUrl(null);
         }
         if (!$this->getRedirectUrl()) {
-            $path = CM_Util::link($this->_request->getPath(), $this->_request->getQuery());
-            $render->getServiceManager()->getTrackings()->trackPageView($render->getEnvironment(), $path);
+            $path = CM_Util::link($this->getRequest()->getPath(), $this->getRequest()->getQuery());
+            $render->getServiceManager()->getTrackings()->trackPageView($render->getEnvironment(), $this->getRequest(), $path);
             $html = $this->_processPageLoop($this->getRequest());
             $this->_setContent($html);
         }
@@ -156,7 +156,7 @@ class CM_Http_Response_Page extends CM_Http_Response_Abstract {
         }, function (CM_Exception $ex, array $errorOptions) use ($request) {
             $this->getRender()->getGlobalResponse()->clear();
             /** @var CM_Page_Abstract $errorPage */
-            $errorPage =  $errorOptions['errorPage'];
+            $errorPage = $errorOptions['errorPage'];
             $request->setPath($errorPage::getPath());
             $request->setQuery(array());
             return false;

--- a/library/CM/Paging/Log/Abstract.php
+++ b/library/CM/Paging/Log/Abstract.php
@@ -70,8 +70,7 @@ abstract class CM_Paging_Log_Abstract extends CM_Paging_Abstract implements CM_T
         if ($fqdn = CM_Util::getFqdn()) {
             $metaInfo['fqdn'] = $fqdn;
         }
-        if (CM_Http_Request_Abstract::hasInstance()) {
-            $request = CM_Http_Request_Abstract::getInstance();
+        if ($request = CM_Http_Request_Abstract::factoryFromGlobals()) {
             $metaInfo['uri'] = $request->getUri();
             if ($viewer = $request->getViewer()) {
                 $metaInfo['userId'] = $viewer->getId();

--- a/library/CM/Service/Tracking/ClientInterface.php
+++ b/library/CM/Service/Tracking/ClientInterface.php
@@ -3,10 +3,11 @@
 interface CM_Service_Tracking_ClientInterface {
 
     /**
-     * @param CM_Frontend_Environment $environment
+     * @param CM_Frontend_Environment       $environment
+     * @param CM_Http_Request_Abstract|null $request
      * @return string
      */
-    public function getHtml(CM_Frontend_Environment $environment);
+    public function getHtml(CM_Frontend_Environment $environment, CM_Http_Request_Abstract $request = null);
 
     /**
      * @return string
@@ -25,10 +26,11 @@ interface CM_Service_Tracking_ClientInterface {
     public function trackAffiliate($requestClientId, $affiliateName);
 
     /**
-     * @param CM_Frontend_Environment $environment
-     * @param string                  $path
+     * @param CM_Frontend_Environment       $environment
+     * @param CM_Http_Request_Abstract|null $request
+     * @param string                        $path
      */
-    public function trackPageView(CM_Frontend_Environment $environment, $path);
+    public function trackPageView(CM_Frontend_Environment $environment, CM_Http_Request_Abstract $request = null, $path);
 
     /**
      * @param CM_Splittest_Fixture        $fixture

--- a/library/CM/Service/Trackings.php
+++ b/library/CM/Service/Trackings.php
@@ -12,10 +12,10 @@ class CM_Service_Trackings extends CM_Service_ManagerAware implements CM_Service
         $this->_trackingServiceNameList = $trackingServiceNameList;
     }
 
-    public function getHtml(CM_Frontend_Environment $environment) {
+    public function getHtml(CM_Frontend_Environment $environment, CM_Http_Request_Abstract $request = null) {
         $html = '';
         foreach ($this->getTrackingServiceList() as $trackingService) {
-            $html .= $trackingService->getHtml($environment);
+            $html .= $trackingService->getHtml($environment, $request);
         }
         return $html;
     }
@@ -40,9 +40,9 @@ class CM_Service_Trackings extends CM_Service_ManagerAware implements CM_Service
         }
     }
 
-    public function trackPageView(CM_Frontend_Environment $environment, $path) {
+    public function trackPageView(CM_Frontend_Environment $environment, CM_Http_Request_Abstract $request = null, $path) {
         foreach ($this->getTrackingServiceList() as $trackingService) {
-            $trackingService->trackPageView($environment, $path);
+            $trackingService->trackPageView($environment, $request, $path);
         }
     }
 

--- a/library/CM/Stream/Adapter/Video/Abstract.php
+++ b/library/CM/Stream/Adapter/Video/Abstract.php
@@ -5,11 +5,10 @@ abstract class CM_Stream_Adapter_Video_Abstract extends CM_Stream_Adapter_Abstra
     abstract public function synchronize();
 
     /**
-     * @param CM_Http_Request_Abstract $request
      * @throws CM_Exception_Invalid
      * return int
      */
-    abstract public function getServerId(CM_Http_Request_Abstract $request);
+    abstract public function getServerId();
 
     /**
      * @param CM_Model_Stream_Abstract $stream

--- a/library/CM/Stream/Adapter/Video/Wowza.php
+++ b/library/CM/Stream/Adapter/Video/Wowza.php
@@ -59,7 +59,8 @@ class CM_Stream_Adapter_Video_Wowza extends CM_Stream_Adapter_Video_Abstract {
     }
 
     public function getServerId() {
-        $ipAddress = long2ip(CM_Http_Request_Abstract::factoryFromGlobals()->getIp());
+        $request = CM_Http_Request_Abstract::factoryFromGlobals();
+        $ipAddress = $request ? long2ip($request->getIp()) : '';
 
         $servers = CM_Stream_Video::_getConfig()->servers;
         foreach ($servers as $serverId => $server) {

--- a/library/CM/Stream/Adapter/Video/Wowza.php
+++ b/library/CM/Stream/Adapter/Video/Wowza.php
@@ -58,8 +58,8 @@ class CM_Stream_Adapter_Video_Wowza extends CM_Stream_Adapter_Video_Abstract {
         }
     }
 
-    public function getServerId(CM_Http_Request_Abstract $request) {
-        $ipAddress = long2ip($request->getIp());
+    public function getServerId() {
+        $ipAddress = long2ip(CM_Http_Request_Abstract::factoryFromGlobals()->getIp());
 
         $servers = CM_Stream_Video::_getConfig()->servers;
         foreach ($servers as $serverId => $server) {

--- a/library/CM/Stream/Video.php
+++ b/library/CM/Stream/Video.php
@@ -63,8 +63,7 @@ class CM_Stream_Video extends CM_Stream_Abstract {
      * @return int
      */
     public static function rpc_publish($streamName, $clientKey, $start, $width, $height, $data) {
-        $request = CM_Http_Request_Abstract::getInstance();
-        $serverId = self::getInstance()->getAdapter()->getServerId($request);
+        $serverId = self::getInstance()->getAdapter()->getServerId();
 
         $channelId = self::getInstance()->getAdapter()->publish($streamName, $clientKey, $start, $width, $height, $serverId, $data);
         return $channelId;
@@ -76,7 +75,7 @@ class CM_Stream_Video extends CM_Stream_Abstract {
      */
     public static function rpc_unpublish($streamName) {
         $adapter = self::getInstance()->getAdapter();
-        $adapter->getServerId(CM_Http_Request_Abstract::getInstance());
+        $adapter->getServerId();
         $adapter->unpublish($streamName);
         return true;
     }
@@ -90,7 +89,7 @@ class CM_Stream_Video extends CM_Stream_Abstract {
      */
     public static function rpc_subscribe($streamName, $clientKey, $start, $data) {
         $adapter = self::getInstance()->getAdapter();
-        $adapter->getServerId(CM_Http_Request_Abstract::getInstance());
+        $adapter->getServerId();
         $adapter->subscribe($streamName, $clientKey, $start, $data);
         return true;
     }
@@ -102,7 +101,7 @@ class CM_Stream_Video extends CM_Stream_Abstract {
      */
     public static function rpc_unsubscribe($streamName, $clientKey) {
         $adapter = self::getInstance()->getAdapter();
-        $adapter->getServerId(CM_Http_Request_Abstract::getInstance());
+        $adapter->getServerId();
         $adapter->unsubscribe($streamName, $clientKey);
         return true;
     }

--- a/library/CMService/GoogleAnalytics/Client.php
+++ b/library/CMService/GoogleAnalytics/Client.php
@@ -147,7 +147,7 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
         return $js;
     }
 
-    public function getHtml(CM_Frontend_Environment $environment) {
+    public function getHtml(CM_Frontend_Environment $environment, CM_Http_Request_Abstract $request = null) {
         $scriptName = 'analytics.js';
         if ($environment->isDebug()) {
             $scriptName = 'analytics_debug.js';
@@ -164,8 +164,8 @@ EOF;
         $fieldList = [
             'cookieDomain' => $environment->getSite()->getHost(),
         ];
-        if (CM_Http_Request_Abstract::hasInstance()) {
-            $fieldList['clientId'] = (string) CM_Http_Request_Abstract::getInstance()->getClientId();
+        if ($request) {
+            $fieldList['clientId'] = (string) $request->getClientId();
         }
         if ($user = $environment->getViewer()) {
             $fieldList['userId'] = $user->getId();
@@ -184,7 +184,7 @@ EOF;
     public function trackAffiliate($requestClientId, $affiliateName) {
     }
 
-    public function trackPageView(CM_Frontend_Environment $environment, $path = null) {
+    public function trackPageView(CM_Frontend_Environment $environment, CM_Http_Request_Abstract $request = null, $path = null) {
         if ($viewer = $environment->getViewer()) {
             $this->setUserId($viewer->getId());
         }

--- a/library/CMService/KissMetrics/Client.php
+++ b/library/CMService/KissMetrics/Client.php
@@ -15,7 +15,7 @@ class CMService_KissMetrics_Client implements CM_Service_Tracking_ClientInterfac
         $this->_code = (string) $code;
     }
 
-    public function getHtml(CM_Frontend_Environment $environment) {
+    public function getHtml(CM_Frontend_Environment $environment, CM_Http_Request_Abstract $request = null) {
         $html = '<script type="text/javascript">';
         $html .= 'var _kmq = _kmq || [];';
         $html .= "var _kmk = _kmk || '" . $this->_getCode() . "';";
@@ -127,12 +127,12 @@ EOF;
         $kissMetrics->submit();
     }
 
-    public function trackPageView(CM_Frontend_Environment $environment, $path) {
+    public function trackPageView(CM_Frontend_Environment $environment, CM_Http_Request_Abstract $request = null, $path) {
         if ($viewer = $environment->getViewer()) {
             $this->setUserId($viewer->getId());
         }
-        if (CM_Http_Request_Abstract::hasInstance()) {
-            $this->setRequestClientId(CM_Http_Request_Abstract::getInstance()->getClientId());
+        if ($request) {
+            $this->setRequestClientId($request->getClientId());
         }
     }
 

--- a/tests/library/CM/Frontend/RenderTest.php
+++ b/tests/library/CM/Frontend/RenderTest.php
@@ -86,7 +86,7 @@ class CM_Frontend_RenderTest extends CMTest_TestCase {
 
         $render = new CM_Frontend_Render();
         $this->assertSame($baseUrl . '/test', $render->getUrlPage($page));
-        $render = new CM_Frontend_Render(null, true); // This should never happen in application, but lets test it
+        $render = new CM_Frontend_Render(null, null, true); // This should never happen in application, but lets test it
         $this->assertSame($baseUrl . '/test', $render->getUrlPage($page));
 
         $language = CMTest_TH::createLanguage('en');
@@ -94,7 +94,7 @@ class CM_Frontend_RenderTest extends CMTest_TestCase {
         $environment = new CM_Frontend_Environment(null, null, $language);
         $render = new CM_Frontend_Render($environment);
         $this->assertSame($baseUrl . '/test', $render->getUrlPage($page));
-        $render = new CM_Frontend_Render($environment, true);
+        $render = new CM_Frontend_Render($environment, null, true);
         $this->assertSame($baseUrl . '/en/test', $render->getUrlPage($page));
     }
 

--- a/tests/library/CM/Http/Response/PageTest.php
+++ b/tests/library/CM/Http/Response/PageTest.php
@@ -92,7 +92,7 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $this->assertContains('ga("send", "pageview", "/mock5")', $html);
         $this->assertContains('var _kmq = _kmq || [];', $html);
         $this->assertContains("var _kmk = _kmk || 'km123';", $html);
-        $clientId = CM_Http_Request_Abstract::getInstance()->getClientId();
+        $clientId = $response->getRequest()->getClientId();
         $this->assertContains("_kmq.push(['identify', 'Guest {$clientId}']);", $html);
         $this->assertNotContains("_kmq.push(['alias'", $html);
     }
@@ -112,7 +112,7 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $this->assertContains('ga("send", "pageview", "/mock5")', $html);
         $this->assertContains('var _kmq = _kmq || [];', $html);
         $this->assertContains("var _kmk = _kmk || 'km123';", $html);
-        $clientId = CM_Http_Request_Abstract::getInstance()->getClientId();
+        $clientId = $response->getRequest()->getClientId();
         $this->assertContains("_kmq.push(['identify', 'Guest {$clientId}']);", $html);
         $this->assertContains("_kmq.push(['identify', '1']);", $html);
         $this->assertContains("_kmq.push(['alias', 'Guest {$clientId}', '1']);", $html);

--- a/tests/library/CM/Layout/AbstractTest.php
+++ b/tests/library/CM/Layout/AbstractTest.php
@@ -18,7 +18,7 @@ class CM_Layout_AbstractTest extends CMTest_TestCase {
     public function testTrackingGuest() {
         $siteMock = $this->getMockSite('CM_Site_Abstract', null, array('url' => 'http://www.example.com'));
         $environment = new CM_Frontend_Environment($siteMock);
-        $render = new CM_Frontend_Render($environment, null, $this->_getServiceManager('ga123', 'km123'));
+        $render = new CM_Frontend_Render($environment, null, null, $this->_getServiceManager('ga123', 'km123'));
         $this->getMockForAbstractClass('CM_Layout_Abstract', array(), 'CM_Layout_Default');
         $pageMock = $this->getMockForAbstractClass('CM_Page_Abstract', array(), 'CM_Page_Mock' . uniqid());
         /** @var CM_Page_Abstract $pageMock */
@@ -41,7 +41,7 @@ class CM_Layout_AbstractTest extends CMTest_TestCase {
         $viewer->expects($this->any())->method('getLanguage')->will($this->returnValue(null));
         /** @var CM_Model_User $viewer */
         $environment = new CM_Frontend_Environment($site, $viewer);
-        $render = new CM_Frontend_Render($environment, null, $this->_getServiceManager('ga123', 'km123'));
+        $render = new CM_Frontend_Render($environment, null, null, $this->_getServiceManager('ga123', 'km123'));
         $this->getMockForAbstractClass('CM_Layout_Abstract', array(), 'CM_Layout_Default');
         $pageMock = $this->getMockForAbstractClass('CM_Page_Abstract', array(), 'CM_Page_Mock' . uniqid());
         /** @var CM_Page_Abstract $pageMock */
@@ -62,7 +62,7 @@ class CM_Layout_AbstractTest extends CMTest_TestCase {
         $language2 = CMTest_TH::createLanguage('de');
 
         $environment = new CM_Frontend_Environment($site, null, $language2, null, true);
-        $render = new CM_Frontend_Render($environment, true);
+        $render = new CM_Frontend_Render($environment, null, true);
 
         $this->getMockForAbstractClass('CM_Layout_Abstract', array(), 'CM_Layout_Default');
         $page = new CM_Page_Example();

--- a/tests/library/CM/Stream/Adapter/Video/WowzaTest.php
+++ b/tests/library/CM/Stream/Adapter/Video/WowzaTest.php
@@ -55,23 +55,23 @@ class CM_Stream_Adapter_Video_WowzaTest extends CMTest_TestCase {
     public function testGetServerId() {
         $adapter = new CM_Stream_Adapter_Video_Wowza();
         $ipAddresses = array('10.0.3.109', '10.0.3.108');
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/';
         foreach ($ipAddresses as $ipAddress) {
-            $request = $this->getMockForAbstractClass('CM_Http_Request_Abstract', array($ipAddress), 'CM_Http_Request_Mock', true, true, true, array('getIp',
-                'getHost'));
-            $request->expects($this->any())->method('getIp')->will($this->returnValue(sprintf('%u', ip2long($ipAddress))));
-            $this->assertEquals(1, $adapter->getServerId($request));
+            $_SERVER['REMOTE_ADDR'] = $ipAddress;
+            $this->assertEquals(1, $adapter->getServerId());
         }
         try {
-            $ipAddress = '66.66.66.66';
-            $request = $this->getMockForAbstractClass('CM_Http_Request_Abstract', array($ipAddress), 'CM_Http_Request_Mock', true, true, true, array('getIp',
-                'getHost'));
-            $request->expects($this->any())->method('getIp')->will($this->returnValue(sprintf('%u', ip2long($ipAddress))));
-            $adapter->getServerId($request);
+            $_SERVER['REMOTE_ADDR'] = '66.66.66.66';
+            $adapter->getServerId();
             $this->fail('Found server with incorrect ipAddress');
         } catch (CM_Exception_Invalid $e) {
             $this->assertContains('No video server', $e->getMessage());
             $this->assertContains('`66.66.66.66`', $e->getMessage());
         }
+        unset($_SERVER['REQUEST_METHOD']);
+        unset($_SERVER['REQUEST_URI']);
+        unset($_SERVER['REMOTE_ADDR']);
     }
 
     private function _generateWowzaData(array $streamChannels) {

--- a/tests/library/CMService/GoogleAnalytics/ClientTest.php
+++ b/tests/library/CMService/GoogleAnalytics/ClientTest.php
@@ -8,7 +8,7 @@ class CMService_GoogleAnalytics_ClientTest extends CMTest_TestCase {
         $environment = new CM_Frontend_Environment($site);
         $request = new CM_Http_Request_Get('/pseudo-request', ['Cookie' => 'clientId=222']);
 
-        $html = $googleAnalytics->getHtml($environment);
+        $html = $googleAnalytics->getHtml($environment, $request);
         $this->assertContains('ga("create", "key123", {"cookieDomain":"www.my-website.net","clientId":"222"}', $html);
     }
 
@@ -19,7 +19,7 @@ class CMService_GoogleAnalytics_ClientTest extends CMTest_TestCase {
         $environment = new CM_Frontend_Environment($site, $viewer);
         $request = new CM_Http_Request_Get('/pseudo-request', ['Cookie' => 'clientId=222']);
 
-        $html = $googleAnalytics->getHtml($environment);
+        $html = $googleAnalytics->getHtml($environment, $request);
         $this->assertContains('ga("create", "key123", {"cookieDomain":"www.my-website.net","clientId":"222","userId":' . $viewer->getId() . '}',
             $html);
     }
@@ -117,7 +117,7 @@ class CMService_GoogleAnalytics_ClientTest extends CMTest_TestCase {
 
         $viewer = CMTest_TH::createUser();
         $environmentWithViewer = new CM_Frontend_Environment(null, $viewer);
-        $googleAnalytics->trackPageView($environmentWithViewer, '/foo');
+        $googleAnalytics->trackPageView($environmentWithViewer, null, '/foo');
         $js = $googleAnalytics->getJs($environment);
         $this->assertContains('ga("set", "userId", "' . $viewer->getId() . '")', $js);
     }


### PR DESCRIPTION
We want the tracking services to store the clientId on the response's request object and not on the request singleton, otherwise the cookie isn't being sent to the client. To avoid such situations in the future (which are difficult to debug), I suggest to remove the request singleton altogether, and pass the request object all the way via the `CM_Frontend_Render`.
