### PR TITLE
Add optional getter closure for Cache::get()

### DIFF
--- a/library/CM/Cache/Abstract.php
+++ b/library/CM/Cache/Abstract.php
@@ -5,12 +5,28 @@ abstract class CM_Cache_Abstract extends CM_Class_Abstract {
     /** @var CM_Cache_Storage_Abstract */
     protected $_storage;
 
-    public function __construct() {
-        $storageClassName = static::_getConfig()->storage;
-        if (!is_subclass_of($storageClassName, 'CM_Cache_Storage_Abstract')) {
-            throw new CM_Exception('Invalid cache storage: `' . $storageClassName . '`');
+    /** @var int */
+    protected $_lifetime;
+
+    /**
+     * @param CM_Cache_Storage_Abstract|null $storage
+     * @param int|null                       $lifetime
+     * @throws CM_Exception
+     */
+    public function __construct(CM_Cache_Storage_Abstract $storage = null, $lifetime = null) {
+        if (null === $storage) {
+            $storageClassName = static::_getConfig()->storage;
+            if (!is_subclass_of($storageClassName, 'CM_Cache_Storage_Abstract')) {
+                throw new CM_Exception('Invalid cache storage: `' . $storageClassName . '`');
+            }
+            $storage = new $storageClassName();
         }
-        $this->_storage = new $storageClassName();
+        $this->_storage = $storage;
+
+        if (null === $lifetime) {
+            $lifetime = static::_getConfig()->lifetime;
+        }
+        $this->_lifetime = (int) $lifetime;
     }
 
     /**
@@ -20,7 +36,7 @@ abstract class CM_Cache_Abstract extends CM_Class_Abstract {
      */
     public final function set($key, $value, $lifeTime = null) {
         if (!$lifeTime) {
-            $lifeTime = static::_getConfig()->lifetime;
+            $lifeTime = $this->_lifetime;
         }
         $this->_getStorage()->set($key, $value, $lifeTime);
     }

--- a/library/CM/Cache/Abstract.php
+++ b/library/CM/Cache/Abstract.php
@@ -42,11 +42,19 @@ abstract class CM_Cache_Abstract extends CM_Class_Abstract {
     }
 
     /**
-     * @param string $key
+     * @param string       $key
+     * @param Closure|null $getter fn(string $key)
      * @return mixed|false
      */
-    public final function get($key) {
-        return $this->_getStorage()->get($key);
+    public final function get($key, Closure $getter = null) {
+        $value = $this->_getStorage()->get($key);
+        if (false === $value && null !== $getter) {
+            $value = $getter($key);
+            if (false !== $value) {
+                $this->set($key, $value);
+            }
+        }
+        return $value;
     }
 
     /**

--- a/tests/library/CM/Cache/AbstractTest.php
+++ b/tests/library/CM/Cache/AbstractTest.php
@@ -37,4 +37,37 @@ class CM_Cache_AbstractTest extends CMTest_TestCase {
         $this->assertFalse($cache->getTagged('tag1', 'key2'));
         $this->assertEquals('data3', $cache->getTagged('tag2', 'key3'));
     }
+
+    public function testGetWithGetter() {
+        $cache = $this->mockClass('CM_Cache_Abstract')->newInstance([new CM_Cache_Storage_Runtime(), 30]);
+        /** @var CM_Cache_Abstract $cache */
+
+        $getterCallCount = 0;
+
+        $getter = function ($key) use (&$getterCallCount) {
+            $this->assertSame('foo', $key);
+            $getterCallCount++;
+            return 12;
+        };
+
+        $this->assertSame(12, $cache->get('foo', $getter));
+        $this->assertSame(12, $cache->get('foo', $getter));
+        $this->assertSame(1, $getterCallCount);
+    }
+
+    public function testGetWithGetterReturningFalse() {
+        $cache = $this->mockClass('CM_Cache_Abstract')->newInstance([new CM_Cache_Storage_Runtime(), 30]);
+        /** @var CM_Cache_Abstract $cache */
+
+        $getterCallCount = 0;
+
+        $getter = function () use (&$getterCallCount) {
+            $getterCallCount++;
+            return false;
+        };
+
+        $this->assertSame(false, $cache->get('foo', $getter));
+        $this->assertSame(false, $cache->get('foo', $getter));
+        $this->assertSame(2, $getterCallCount);
+    }
 }

--- a/tests/library/CM/Cache/AbstractTest.php
+++ b/tests/library/CM/Cache/AbstractTest.php
@@ -1,9 +1,11 @@
 <?php
 
-class CM_Cache_SharedTest extends CMTest_TestCase {
+class CM_Cache_AbstractTest extends CMTest_TestCase {
 
     public function testKeys() {
-        $cache = CM_Cache_Shared::getInstance();
+        $cache = $this->mockClass('CM_Cache_Abstract')->newInstance([new CM_Cache_Storage_Runtime(), 30]);
+        /** @var CM_Cache_Abstract $cache */
+
         $cache->set('key1', 'data1');
         $cache->set('key2', 'data2');
         $this->assertEquals('data1', $cache->get('key1'));
@@ -17,7 +19,9 @@ class CM_Cache_SharedTest extends CMTest_TestCase {
     }
 
     public function testTagged() {
-        $cache = CM_Cache_Shared::getInstance();
+        $cache = $this->mockClass('CM_Cache_Abstract')->newInstance([new CM_Cache_Storage_Runtime(), 30]);
+        /** @var CM_Cache_Abstract $cache */
+
         $cache->setTagged('tag1', 'key1', 'data1');
         $cache->setTagged('tag1', 'key2', 'data2');
         $cache->setTagged('tag2', 'key3', 'data3');


### PR DESCRIPTION
To simplify cache usages for when the cache-key is used in only one function or class.
Together with the existing `Cache::key()` function some code could be changed from:
```php
$cache = CM_Cache_Shared::getInstance();
$cacheKey = CM_CacheConst::Some_Constant . '_bar:' . $bar;
if (false === ($result = $cache->get($cacheKey))) {
    $result = 12;
    $cache->set($cacheKey, $result);
}
```
to:
```php
$cache = CM_Cache_Shared::getInstance();
$result = $cache->get($cache->key(__CLASS__, 'foo', $bar), function () {
    return 12;
});
```

@tomaszdurka @dlondero @mariansollmann please review