### PR TITLE
Don't specify density for PNG in app manifest

### DIFF
--- a/layout/default/resource/manifest.json.smarty
+++ b/layout/default/resource/manifest.json.smarty
@@ -6,38 +6,32 @@
 		{
 			"src": "{resourceUrl path='img/meta/android-chrome-36x36.png' type='layout'}",
 			"sizes": "36x36",
-			"type": "image/png",
-			"density": "0.75"
+			"type": "image/png"
 		},
 		{
 			"src": "{resourceUrl path='img/meta/android-chrome-48x48.png' type='layout'}",
 			"sizes": "48x48",
-			"type": "image/png",
-			"density": "1.0"
+			"type": "image/png"
 		},
 		{
 			"src": "{resourceUrl path='img/meta/android-chrome-72x72.png' type='layout'}",
 			"sizes": "72x72",
-			"type": "image/png",
-			"density": "1.5"
+			"type": "image/png"
 		},
 		{
 			"src": "{resourceUrl path='img/meta/android-chrome-96x96.png' type='layout'}",
 			"sizes": "96x96",
-			"type": "image/png",
-			"density": "2.0"
+			"type": "image/png"
 		},
 		{
 			"src": "{resourceUrl path='img/meta/android-chrome-144x144.png' type='layout'}",
 			"sizes": "144x144",
-			"type": "image/png",
-			"density": "3.0"
+			"type": "image/png"
 		},
 		{
 			"src": "{resourceUrl path='img/meta/android-chrome-192x192.png' type='layout'}",
 			"sizes": "192x192",
-			"type": "image/png",
-			"density": "4.0"
+			"type": "image/png"
 		}
 	]
 }


### PR DESCRIPTION
I don't think we should specify a *density* for PNGs, as they all are suited only for a density of 1.
Afaik the browser itself picks the right version based on the screen size and density.

See https://w3c.github.io/manifest/#icon-object-and-its-members

@vogdb please review
@christopheschwyzer fyi