### PR TITLE
Move mail delivery agent configuration to protected function

### DIFF
--- a/library/CM/Mail.php
+++ b/library/CM/Mail.php
@@ -364,7 +364,6 @@ class CM_Mail extends CM_View_Abstract implements CM_Typed {
 
     /**
      * @throws CM_Exception_Invalid
-     * @throws phpmailerException
      */
     protected function _send($subject, $text, $html = null) {
         if (!self::_getConfig()->send) {

--- a/library/CM/Mail.php
+++ b/library/CM/Mail.php
@@ -364,7 +364,6 @@ class CM_Mail extends CM_View_Abstract implements CM_Typed {
 
     /**
      * @throws CM_Exception_Invalid
-     * @throws CM_Exception_NotAllowed
      * @throws phpmailerException
      */
     protected function _send($subject, $text, $html = null) {

--- a/library/CM/Mail.php
+++ b/library/CM/Mail.php
@@ -355,6 +355,18 @@ class CM_Mail extends CM_View_Abstract implements CM_Typed {
         return $renderAdapter->fetch();
     }
 
+    /**
+     * @return string|null
+     */
+    protected function _getMailDeliveryAgent() {
+        return $this->_getConfig()->mailDeliveryAgent;
+    }
+
+    /**
+     * @throws CM_Exception_Invalid
+     * @throws CM_Exception_NotAllowed
+     * @throws phpmailerException
+     */
     protected function _send($subject, $text, $html = null) {
         if (!self::_getConfig()->send) {
             $this->_log($subject, $text);
@@ -374,7 +386,7 @@ class CM_Mail extends CM_View_Abstract implements CM_Typed {
             foreach ($this->_bcc as $bcc) {
                 $mail->AddBCC($bcc['address'], $bcc['name']);
             }
-            if ($mailDeliveryAgent = $this->_getConfig()->mailDeliveryAgent) {
+            if ($mailDeliveryAgent = $this->_getMailDeliveryAgent()) {
                 $mail->AddCustomHeader('X-MDA: ' . $mailDeliveryAgent);
             }
             $mail->SetFrom($this->_sender['address'], $this->_sender['name']);


### PR DESCRIPTION
Right now part of  `_send`.. awkward to overwrite in subclasses

Better: separate function

