### PR TITLE
CM_Util::varDump: Show contents of CM_Params

### DIFF
--- a/layout/default/Component/LogList/default.tpl
+++ b/layout/default/Component/LogList/default.tpl
@@ -41,7 +41,7 @@
           {foreach $log.metaInfo as $key => $value}
             <div class="tableField clearfix">
               <div class="label">{$key|escape}</div>
-              <div class="value">{$value|@varline|escape}</div>
+              <div class="value">{$value|escape}</div>
             </div>
           {/foreach}
         </div>

--- a/library/CM/Debug/DebugInfoInterface.php
+++ b/library/CM/Debug/DebugInfoInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-interface CM_DebugInfo_DebugInfoInterface {
+interface CM_Debug_DebugInfoInterface {
 
     /**
      * @return string

--- a/library/CM/DebugInfo/DebugInfoInterface.php
+++ b/library/CM/DebugInfo/DebugInfoInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+interface CM_DebugInfo_DebugInfoInterface {
+
+    /**
+     * @return string
+     */
+    public function __debugInfo();
+}

--- a/library/CM/DebugInfo/DebugInfoInterface.php
+++ b/library/CM/DebugInfo/DebugInfoInterface.php
@@ -5,5 +5,5 @@ interface CM_DebugInfo_DebugInfoInterface {
     /**
      * @return string
      */
-    public function __debugInfo();
+    public function getDebugInfo();
 }

--- a/library/CM/Exception.php
+++ b/library/CM/Exception.php
@@ -70,16 +70,10 @@ class CM_Exception extends Exception {
     }
 
     /**
-     * @param boolean|null $raw
-     * @return string[]
+     * @return mixed[]
      */
-    public function getMetaInfo($raw = null) {
-        if ($raw) {
-            return $this->_metaInfo;
-        }
-        return Functional\map($this->_metaInfo, function ($value) {
-            return CM_Util::varDump($value);
-        });
+    public function getMetaInfo() {
+        return $this->_metaInfo;
     }
 
     /**

--- a/library/CM/ExceptionHandling/Handler/Abstract.php
+++ b/library/CM/ExceptionHandling/Handler/Abstract.php
@@ -91,7 +91,7 @@ abstract class CM_ExceptionHandling_Handler_Abstract {
         try {
             if ($exception instanceof CM_Exception) {
                 $log = $exception->getLog();
-                $metaInfo = $exception->getMetaInfo(true);
+                $metaInfo = $exception->getMetaInfo();
             } else {
                 $log = new CM_Paging_Log_Error();
                 $metaInfo = null;

--- a/library/CM/ExceptionHandling/SerializableException.php
+++ b/library/CM/ExceptionHandling/SerializableException.php
@@ -125,7 +125,7 @@ class CM_ExceptionHandling_SerializableException {
             if (array_key_exists('args', $row)) {
                 $arguments = array();
                 foreach ($row['args'] as $argument) {
-                    $arguments[] = CM_Util::varDump($argument);
+                    $arguments[] = CM_Util::varDump($argument, ['lengthMax' => 30]);
                 }
                 $code .= '(' . implode(', ', $arguments) . ')';
             }

--- a/library/CM/ExceptionHandling/SerializableException.php
+++ b/library/CM/ExceptionHandling/SerializableException.php
@@ -88,7 +88,9 @@ class CM_ExceptionHandling_SerializableException {
         $this->line = $exception->getLine();
         $this->file = $exception->getFile();
         if ($exception instanceof CM_Exception) {
-            $this->metaInfo = $exception->getMetaInfo();
+            $this->metaInfo = Functional\map($exception->getMetaInfo(true), function ($value) {
+                return CM_Util::varDump($value);
+            });
         }
 
         try {

--- a/library/CM/ExceptionHandling/SerializableException.php
+++ b/library/CM/ExceptionHandling/SerializableException.php
@@ -88,7 +88,7 @@ class CM_ExceptionHandling_SerializableException {
         $this->line = $exception->getLine();
         $this->file = $exception->getFile();
         if ($exception instanceof CM_Exception) {
-            $this->metaInfo = Functional\map($exception->getMetaInfo(true), function ($value) {
+            $this->metaInfo = Functional\map($exception->getMetaInfo(), function ($value) {
                 return CM_Util::varDump($value);
             });
         }

--- a/library/CM/Model/Abstract.php
+++ b/library/CM/Model/Abstract.php
@@ -250,7 +250,7 @@ abstract class CM_Model_Abstract extends CM_Class_Abstract
         }
     }
 
-    public function __debugInfo() {
+    public function getDebugInfo() {
         $debugInfo = get_class($this);
         if ($this->hasIdRaw()) {
             $debugInfo .= '(' . implode(', ', (array) $this->getIdRaw()) . ')';

--- a/library/CM/Model/Abstract.php
+++ b/library/CM/Model/Abstract.php
@@ -1,6 +1,7 @@
 <?php
 
-abstract class CM_Model_Abstract extends CM_Class_Abstract implements CM_Comparable, CM_ArrayConvertible, CM_Cacheable, Serializable, CM_Typed {
+abstract class CM_Model_Abstract extends CM_Class_Abstract
+    implements CM_Comparable, CM_ArrayConvertible, CM_Cacheable, Serializable, CM_Typed, CM_DebugInfo_DebugInfoInterface {
 
     /** @var array|null */
     protected $_id;
@@ -247,6 +248,14 @@ abstract class CM_Model_Abstract extends CM_Class_Abstract implements CM_Compara
             }
             $this->_onChange();
         }
+    }
+
+    public function __debugInfo() {
+        $debugInfo = get_class($this);
+        if ($this->hasIdRaw()) {
+            $debugInfo .= '(' . implode(', ', (array) $this->getIdRaw()) . ')';
+        }
+        return $debugInfo;
     }
 
     /**

--- a/library/CM/Model/Abstract.php
+++ b/library/CM/Model/Abstract.php
@@ -1,7 +1,7 @@
 <?php
 
 abstract class CM_Model_Abstract extends CM_Class_Abstract
-    implements CM_Comparable, CM_ArrayConvertible, CM_Cacheable, Serializable, CM_Typed, CM_DebugInfo_DebugInfoInterface {
+    implements CM_Comparable, CM_ArrayConvertible, CM_Cacheable, Serializable, CM_Typed, CM_Debug_DebugInfoInterface {
 
     /** @var array|null */
     protected $_id;

--- a/library/CM/Paging/Log/Abstract.php
+++ b/library/CM/Paging/Log/Abstract.php
@@ -116,7 +116,7 @@ abstract class CM_Paging_Log_Abstract extends CM_Paging_Abstract implements CM_T
      */
     protected function _serialize(array $valueList) {
         $valueListString = Functional\map($valueList, function ($value) {
-            return CM_Util::varDump($value, true);
+            return CM_Util::varDump($value, ['recursive' => true]);
         });
         return serialize($valueListString);
     }

--- a/library/CM/Paging/Log/Abstract.php
+++ b/library/CM/Paging/Log/Abstract.php
@@ -3,8 +3,8 @@
 abstract class CM_Paging_Log_Abstract extends CM_Paging_Abstract implements CM_Typed {
 
     /**
-     * @param string     $msg
-     * @param array|null $metaInfo
+     * @param string       $msg
+     * @param mixed[]|null $metaInfo
      */
     public function add($msg, array $metaInfo = null) {
         $metaInfo = array_merge((array) $metaInfo, $this->_getDefaultMetaInfo());
@@ -90,14 +90,14 @@ abstract class CM_Paging_Log_Abstract extends CM_Paging_Abstract implements CM_T
     }
 
     /**
-     * @param string     $msg
-     * @param array|null $metaInfo
+     * @param string       $msg
+     * @param mixed[]|null $metaInfo
      */
     protected function _add($msg, array $metaInfo = null) {
         $msg = (string) $msg;
         $values = array('type' => $this->getType(), 'msg' => $msg, 'timeStamp' => time());
         if (!empty($metaInfo)) {
-            $values['metaInfo'] = serialize($this->_dump($metaInfo));
+            $values['metaInfo'] = $this->_serialize($metaInfo);
         }
         CM_Db_Db::insertDelayed('cm_log', $values);
     }
@@ -111,27 +111,23 @@ abstract class CM_Paging_Log_Abstract extends CM_Paging_Abstract implements CM_T
     }
 
     /**
-     * @param mixed $value
+     * @param mixed[] $valueList
      * @return string
      */
-    protected function _dump($value) {
-        if (is_array($value)) {
-            foreach ($value as &$element) {
-                $element = $this->_dump($element);
-            }
-        } elseif ($value instanceof CM_Model_Abstract) {
-            $value = CM_Util::varDump($value);
-        }
-        return $value;
+    protected function _serialize(array $valueList) {
+        $valueListString = Functional\map($valueList, function ($value) {
+            return CM_Util::varDump($value, true);
+        });
+        return serialize($valueListString);
     }
 
     /**
      * @param string $value
-     * @return mixed|null
+     * @return string[]|null
      */
     protected function _unserialize($value) {
         $result = @unserialize($value);
-        if (false === $result) {
+        if (!is_array($result)) {
             return null;
         }
         return $result;

--- a/library/CM/Paging/Log/Abstract.php
+++ b/library/CM/Paging/Log/Abstract.php
@@ -126,14 +126,13 @@ abstract class CM_Paging_Log_Abstract extends CM_Paging_Abstract implements CM_T
     }
 
     /**
-     * @param string  $value
-     * @param boolean $returnNull
+     * @param string $value
      * @return mixed|null
      */
-    protected function _unserialize($value, $returnNull) {
+    protected function _unserialize($value) {
         $result = @unserialize($value);
         if (false === $result) {
-            return $returnNull ? null : $value;
+            return null;
         }
         return $result;
     }

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -1,6 +1,6 @@
 <?php
 
-class CM_Params extends CM_Class_Abstract {
+class CM_Params extends CM_Class_Abstract implements CM_DebugInfo_DebugInfoInterface {
 
     private $_params;
 
@@ -405,6 +405,17 @@ class CM_Params extends CM_Class_Abstract {
      */
     public function remove($key) {
         unset($this->_params[$key]);
+    }
+
+    /**
+     * @return string
+     */
+    public function __debugInfo() {
+        try {
+            return CM_Util::varDump($this->getParamsDecoded(), ['recursive' => true]);
+        } catch (Exception $e) {
+            return '[Cannot dump params: `' . $e->getMessage() . '`]';
+        }
     }
 
     /**

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -410,7 +410,7 @@ class CM_Params extends CM_Class_Abstract implements CM_DebugInfo_DebugInfoInter
     /**
      * @return string
      */
-    public function __debugInfo() {
+    public function getDebugInfo() {
         try {
             return CM_Util::varDump($this->getParamsDecoded(), ['recursive' => true]);
         } catch (Exception $e) {

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -1,6 +1,6 @@
 <?php
 
-class CM_Params extends CM_Class_Abstract implements CM_DebugInfo_DebugInfoInterface {
+class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface {
 
     private $_params;
 

--- a/library/CM/Util.php
+++ b/library/CM/Util.php
@@ -31,18 +31,21 @@ class CM_Util {
     }
 
     /**
-     * @param mixed     $argument
-     * @param bool|null $recursive
+     * @param mixed      $argument
+     * @param array|null $options
      * @throws CM_Exception_Invalid
      * @return string
      */
-    public static function varDump($argument, $recursive = null) {
-        $recursive = (bool) $recursive;
+    public static function varDump($argument, array $options = null) {
+        $options = array_merge([
+            'recursive' => false,
+        ], (array) $options);
+        $recursive = (bool) $options['recursive'];
 
         if (is_array($argument)) {
             if ($recursive) {
-                $elementList = Functional\map($argument, function ($value, $key) use ($recursive) {
-                    return self::varDump($key, $recursive) . ' => ' . self::varDump($value, $recursive);
+                $elementList = Functional\map($argument, function ($value, $key) use ($options) {
+                    return self::varDump($key, $options) . ' => ' . self::varDump($value, $options);
                 });
                 return '[' . implode(', ', $elementList) . ']';
             } else {

--- a/library/CM/Util.php
+++ b/library/CM/Util.php
@@ -39,10 +39,10 @@ class CM_Util {
     public static function varDump($argument, array $options = null) {
         $options = array_merge([
             'recursive' => false,
-            'lengthMax' => 20,
+            'lengthMax' => null,
         ], (array) $options);
         $recursive = (bool) $options['recursive'];
-        $lengthMax = (int) $options['lengthMax'];
+        $lengthMax = (null === $options['lengthMax']) ? null : (int) $options['lengthMax'];
 
         if (is_array($argument)) {
             if ($recursive) {
@@ -67,7 +67,7 @@ class CM_Util {
             return $value;
         }
         if (is_string($argument)) {
-            if (strlen($argument) > $lengthMax) {
+            if (null !== $lengthMax && strlen($argument) > $lengthMax) {
                 $argument = substr($argument, 0, $lengthMax) . '...';
             }
             return "'" . $argument . "'";

--- a/library/CM/Util.php
+++ b/library/CM/Util.php
@@ -58,13 +58,10 @@ class CM_Util {
             if ($argument instanceof stdClass) {
                 return 'object';
             }
-            $value = get_class($argument);
-            if ($argument instanceof CM_Model_Abstract) {
-                if ($argument->hasIdRaw()) {
-                    $value .= '(' . implode(', ', (array) $argument->getIdRaw()) . ')';
-                }
+            if ($argument instanceof CM_DebugInfo_DebugInfoInterface) {
+                return $argument->__debugInfo();
             }
-            return $value;
+            return get_class($argument);
         }
         if (is_string($argument)) {
             if (null !== $lengthMax && strlen($argument) > $lengthMax) {

--- a/library/CM/Util.php
+++ b/library/CM/Util.php
@@ -59,7 +59,7 @@ class CM_Util {
                 return 'object';
             }
             if ($argument instanceof CM_DebugInfo_DebugInfoInterface) {
-                return $argument->__debugInfo();
+                return $argument->getDebugInfo();
             }
             return get_class($argument);
         }

--- a/library/CM/Util.php
+++ b/library/CM/Util.php
@@ -51,7 +51,7 @@ class CM_Util {
             if (strlen($argument) > 20) {
                 $argument = substr($argument, 0, 20) . '...';
             }
-            return '\'' . $argument . '\'';
+            return "'" . $argument . "'";
         }
         if (is_bool($argument) || is_numeric($argument)) {
             return var_export($argument, true);

--- a/library/CM/Util.php
+++ b/library/CM/Util.php
@@ -39,8 +39,10 @@ class CM_Util {
     public static function varDump($argument, array $options = null) {
         $options = array_merge([
             'recursive' => false,
+            'lengthMax' => 20,
         ], (array) $options);
         $recursive = (bool) $options['recursive'];
+        $lengthMax = (int) $options['lengthMax'];
 
         if (is_array($argument)) {
             if ($recursive) {
@@ -65,8 +67,8 @@ class CM_Util {
             return $value;
         }
         if (is_string($argument)) {
-            if (strlen($argument) > 20) {
-                $argument = substr($argument, 0, 20) . '...';
+            if (strlen($argument) > $lengthMax) {
+                $argument = substr($argument, 0, $lengthMax) . '...';
             }
             return "'" . $argument . "'";
         }

--- a/library/CM/Util.php
+++ b/library/CM/Util.php
@@ -31,10 +31,24 @@ class CM_Util {
     }
 
     /**
-     * @param mixed $argument
+     * @param mixed     $argument
+     * @param bool|null $recursive
+     * @throws CM_Exception_Invalid
      * @return string
      */
-    public static function varDump($argument) {
+    public static function varDump($argument, $recursive = null) {
+        $recursive = (bool) $recursive;
+
+        if (is_array($argument)) {
+            if ($recursive) {
+                $elementList = Functional\map($argument, function ($value, $key) use ($recursive) {
+                    return self::varDump($key, $recursive) . ' => ' . self::varDump($value, $recursive);
+                });
+                return '[' . implode(', ', $elementList) . ']';
+            } else {
+                return '[]';
+            }
+        }
         if (is_object($argument)) {
             if ($argument instanceof stdClass) {
                 return 'object';

--- a/library/CM/Util.php
+++ b/library/CM/Util.php
@@ -58,7 +58,7 @@ class CM_Util {
             if ($argument instanceof stdClass) {
                 return 'object';
             }
-            if ($argument instanceof CM_DebugInfo_DebugInfoInterface) {
+            if ($argument instanceof CM_Debug_DebugInfoInterface) {
                 return $argument->getDebugInfo();
             }
             return get_class($argument);

--- a/resources/db/update/48.php
+++ b/resources/db/update/48.php
@@ -1,0 +1,16 @@
+<?php
+
+$rowList = CM_Db_Db::select('cm_log', '*')->fetchAll();
+foreach ($rowList as $row) {
+    $metaInfo = @unserialize($row['metaInfo']);
+
+    if (is_array($metaInfo)) {
+        $metaInfo = Functional\map($metaInfo, function ($value) {
+            return CM_Util::varDump($value, ['recursive' => true]);
+        });
+    } else {
+        $metaInfo = null;
+    }
+
+    CM_Db_Db::update('cm_log', ['metaInfo' => serialize($metaInfo)], ['id' => $row['id']]);
+}

--- a/tests/library/CM/EmoticonTest.php
+++ b/tests/library/CM/EmoticonTest.php
@@ -16,7 +16,7 @@ class CM_EmoticonTest extends CMTest_TestCase {
             $this->fail('Instantiated nonexistent emoticon');
         } catch (CM_Exception_Invalid $ex) {
             $this->assertSame('Nonexistent Emoticon', $ex->getMessage());
-            $this->assertSame(['name' => 'nonexistentEmoticon'], $ex->getMetaInfo(true));
+            $this->assertSame(['name' => 'nonexistentEmoticon'], $ex->getMetaInfo());
         }
     }
 

--- a/tests/library/CM/ExceptionHandling/Handler/AbstractTest.php
+++ b/tests/library/CM/ExceptionHandling/Handler/AbstractTest.php
@@ -3,16 +3,27 @@
 class CM_ExceptionHandling_Handler_AbstractTest extends CMTest_TestCase {
 
     public function testLogException() {
-        $log = $this->getMockBuilder('CM_Paging_Log_Error')->setMethods(array('add'))->disableOriginalConstructor()->getMock();
-        $log->expects($this->once())->method('add')->will($this->returnValue(null));
+        $msg = 'My Exception';
+        $metaInfo = ['foo' => 12, 'bar' => [1, 2, 3]];
 
-        $exception = $this->getMockBuilder('CM_Exception')->setMethods(array('getLog', 'getMetaInfo'))->getMock();
+        /** @var CM_Paging_Log_Error|\Mocka\ClassMock $log */
+        $log = $this->mockClass('CM_Paging_Log_Error')->newInstanceWithoutConstructor();
+        $addMethod = $log->mockMethod('add')->set(function ($msgActual, array $metaInfoActual) use ($msg, $metaInfo) {
+            $this->assertSame($msg, $msgActual);
+            $this->assertSame($metaInfo, $metaInfoActual);
+        });
+
+        /** @var CM_Exception|PHPUnit_Framework_MockObject_MockObject $exception */
+        $exception = $this->getMockBuilder('CM_Exception')->setMethods(['getMessage', 'getLog', 'getMetaInfo'])->getMock();
+        $exception->expects($this->any())->method('getMessage')->will($this->returnValue($msg));
         $exception->expects($this->any())->method('getLog')->will($this->returnValue($log));
-        $exception->expects($this->any())->method('getMetaInfo')->will($this->returnValue(array()));
+        $exception->expects($this->any())->method('getMetaInfo')->will($this->returnValue($metaInfo));
 
-        $method = CMTest_TH::getProtectedMethod('CM_ExceptionHandling_Handler_Abstract', 'logException');
-        $exceptionHandler = $this->getMockBuilder('CM_ExceptionHandling_Handler_Abstract')->getMockForAbstractClass();
-        $method->invoke($exceptionHandler, $exception);
+        /** @var CM_ExceptionHandling_Handler_Abstract|\Mocka\ClassMock $exceptionHandler */
+        $exceptionHandler = $this->mockObject('CM_ExceptionHandling_Handler_Abstract');
+        $exceptionHandler->logException($exception);
+
+        $this->assertSame(1, $addMethod->getCallCount());
     }
 
     public function testLogExceptionFileLog() {

--- a/tests/library/CM/ExceptionHandling/SerializableExceptionTest.php
+++ b/tests/library/CM/ExceptionHandling/SerializableExceptionTest.php
@@ -62,12 +62,12 @@ class CM_ExceptionHandling_SerializableExceptionTest extends CMTest_TestCase {
     }
 
     public function testGetters() {
-        $exception = new CM_Exception('Foo bar', ['foo' => new SplFixedArray()]);
+        $exception = new CM_Exception('Foo bar', ['foo' => new SplFixedArray(), 'bar' => [1, 2, 3]]);
         $serializableException = new CM_ExceptionHandling_SerializableException($exception);
         $this->assertSame('Foo bar', $serializableException->getMessage());
         $this->assertSame('CM_Exception', $serializableException->getClass());
         $this->assertSame(__FILE__, $serializableException->getFile());
         $this->assertInternalType('int', $serializableException->getLine());
-        $this->assertSame(['foo' => 'SplFixedArray'], $serializableException->getMeta());
+        $this->assertSame(['foo' => 'SplFixedArray', 'bar' => '[]'], $serializableException->getMeta());
     }
 }

--- a/tests/library/CM/ExceptionHandling/SerializableExceptionTest.php
+++ b/tests/library/CM/ExceptionHandling/SerializableExceptionTest.php
@@ -62,11 +62,12 @@ class CM_ExceptionHandling_SerializableExceptionTest extends CMTest_TestCase {
     }
 
     public function testGetters() {
-        $exception = new CM_Exception('Foo bar');
+        $exception = new CM_Exception('Foo bar', ['foo' => new SplFixedArray()]);
         $serializableException = new CM_ExceptionHandling_SerializableException($exception);
         $this->assertSame('Foo bar', $serializableException->getMessage());
         $this->assertSame('CM_Exception', $serializableException->getClass());
         $this->assertSame(__FILE__, $serializableException->getFile());
         $this->assertInternalType('int', $serializableException->getLine());
+        $this->assertSame(['foo' => 'SplFixedArray'], $serializableException->getMeta());
     }
 }

--- a/tests/library/CM/ExceptionTest.php
+++ b/tests/library/CM/ExceptionTest.php
@@ -4,15 +4,15 @@ class CM_ExceptionTest extends CMTest_TestCase {
 
     public function testConstructor() {
         $user = CMTest_TH::createUser();
-        $exception = new CM_Exception('foo',
-            array('meta' => 'foo', 'user' => $user),
-            array('messagePublic' => 'foo {$bar}', 'messagePublicVariables' => array('bar' => 'foo'), 'severity' => CM_Exception::ERROR));
+        $metaInfo = array('meta' => 'foo', 'user' => $user);
+        $options = array('messagePublic' => 'foo {$bar}', 'messagePublicVariables' => array('bar' => 'foo'), 'severity' => CM_Exception::ERROR);
+        $exception = new CM_Exception('foo', $metaInfo, $options);
         $render = new CM_Frontend_Render();
 
         $this->assertSame('foo', $exception->getMessage());
         $this->assertSame('foo foo', $exception->getMessagePublic($render));
         $this->assertSame(CM_Exception::ERROR, $exception->getSeverity());
-        $this->assertSame(array('meta' => CM_Util::varDump('foo'), 'user' => CM_Util::varDump($user)), $exception->getMetaInfo());
+        $this->assertSame($metaInfo, $exception->getMetaInfo());
     }
 
     public function testGetSetSeverity() {

--- a/tests/library/CM/Http/Response/Resource/LayoutTest.php
+++ b/tests/library/CM/Http/Response/Resource/LayoutTest.php
@@ -14,7 +14,7 @@ class CM_Http_Response_Resource_LayoutTest extends CMTest_TestCase {
             $this->getResponseResourceLayout($filePath);
         } catch (CM_Exception_Nonexistent $ex) {
             $this->assertSame('Forbidden filetype', $ex->getMessage());
-            $this->assertSame(['path' => '/browserconfig.xml.smarty'], $ex->getMetaInfo(true));
+            $this->assertSame(['path' => '/browserconfig.xml.smarty'], $ex->getMetaInfo());
         }
     }
 
@@ -37,7 +37,7 @@ class CM_Http_Response_Resource_LayoutTest extends CMTest_TestCase {
             $this->getResponseResourceLayout($filePath);
         } catch (CM_Exception_Nonexistent $ex) {
             $this->assertSame('Invalid filename', $ex->getMessage());
-            $this->assertSame(['path' => '/nonExistent.css'], $ex->getMetaInfo(true));
+            $this->assertSame(['path' => '/nonExistent.css'], $ex->getMetaInfo());
         }
     }
 

--- a/tests/library/CM/Model/AbstractTest.php
+++ b/tests/library/CM/Model/AbstractTest.php
@@ -1066,6 +1066,31 @@ class CM_Model_AbstractTest extends CMTest_TestCase {
         $user = CM_Model_Abstract::createType(CM_Model_User::getTypeStatic());
         $this->assertInstanceOf('CM_Model_User', $user);
     }
+
+    public function testDebugInfo() {
+        $modelClass = new \Mocka\ClassMock('CM_Model_DebugInfoMock1', 'CM_Model_Abstract');
+        /** @var CM_Model_Abstract|\Mocka\AbstractClassTrait $model */
+        $model = $modelClass->newInstance();
+        $model->mockMethod('hasIdRaw')->set(function () {
+            return true;
+        });
+        $model->mockMethod('getIdRaw')->set(function () {
+            return ['id' => 12];
+        });
+
+        $this->assertSame('CM_Model_DebugInfoMock1(12)', $model->__debugInfo());
+    }
+
+    public function testDebugInfoWithoutId() {
+        $modelClass = new \Mocka\ClassMock('CM_Model_DebugInfoMock2', 'CM_Model_Abstract');
+        /** @var CM_Model_Abstract|\Mocka\AbstractClassTrait $model */
+        $model = $modelClass->newInstance();
+        $model->mockMethod('hasIdRaw')->set(function () {
+            return false;
+        });
+
+        $this->assertSame('CM_Model_DebugInfoMock2', $model->__debugInfo());
+    }
 }
 
 class CM_ModelMock extends CM_Model_Abstract {

--- a/tests/library/CM/Model/AbstractTest.php
+++ b/tests/library/CM/Model/AbstractTest.php
@@ -1078,7 +1078,7 @@ class CM_Model_AbstractTest extends CMTest_TestCase {
             return ['id' => 12];
         });
 
-        $this->assertSame('CM_Model_DebugInfoMock1(12)', $model->__debugInfo());
+        $this->assertSame('CM_Model_DebugInfoMock1(12)', $model->getDebugInfo());
     }
 
     public function testDebugInfoWithoutId() {
@@ -1089,7 +1089,7 @@ class CM_Model_AbstractTest extends CMTest_TestCase {
             return false;
         });
 
-        $this->assertSame('CM_Model_DebugInfoMock2', $model->__debugInfo());
+        $this->assertSame('CM_Model_DebugInfoMock2', $model->getDebugInfo());
     }
 }
 

--- a/tests/library/CM/MongoDb/ClientTest.php
+++ b/tests/library/CM/MongoDb/ClientTest.php
@@ -283,13 +283,13 @@ class CM_MongoDb_ClientTest extends CMTest_TestCase {
         try {
             CMTest_TH::callProtectedMethod($mongoDb, '_checkResultForErrors', [false]);
         } catch (CM_MongoDb_Exception $ex) {
-            $this->assertSame(['result' => false], $ex->getMetaInfo(true));
+            $this->assertSame(['result' => false], $ex->getMetaInfo());
         }
 
         try {
             CMTest_TH::callProtectedMethod($mongoDb, '_checkResultForErrors', [['ok' => 0, 'errmsg' => 'foo']]);
         } catch (CM_MongoDb_Exception $ex) {
-            $this->assertSame(['result' => ['ok' => 0, 'errmsg' => 'foo']], $ex->getMetaInfo(true));
+            $this->assertSame(['result' => ['ok' => 0, 'errmsg' => 'foo']], $ex->getMetaInfo());
         }
     }
 }

--- a/tests/library/CM/Paging/Log/AbstractTest.php
+++ b/tests/library/CM/Paging/Log/AbstractTest.php
@@ -14,14 +14,13 @@ class CM_Paging_Log_AbstractTest extends CMTest_TestCase {
 
         $add = CMTest_TH::getProtectedMethod('CM_Paging_Log_Abstract', '_add');
         $add->invoke($paging, 'foo');
-        $obj = CMTest_TH::createUser();
-        $add->invoke($paging, 'bar', array('meta1' => 12, 'meta2' => $obj));
+        $add->invoke($paging, 'bar', array('meta1' => 12, 'meta2' => new SplFixedArray()));
 
         $items = $paging->getItems();
         $this->assertSame(2, count($items));
 
         $this->assertSame('bar', $items[0]['msg']);
-        $this->assertSame(array('meta1' => 12, 'meta2' => CM_Util::varDump($obj)), $items[0]['metaInfo']);
+        $this->assertSame(['meta1' => '12', 'meta2' => 'SplFixedArray'], $items[0]['metaInfo']);
 
         $this->assertSame('foo', $items[1]['msg']);
         $this->assertSame(null, $items[1]['metaInfo']);

--- a/tests/library/CM/ParamsTest.php
+++ b/tests/library/CM/ParamsTest.php
@@ -337,7 +337,7 @@ class CM_ParamsTest extends CMTest_TestCase {
 
     public function testDebugInfo() {
         $params = new CM_Params(['foo' => 12, 'bar' => [1, 2]]);
-        $this->assertSame("['foo' => 12, 'bar' => [0 => 1, 1 => 2]]", $params->__debugInfo());
+        $this->assertSame("['foo' => 12, 'bar' => [0 => 1, 1 => 2]]", $params->getDebugInfo());
     }
 
     public function testDebugInfoWithException() {
@@ -346,6 +346,6 @@ class CM_ParamsTest extends CMTest_TestCase {
         $params->mockMethod('getParamsDecoded')->set(function() {
             throw new Exception('foo');
         });
-        $this->assertSame('[Cannot dump params: `foo`]', $params->__debugInfo());
+        $this->assertSame('[Cannot dump params: `foo`]', $params->getDebugInfo());
     }
 }

--- a/tests/library/CM/ParamsTest.php
+++ b/tests/library/CM/ParamsTest.php
@@ -334,4 +334,18 @@ class CM_ParamsTest extends CMTest_TestCase {
         $resource = fopen(sys_get_temp_dir(), 'r');
         CM_Params::jsonEncode(['foo' => $resource]);
     }
+
+    public function testDebugInfo() {
+        $params = new CM_Params(['foo' => 12, 'bar' => [1, 2]]);
+        $this->assertSame("['foo' => 12, 'bar' => [0 => 1, 1 => 2]]", $params->__debugInfo());
+    }
+
+    public function testDebugInfoWithException() {
+        /** @var CM_Params|\Mocka\AbstractClassTrait $params */
+        $params = $this->mockObject('CM_Params');
+        $params->mockMethod('getParamsDecoded')->set(function() {
+            throw new Exception('foo');
+        });
+        $this->assertSame('[Cannot dump params: `foo`]', $params->__debugInfo());
+    }
 }

--- a/tests/library/CM/UtilTest.php
+++ b/tests/library/CM/UtilTest.php
@@ -115,4 +115,25 @@ class CM_UtilTest extends CMTest_TestCase {
             $this->assertTrue(true);
         }
     }
+
+    /**
+     * @dataProvider varDumpProvider
+     *
+     * @param string $expected
+     * @param mixed  $argument
+     */
+    public function testVarDump($expected, $argument) {
+        $this->assertSame($expected, CM_Util::varDump($argument));
+    }
+
+    public function varDumpProvider() {
+        return [
+            ['array', array()],
+            ['true', true],
+            ["'foo'", 'foo'],
+            ["'foofoofoofoofoofoofo...'", 'foofoofoofoofoofoofoo'],
+            ['object', new stdClass()],
+            ['SplFixedArray', new SplFixedArray()],
+        ];
+    }
 }

--- a/tests/library/CM/UtilTest.php
+++ b/tests/library/CM/UtilTest.php
@@ -117,7 +117,7 @@ class CM_UtilTest extends CMTest_TestCase {
     }
 
     /**
-     * @dataProvider varDumpProviderFlat
+     * @dataProvider varDumpProvider
      *
      * @param string $expected
      * @param mixed  $argument

--- a/tests/library/CM/UtilTest.php
+++ b/tests/library/CM/UtilTest.php
@@ -126,7 +126,7 @@ class CM_UtilTest extends CMTest_TestCase {
         $this->assertSame($expected, CM_Util::varDump($argument));
     }
 
-    public function varDumpProviderFlat() {
+    public function varDumpProvider() {
         return [
             ['[]', []],
             ['[]', ['foo' => 12]],
@@ -134,10 +134,14 @@ class CM_UtilTest extends CMTest_TestCase {
             ['12', 12],
             ['-12.3', -12.3],
             ["'foo'", 'foo'],
-            ["'foofoofoofoofoofoofo...'", 'foofoofoofoofoofoofoo'],
             ['object', new stdClass()],
             ['SplFixedArray', new SplFixedArray()],
         ];
+    }
+
+    public function testVarDumpLengthMax() {
+        $this->assertSame("'foo...'", CM_Util::varDump('fooo', ['lengthMax' => 3]));
+        $this->assertSame("'fooo'", CM_Util::varDump('fooo', ['lengthMax' => 4]));
     }
 
     /**

--- a/tests/library/CM/UtilTest.php
+++ b/tests/library/CM/UtilTest.php
@@ -129,7 +129,10 @@ class CM_UtilTest extends CMTest_TestCase {
     public function varDumpProvider() {
         return [
             ['array', array()],
+            ['array', array(['foo' => 12])],
             ['true', true],
+            ['12', 12],
+            ['-12.3', -12.3],
             ["'foo'", 'foo'],
             ["'foofoofoofoofoofoofo...'", 'foofoofoofoofoofoofoo'],
             ['object', new stdClass()],

--- a/tests/library/CM/UtilTest.php
+++ b/tests/library/CM/UtilTest.php
@@ -147,7 +147,7 @@ class CM_UtilTest extends CMTest_TestCase {
      * @param mixed  $argument
      */
     public function testVarDumpRecursive($expected, $argument) {
-        $this->assertSame($expected, CM_Util::varDump($argument, true));
+        $this->assertSame($expected, CM_Util::varDump($argument, ['recursive' => true]));
     }
 
     public function varDumpProviderRecursive() {

--- a/tests/library/CM/UtilTest.php
+++ b/tests/library/CM/UtilTest.php
@@ -142,6 +142,7 @@ class CM_UtilTest extends CMTest_TestCase {
     public function testVarDumpLengthMax() {
         $this->assertSame("'foo...'", CM_Util::varDump('fooo', ['lengthMax' => 3]));
         $this->assertSame("'fooo'", CM_Util::varDump('fooo', ['lengthMax' => 4]));
+        $this->assertSame("'fooo'", CM_Util::varDump('fooo', ['lengthMax' => null]));
     }
 
     /**

--- a/tests/library/CM/UtilTest.php
+++ b/tests/library/CM/UtilTest.php
@@ -132,7 +132,7 @@ class CM_UtilTest extends CMTest_TestCase {
             ['[]', ['foo' => 12]],
             ['true', true],
             ['12', 12],
-            ['-12.3', -12.3],
+            ['-12', -12],
             ["'foo'", 'foo'],
             ['object', new stdClass()],
             ['SplFixedArray', new SplFixedArray()],

--- a/tests/library/CM/UtilTest.php
+++ b/tests/library/CM/UtilTest.php
@@ -117,7 +117,7 @@ class CM_UtilTest extends CMTest_TestCase {
     }
 
     /**
-     * @dataProvider varDumpProvider
+     * @dataProvider varDumpProviderFlat
      *
      * @param string $expected
      * @param mixed  $argument
@@ -126,10 +126,10 @@ class CM_UtilTest extends CMTest_TestCase {
         $this->assertSame($expected, CM_Util::varDump($argument));
     }
 
-    public function varDumpProvider() {
+    public function varDumpProviderFlat() {
         return [
-            ['array', array()],
-            ['array', array(['foo' => 12])],
+            ['[]', []],
+            ['[]', ['foo' => 12]],
             ['true', true],
             ['12', 12],
             ['-12.3', -12.3],
@@ -137,6 +137,25 @@ class CM_UtilTest extends CMTest_TestCase {
             ["'foofoofoofoofoofoofo...'", 'foofoofoofoofoofoofoo'],
             ['object', new stdClass()],
             ['SplFixedArray', new SplFixedArray()],
+        ];
+    }
+
+    /**
+     * @dataProvider varDumpProviderRecursive
+     *
+     * @param string $expected
+     * @param mixed  $argument
+     */
+    public function testVarDumpRecursive($expected, $argument) {
+        $this->assertSame($expected, CM_Util::varDump($argument, true));
+    }
+
+    public function varDumpProviderRecursive() {
+        return [
+            ['[]', []],
+            ["['foo' => 12]", ['foo' => 12]],
+            ["['foo' => SplFixedArray]", ['foo' => new SplFixedArray()]],
+            ["['foo' => ['bar' => 12, 0 => 13]]", ['foo' => ['bar' => 12, 13]]],
         ];
     }
 }


### PR DESCRIPTION
`CM_Util::varDump()` is used to format arguments in stack traces (`CM_ExceptionHandling_SerializableException::_extractTraceRow()`).

Currently it handles all object the same, except `CM_Model_Abstract` (where it prints the ID). It would be useful if we would show the contents of `CM_Params` to change this line:
```
CM_Jobdistribution_Job_Abstract->_executeJob(SK_Params)
```
into something like:
```
CM_Jobdistribution_Job_Abstract->_executeJob(['foo' => 12])
```

We could add another `if` to `varDump()` or maybe even allow to override that behaviour on the class itself.
@alexispeter @tomaszdurka wdyt?