### PR TITLE
Epom Ad Provider: Remove "zoneId"

### DIFF
--- a/client-vendor/after-body/jquery.epom/jquery.epom.js
+++ b/client-vendor/after-body/jquery.epom/jquery.epom.js
@@ -21,7 +21,7 @@
 
   $.fn.epom = function() {
     return this.each(function() {
-      var zoneId = $(this).data('zone-id');
+      var zoneName = $(this).data('zone-name');
       var variables = $(this).data('variables');
       var src = (location.protocol == 'https:' ? 'https:' : 'http:') + '//n181adserv.com\/ads-api';
       var $element = $(this);
@@ -34,12 +34,12 @@
 
           if (hasContent) {
             $element.addClass('advertisement-hasContent');
-            trackEvent('Banner', 'Impression', 'zone-' + zoneId);
+            trackEvent('Banner', 'Impression', 'zone-' + zoneName);
             var $link = $element.find('a[href]');
             if ($element.is(':visible') && $link.length > 0) {
-              trackEvent('Banner', 'Impression-Clickable', 'zone-' + zoneId);
+              trackEvent('Banner', 'Impression-Clickable', 'zone-' + zoneName);
               $link.on('click', function() {
-                trackEvent('Banner', 'Click', 'zone-' + zoneId);
+                trackEvent('Banner', 'Click', 'zone-' + zoneName);
               });
             }
           }

--- a/library/CM/Adprovider.php
+++ b/library/CM/Adprovider.php
@@ -27,7 +27,7 @@ class CM_Adprovider extends CM_Class_Abstract {
         }
         $adapterClassName = (string) $zoneData['adapter'];
         unset($zoneData['adapter']);
-        return (string) $this->_getAdapter($adapterClassName)->getHtml($zoneData, $variables);
+        return (string) $this->_getAdapter($adapterClassName)->getHtml($zoneName, $zoneData, $variables);
     }
 
     /**

--- a/library/CM/AdproviderAdapter/Abstract.php
+++ b/library/CM/AdproviderAdapter/Abstract.php
@@ -11,9 +11,10 @@ abstract class CM_AdproviderAdapter_Abstract extends CM_Class_Abstract {
     }
 
     /**
+     * @param string    $zoneName
      * @param array    $zoneData
      * @param string[] $variables
      * @return string
      */
-    abstract public function getHtml($zoneData, array $variables);
+    abstract public function getHtml($zoneName, $zoneData, array $variables);
 }

--- a/library/CM/AdproviderAdapter/Abstract.php
+++ b/library/CM/AdproviderAdapter/Abstract.php
@@ -11,7 +11,7 @@ abstract class CM_AdproviderAdapter_Abstract extends CM_Class_Abstract {
     }
 
     /**
-     * @param string    $zoneName
+     * @param string   $zoneName
      * @param array    $zoneData
      * @param string[] $variables
      * @return string

--- a/library/CM/AdproviderAdapter/Epom.php
+++ b/library/CM/AdproviderAdapter/Epom.php
@@ -2,7 +2,7 @@
 
 class CM_AdproviderAdapter_Epom extends CM_AdproviderAdapter_Abstract {
 
-    public function getHtml($zoneData, array $variables) {
+    public function getHtml($zoneName, $zoneData, array $variables) {
         $zoneId = CM_Util::htmlspecialchars($zoneData['zoneId']);
         $variables = $this->_variableKeysToUnderscore($variables);
         $variables['key'] = $zoneData['accessKey'];

--- a/library/CM/AdproviderAdapter/Epom.php
+++ b/library/CM/AdproviderAdapter/Epom.php
@@ -7,7 +7,7 @@ class CM_AdproviderAdapter_Epom extends CM_AdproviderAdapter_Abstract {
         $variables = $this->_variableKeysToUnderscore($variables);
         $variables['key'] = $zoneData['accessKey'];
 
-        $html = '<div id="epom-' . $zoneId . '" class="epom-ad" data-zone-id="' . $zoneId . '" data-variables="' .
+        $html = '<div id="epom-' . $zoneId . '" class="epom-ad" data-zone-name="' . $zoneName . '" data-variables="' .
             CM_Util::htmlspecialchars(json_encode($variables, JSON_FORCE_OBJECT)) . '"></div>';
         return $html;
     }

--- a/library/CM/AdproviderAdapter/Openx.php
+++ b/library/CM/AdproviderAdapter/Openx.php
@@ -9,7 +9,7 @@ class CM_AdproviderAdapter_Openx extends CM_AdproviderAdapter_Abstract {
         return self::_getConfig()->host;
     }
 
-    public function getHtml($zoneData, array $variables) {
+    public function getHtml($zoneName, $zoneData, array $variables) {
         if (!array_key_exists('zoneId', $zoneData)) {
             throw new CM_Exception_Invalid('Missing `zoneId`');
         }

--- a/tests/library/CM/AdproviderAdapter/EpomTest.php
+++ b/tests/library/CM/AdproviderAdapter/EpomTest.php
@@ -6,9 +6,9 @@ class CM_AdproviderAdapter_EpomTest extends CMTest_TestCase {
         $epom = new CM_AdproviderAdapter_Epom();
 
         $html = $epom->getHtml('zoneName1', array('zoneId' => 'zone1', 'accessKey' => 'accessKey'), array('foo' => 'bar'));
-        $this->assertContains('<div id="epom-zone1" class="epom-ad" data-zone-id="zone1" data-variables="{&quot;foo&quot;:&quot;bar&quot;,&quot;key&quot;:&quot;accessKey&quot;}"', $html);
+        $this->assertContains('<div id="epom-zone1" class="epom-ad" data-zone-name="zoneName1" data-variables="{&quot;foo&quot;:&quot;bar&quot;,&quot;key&quot;:&quot;accessKey&quot;}"', $html);
 
         $html = $epom->getHtml('zoneName1', array('zoneId' => 'zone1', 'accessKey' => 'accessKey'), array());
-        $this->assertContains('<div id="epom-zone1" class="epom-ad" data-zone-id="zone1" data-variables="{&quot;key&quot;:&quot;accessKey&quot;}"', $html);
+        $this->assertContains('<div id="epom-zone1" class="epom-ad" data-zone-name="zoneName1" data-variables="{&quot;key&quot;:&quot;accessKey&quot;}"', $html);
     }
 }

--- a/tests/library/CM/AdproviderAdapter/EpomTest.php
+++ b/tests/library/CM/AdproviderAdapter/EpomTest.php
@@ -5,10 +5,10 @@ class CM_AdproviderAdapter_EpomTest extends CMTest_TestCase {
     public function testGetHtml() {
         $epom = new CM_AdproviderAdapter_Epom();
 
-        $html = $epom->getHtml(array('zoneId' => 'zone1', 'accessKey' => 'accessKey'), array('foo' => 'bar'));
+        $html = $epom->getHtml('zoneName1', array('zoneId' => 'zone1', 'accessKey' => 'accessKey'), array('foo' => 'bar'));
         $this->assertContains('<div id="epom-zone1" class="epom-ad" data-zone-id="zone1" data-variables="{&quot;foo&quot;:&quot;bar&quot;,&quot;key&quot;:&quot;accessKey&quot;}"', $html);
 
-        $html = $epom->getHtml(array('zoneId' => 'zone1', 'accessKey' => 'accessKey'), array());
+        $html = $epom->getHtml('zoneName1', array('zoneId' => 'zone1', 'accessKey' => 'accessKey'), array());
         $this->assertContains('<div id="epom-zone1" class="epom-ad" data-zone-id="zone1" data-variables="{&quot;key&quot;:&quot;accessKey&quot;}"', $html);
     }
 }

--- a/tests/library/CM/AdproviderAdapter/OpenxTest.php
+++ b/tests/library/CM/AdproviderAdapter/OpenxTest.php
@@ -7,10 +7,10 @@ class CM_AdproviderAdapter_OpenxTest extends CMTest_TestCase {
         CM_Config::get()->CM_AdproviderAdapter_Openx->host = 'www.foo.org';
         $openx = new CM_AdproviderAdapter_Openx();
 
-        $html = $openx->getHtml(array('zoneId' => 'zone1'), array('foo' => 'bar'));
+        $html = $openx->getHtml('zoneName1', array('zoneId' => 'zone1'), array('foo' => 'bar'));
         $this->assertContains('<div class="openx-ad" data-zone-id="zone1" data-host="www.foo.org" data-variables="{&quot;foo&quot;:&quot;bar&quot;}"', $html);
 
-        $html = $openx->getHtml(array('zoneId' => 'zone1'), array());
+        $html = $openx->getHtml('zoneName1', array('zoneId' => 'zone1'), array());
         $this->assertContains('<div class="openx-ad" data-zone-id="zone1" data-host="www.foo.org" data-variables="{}"', $html);
     }
 }

--- a/tests/library/CM/AdproviderTest.php
+++ b/tests/library/CM/AdproviderTest.php
@@ -55,7 +55,7 @@ class CM_AdproviderTest extends CMTest_TestCase {
 
 class CM_AdproviderAdapter_Mock extends CM_AdproviderAdapter_Abstract {
 
-    public function getHtml($zoneData, array $variables) {
+    public function getHtml($zoneName, $zoneData, array $variables) {
         return json_encode(array('zoneData' => $zoneData, 'variables' => $variables));
     }
 }


### PR DESCRIPTION
`zoneId` is only used for GA tracking in epom provider.
How about replacing it by using the zone's name (e.g. `square-medium`)?