### PR TITLE
Rebuild test to ignore forks' terminations order

### DIFF
--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -2,6 +2,7 @@
 
 class CM_Process {
 
+    const FORKING_DELAY = 200;
     const RESPAWN_TIMEOUT = 10;
 
     /** @var Closure|null */
@@ -165,6 +166,7 @@ class CM_Process {
             throw new CM_Exception('Cannot open stream socket pair');
         }
         $pid = pcntl_fork();
+        usleep(self::FORKING_DELAY);
         if ($pid === -1) {
             throw new CM_Exception('Could not spawn child process');
         }


### PR DESCRIPTION
Fixes #1285 