### PR TITLE
handle empty files in CM_Clockwork_Storage_FileSystem

### DIFF
--- a/library/CM/Clockwork/Storage/FileSystem.php
+++ b/library/CM/Clockwork/Storage/FileSystem.php
@@ -8,7 +8,7 @@ class CM_Clockwork_Storage_FileSystem extends CM_Clockwork_Storage_Abstract impl
         $data = [];
         $file = $this->_getStorageFile();
         if ($file->exists()) {
-            $values = CM_Params::jsonDecode($file->read(), true);
+            $values = (array) CM_Params::jsonDecode($file->read(), true);
             $data = \Functional\map($values, function ($timeStamp) {
                 return new DateTime('@' . $timeStamp);
             });

--- a/library/CM/Clockwork/Storage/FileSystem.php
+++ b/library/CM/Clockwork/Storage/FileSystem.php
@@ -8,7 +8,7 @@ class CM_Clockwork_Storage_FileSystem extends CM_Clockwork_Storage_Abstract impl
         $data = [];
         $file = $this->_getStorageFile();
         if ($file->exists()) {
-            $values = (array) CM_Params::jsonDecode($file->read(), true);
+            $values = (array) CM_Params::jsonDecode($file->read());
             $data = \Functional\map($values, function ($timeStamp) {
                 return new DateTime('@' . $timeStamp);
             });

--- a/library/CM/Clockwork/Storage/FileSystem.php
+++ b/library/CM/Clockwork/Storage/FileSystem.php
@@ -8,7 +8,7 @@ class CM_Clockwork_Storage_FileSystem extends CM_Clockwork_Storage_Abstract impl
         $data = [];
         $file = $this->_getStorageFile();
         if ($file->exists()) {
-            $values = CM_Params::decode($file->read(), true);
+            $values = CM_Params::jsonDecode($file->read(), true);
             $data = \Functional\map($values, function ($timeStamp) {
                 return new DateTime('@' . $timeStamp);
             });


### PR DESCRIPTION
empty files trigger cryptic error
```
Functional\Exceptions\InvalidArgumentException: Functional\map() expects parameter 1 to be array or instance of Traversable in /home/vagrant/sk/vendor/lstrojny/functional-php/src/Functional/Exceptions/InvalidArgumentException.php on line 79
0. {main} /home/vagrant/sk/bin/cm:0
1. CM_Cli_CommandManager->run(CM_Cli_Arguments) /home/vagrant/sk/vendor/cargomedia/cm/bin/cm:21
2. CM_Process->waitForChildren(true, Closure) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Cli/CommandManager.php:186
3. CM_Process->_wait(true, Closure, false) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Process.php:135
4. CM_Process->_fork(Closure, 1) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Process.php:237
5. CM_Process_ForkHandler->runAndSendWorkload() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Process.php:182
6. CM_Cli_CommandManager->{closure}() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Process/ForkHandler.php:58 
7. CM_Cli_Command->run(CM_Cli_Arguments, CM_InputStream_Readline, CM_OutputStream_Stream_StandardOutput, CM_OutputStream_Stream_StandardError) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Cli/CommandManager.php:178 
8. call_user_func_array(array, array) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Cli/Command.php:29 
9. [internal function]  
10. CM_Clockwork_Manager->start() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Maintenance/Cli.php:18 
11. CM_Clockwork_Manager->runEvents() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Clockwork/Manager.php:88 
12. CM_Clockwork_Manager->_shouldRun(CM_Clockwork_Event) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Clockwork/Manager.php:57 
13. CM_Clockwork_Storage_Abstract->getLastRuntime(CM_Clockwork_Event) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Clockwork/Manager.php:111 
14. CM_Clockwork_Storage_FileSystem->_load() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Clockwork/Storage/Abstract.php:34 
15. Functional\map(NULL, Closure) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Clockwork/Storage/FileSystem.php:14 
16. Functional\Exceptions\InvalidArgumentException->assertCollection(NULL, 'Functional\map', 1) /home/vagrant/sk/vendor/lstrojny/functional-php/src/Functional/Map.php:35
```
should be handled as empty array?