### PR TITLE
Destroy jquery.autosize

### DIFF
--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -311,6 +311,14 @@ var CM_App = CM_Class_Abstract.extend({
       $dom.find('.fancySelect').fancySelect();
     },
     /**
+     * @param {jQuery} $dom
+     */
+    teardown: function($dom) {
+      $dom.find('.timeago').timeago('dispose');
+      $dom.find('textarea.autosize, .autosize textarea').trigger('autosize.destroy');
+      $dom.find('.showTooltip[title]').tooltip('destroy');
+    },
+    /**
      * @param {jQuery} $element
      * @param {Function} [success] fn(MediaElement, Element)
      * @param {Boolean} [preferPlugins]

--- a/library/CM/Component/Abstract.js
+++ b/library/CM/Component/Abstract.js
@@ -9,6 +9,10 @@ var CM_Component_Abstract = CM_View_Abstract.extend({
     CM_View_Abstract.prototype._ready.call(this);
 
     cm.dom.setup(this.$());
+
+    this.on('destruct', function() {
+      cm.dom.teardown(this.$());
+    })
   },
 
   /**


### PR DESCRIPTION
Via https://github.com/jackmoore/autosize/issues/210
We currently don't destroy the autosize plugin when it's not used anymore.
Should be done on view destruction, and maybe set up in `cm.dom.setup`?

```
$('textarea').trigger('autosize.destroy');
```

@vogdb thoughts?