### PR TITLE
Reset serviceManager instances on forking

### DIFF
--- a/library/CM/Bootloader.php
+++ b/library/CM/Bootloader.php
@@ -174,7 +174,7 @@ class CM_Bootloader {
     protected function _registerServices() {
         $serviceManager = CM_Service_Manager::getInstance();
 
-        $serviceManager->registerInstance('debug', new CM_Debug($this->isDebug()));
+        $serviceManager->register('debug', 'CM_Debug', ['enabled' => $this->isDebug()]);
         $serviceManager->register('filesystems', 'CM_Service_Filesystems');
         $serviceManager->register('filesystem-tmp', 'CM_File_Filesystem', array(
             new CM_File_Filesystem_Adapter_Local($this->getDirTmp()),

--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -177,6 +177,9 @@ class CM_Process {
             try {
                 fclose($sockets[1]);
                 $this->_reset();
+                $serviceManager = CM_Service_Manager::getInstance();
+                $serviceManager->resetInstances();
+                $serviceManager->registerInstance('debug', new CM_Debug(CM_Bootloader::getInstance()->isDebug()));
                 $forkHandler = new CM_Process_ForkHandler($this->getProcessId(), $workload, $sockets[0]);
                 $forkHandler->runAndSendWorkload();
                 $forkHandler->closeIpcStream();

--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -177,9 +177,7 @@ class CM_Process {
             try {
                 fclose($sockets[1]);
                 $this->_reset();
-                $serviceManager = CM_Service_Manager::getInstance();
-                $serviceManager->resetInstances();
-                $serviceManager->registerInstance('debug', new CM_Debug(CM_Bootloader::getInstance()->isDebug()));
+                CM_Service_Manager::getInstance()->resetServiceInstances();
                 $forkHandler = new CM_Process_ForkHandler($this->getProcessId(), $workload, $sockets[0]);
                 $forkHandler->runAndSendWorkload();
                 $forkHandler->closeIpcStream();

--- a/library/CM/Service/Manager.php
+++ b/library/CM/Service/Manager.php
@@ -107,6 +107,10 @@ class CM_Service_Manager extends CM_Class_Abstract {
         $this->_serviceInstanceList[$serviceName] = $instance;
     }
 
+    public function resetInstances() {
+        $this->_serviceInstanceList = [];
+    }
+
     /**
      * @param string $serviceName
      */

--- a/library/CM/Service/Manager.php
+++ b/library/CM/Service/Manager.php
@@ -107,7 +107,7 @@ class CM_Service_Manager extends CM_Class_Abstract {
         $this->_serviceInstanceList[$serviceName] = $instance;
     }
 
-    public function resetInstances() {
+    public function resetServiceInstances() {
         $this->_serviceInstanceList = [];
     }
 


### PR DESCRIPTION
To avoid sharing mysql connection between processes.
Addressing https://github.com/cargomedia/puppet-cargomedia/issues/724

After forking, in the child call something like:
```php
CM_Service_Manager::getInstance()->resetInstances();
```

Can add an acceptance test with something like this:
```php
$assert = function ($expected, $actual) {
    if ($expected !== $actual) {
        throw new Exception('Assertion failed: `' . $expected . '` !== `' . $actual . '`');
    }
};

$mysql = CM_Service_Manager::getInstance()->getDatabases()->getMaster();
$mysql->setBuffered(false);

$process = CM_Process::getInstance();
$process->fork(function () use ($assert, $mysql) {
    for ($i = 0; $i < 1000; $i++) {
        $result2 = $mysql->createStatement('SELECT "bar"')->execute()->fetchColumn();
        $assert('bar', $result2);
    }
});

for ($i = 0; $i < 1000; $i++) {
    $result1 = $mysql->createStatement('SELECT "foo"')->execute()->fetchColumn();
    $assert('foo', $result1);
}

$process->waitForChildren();
```

@alexispeter for you?