### PR TITLE
Fix split test setters

### DIFF
--- a/library/CM/Model/Splittest.php
+++ b/library/CM/Model/Splittest.php
@@ -39,10 +39,12 @@ class CM_Model_Splittest extends CM_Model_Abstract implements CM_Service_Manager
 
     /**
      * @param int $timestamp
+     * @return CM_Model_Splittest
      */
     public function setCreated($timestamp) {
         $timestamp = (int) $timestamp;
-        $this->_set('createStamp', $timestamp);
+        CM_Db_Db::update('cm_splittest', ['createStamp' => $timestamp], ['id' => $this->getId()]);
+        return $this->_change();
     }
 
     /**
@@ -54,10 +56,12 @@ class CM_Model_Splittest extends CM_Model_Abstract implements CM_Service_Manager
 
     /**
      * @param bool $optimized
+     * @return CM_Model_Splittest
      */
     public function setOptimized($optimized) {
         $optimized = (bool) $optimized;
-        $this->_set('optimized', $optimized);
+        CM_Db_Db::update('cm_splittest', ['optimized' => $optimized], ['id' => $this->getId()]);
+        return $this->_change();
     }
 
     /**

--- a/tests/library/CM/Model/SplittestTest.php
+++ b/tests/library/CM/Model/SplittestTest.php
@@ -15,7 +15,7 @@ class CM_Model_SplittestTest extends CMTest_TestCase {
         $this->assertInstanceOf('CM_Model_Splittest', $test);
 
         try {
-            $test = CM_Model_Splittest::create('foo', ['v1', 'v2']);
+            CM_Model_Splittest::create('foo', ['v1', 'v2']);
             $this->fail('Could create duplicate splittest');
         } catch (CM_Exception $e) {
             $this->assertTrue(true);
@@ -37,7 +37,25 @@ class CM_Model_SplittestTest extends CMTest_TestCase {
         $time = time();
         /** @var CM_Model_Splittest $test */
         $test = CM_Model_Splittest::create('foo', ['v1', 'v2']);
-        $this->assertGreaterThanOrEqual($time, $test->getCreated());
+        $this->assertSame($time, $test->getCreated());
+    }
+
+    public function testSetCreated() {
+        $time = time();
+        /** @var CM_Model_Splittest $test */
+        $test = CM_Model_Splittest::create('foo', ['v1', 'v2']);
+        $test->setCreated($time + 10);
+        $test = new CM_Model_Splittest($test->getName());
+        $this->assertSame($time + 10, $test->getCreated());
+    }
+
+    public function testSetOptimized() {
+        /** @var CM_Model_Splittest $test */
+        $test = CM_Model_Splittest::create('foo', ['v1']);
+        $this->assertSame(false, $test->getOptimized());
+        $test->setOptimized(true);
+        $test = new CM_Model_Splittest($test->getName());
+        $this->assertSame(true, $test->getOptimized());
     }
 
     public function testFlush() {

--- a/tests/library/CM/Model/SplittestTest.php
+++ b/tests/library/CM/Model/SplittestTest.php
@@ -45,7 +45,8 @@ class CM_Model_SplittestTest extends CMTest_TestCase {
         /** @var CM_Model_Splittest $test */
         $test = CM_Model_Splittest::create('foo', ['v1', 'v2']);
         $test->setCreated($time + 10);
-        $test = new CM_Model_Splittest($test->getName());
+        CMTest_TH::clearCache();
+        CMTest_TH::reinstantiateModel($test);
         $this->assertSame($time + 10, $test->getCreated());
     }
 
@@ -54,7 +55,8 @@ class CM_Model_SplittestTest extends CMTest_TestCase {
         $test = CM_Model_Splittest::create('foo', ['v1']);
         $this->assertSame(false, $test->getOptimized());
         $test->setOptimized(true);
-        $test = new CM_Model_Splittest($test->getName());
+        CMTest_TH::clearCache();
+        CMTest_TH::reinstantiateModel($test);
         $this->assertSame(true, $test->getOptimized());
     }
 


### PR DESCRIPTION
I've copy-pasted the bug in `setCreated()`... Fixed by updating the data manually in the database. Using `CM_Model_StorageAdapter_Database` would be nice, too – but let's keep it for the next step... 