### PR TITLE
Define "display" and "start_url" in manifest.json

### DIFF
--- a/layout/default/resource/manifest.json.smarty
+++ b/layout/default/resource/manifest.json.smarty
@@ -1,5 +1,7 @@
 {
 	"name": "{$render->getSite()->getName()}",
+	"display": "standalone",
+	"start_url": "/",
 	"icons": [
 		{
 			"src": "{resourceUrl path='img/meta/android-chrome-36x36.png' type='layout'}",


### PR DESCRIPTION
According to http://updates.html5rocks.com/2014/11/Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android

Untested yet, should test in Chrome on Android.