### PR TITLE
Move GA tracking from end of <body> to beginning

### DIFF
--- a/layout/default/Layout/Abstract/default.tpl
+++ b/layout/default/Layout/Abstract/default.tpl
@@ -54,6 +54,8 @@
     {block name='head'}{/block}
   </head>
   <body id="{$viewResponse->getAutoId()}" class="{$viewResponse->getCssClasses()|implode:' '}">
+    {capture name='pageContent'}{$renderAdapter->fetchPage()}{/capture}
+
     {$render->getServiceManager()->getTrackings()->getHtml($render->getEnvironment())}
 
     {if CM_Http_Request_Abstract::hasInstance() && !CM_Http_Request_Abstract::getInstance()->isSupported()}
@@ -67,7 +69,7 @@
     {block name='body-start'}{/block}
     <div id="body-container">
       {block name='body'}
-        {$renderAdapter->fetchPage()}
+        {$smarty.capture.pageContent}
       {/block}
     </div>
     {if CM_Bootloader::getInstance()->isDebug()}{component name='CM_Component_Debug'}{/if}

--- a/layout/default/Layout/Abstract/default.tpl
+++ b/layout/default/Layout/Abstract/default.tpl
@@ -4,8 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge; requiresActiveX=true">
     {if isset($pageDescription)}<meta name="description" content="{$pageDescription|escape}">{/if}
-    {if isset($pageKeywords)}
-      <meta name="keywords" content="{$pageKeywords|escape}">{/if}
+    {if isset($pageKeywords)}<meta name="keywords" content="{$pageKeywords|escape}">{/if}
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-title" content="{$render->getSite()->getName()|escape}">
@@ -55,6 +54,7 @@
     {block name='head'}{/block}
   </head>
   <body id="{$viewResponse->getAutoId()}" class="{$viewResponse->getCssClasses()|implode:' '}">
+    {$render->getServiceManager()->getTrackings()->getHtml($render->getEnvironment())}
 
     {if CM_Http_Request_Abstract::hasInstance() && !CM_Http_Request_Abstract::getInstance()->isSupported()}
       <div id="browserNotSupported">
@@ -77,7 +77,6 @@
       {resourceJs file="translations/{CM_Model_Language::getVersionJavascript()}.js" type="library"}
     {/if}
     {$render->getGlobalResponse()->getHtml()}
-    {$render->getServiceManager()->getTrackings()->getHtml($render->getEnvironment())}
     {block name='body-end'}{/block}
   </body>
 </html>


### PR DESCRIPTION
@tomaszdurka please review

This is according to GA universal tracking guidelines.
Problems could arise if we'd modify the tracking instance during page rendering. But as far as I can see we only do so in `prepareResponse()`, so it should be fine.