### PR TITLE
Wrap child process code in fork() in try/catch

### DIFF
--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -174,11 +174,15 @@ class CM_Process {
             $this->_forkHandlerList[$sequence] = new CM_Process_ForkHandler($pid, $workload, $sockets[1]);
         } else {
             // child
-            fclose($sockets[1]);
-            $this->_reset();
-            $forkHandler = new CM_Process_ForkHandler($this->getProcessId(), $workload, $sockets[0]);
-            $forkHandler->runAndSendWorkload();
-            $forkHandler->closeIpcStream();
+            try {
+                fclose($sockets[1]);
+                $this->_reset();
+                $forkHandler = new CM_Process_ForkHandler($this->getProcessId(), $workload, $sockets[0]);
+                $forkHandler->runAndSendWorkload();
+                $forkHandler->closeIpcStream();
+            } catch (Exception $e) {
+                CM_Bootloader::getInstance()->getExceptionHandler()->handleException($e);
+            }
             exit;
         }
     }


### PR DESCRIPTION
Otherwise an exception in the child process might lead to catch-blocks from the parent process to be executed (that were copied during forking).

Paired with @alexispeter
@tomaszdurka fyi