### PR TITLE
Make flushing split tests more robust under load

### DIFF
--- a/library/CM/Model/Splittest.php
+++ b/library/CM/Model/Splittest.php
@@ -254,6 +254,7 @@ class CM_Model_Splittest extends CM_Model_Abstract implements CM_Service_Manager
                 $this->getServiceManager()->getTrackings()->trackSplittest($fixture, $variation);
             } catch (CM_Db_Exception $exception) {
                 $variationListFixture = $this->_getVariationListFixture($fixture, true);
+                $this->_change();
                 if (!array_key_exists($this->getId(), $variationListFixture) ||
                     $variationListFixture[$this->getId()]['flushStamp'] != $this->getCreated()
                 ) {

--- a/library/CM/Model/Splittest.php
+++ b/library/CM/Model/Splittest.php
@@ -233,37 +233,51 @@ class CM_Model_Splittest extends CM_Model_Abstract implements CM_Service_Manager
 
     /**
      * @param CM_Splittest_Fixture $fixture
+     * @param bool|null            $updateCache
+     * @return string|null
+     */
+    protected function _findVariationNameFixture(CM_Splittest_Fixture $fixture, $updateCache = null) {
+        $updateCache = (bool) $updateCache;
+        $variationListFixture = $this->_getVariationListFixture($fixture, $updateCache);
+        if ($updateCache) {
+            $this->_change();
+        }
+        if (!isset($variationListFixture[$this->getId()]) || $variationListFixture[$this->getId()]['flushStamp'] !== $this->getCreated()) {
+            return null;
+        }
+        return $variationListFixture[$this->getId()]['variation'];
+    }
+
+    /**
+     * @param CM_Splittest_Fixture $fixture
      * @throws CM_Db_Exception
      * @throws CM_Exception_Invalid
      * @return string
      */
     protected function _getVariationFixture(CM_Splittest_Fixture $fixture) {
-        $columnId = $fixture->getColumnId();
-        $fixtureId = $fixture->getId();
-
-        $variationListFixture = $this->_getVariationListFixture($fixture);
-        if (!array_key_exists($this->getId(), $variationListFixture) || $variationListFixture[$this->getId()]['flushStamp'] != $this->getCreated()) {
+        $variationName = $this->_findVariationNameFixture($fixture);
+        if (null === $variationName) {
             $variation = $this->_getVariationRandom();
+            $variationName = $variation->getName();
             try {
+                $columnId = $fixture->getColumnId();
+                $fixtureId = $fixture->getId();
                 CM_Db_Db::insert('cm_splittestVariation_fixture',
                     array('splittestId' => $this->getId(), $columnId => $fixtureId, 'variationId' => $variation->getId(), 'createStamp' => time()));
-                $variationListFixture[$this->getId()] = ['variation' => $variation->getName(), 'flushStamp' => $this->getCreated()];
+                $variationListFixture = $this->_getVariationListFixture($fixture);
+                $variationListFixture[$this->getId()] = ['variation' => $variationName, 'flushStamp' => $this->getCreated()];
                 $cacheKey = self::_getCacheKeyFixture($fixture);
                 $cache = CM_Cache_Local::getInstance();
                 $cache->set($cacheKey, $variationListFixture);
                 $this->getServiceManager()->getTrackings()->trackSplittest($fixture, $variation);
             } catch (CM_Db_Exception $exception) {
-                $variationListFixture = $this->_getVariationListFixture($fixture, true);
-                $this->_change();
-                if (!array_key_exists($this->getId(), $variationListFixture) ||
-                    $variationListFixture[$this->getId()]['flushStamp'] != $this->getCreated()
-                ) {
+                $variationName = $this->_findVariationNameFixture($fixture, true);
+                if (null === $variationName) {
                     throw $exception;
                 }
             }
         }
-
-        return $variationListFixture[$this->getId()]['variation'];
+        return $variationName;
     }
 
     /**

--- a/library/CM/Model/Splittest.php
+++ b/library/CM/Model/Splittest.php
@@ -242,7 +242,7 @@ class CM_Model_Splittest extends CM_Model_Abstract implements CM_Service_Manager
         if ($updateCache) {
             $this->_change();
         }
-        if (!isset($variationListFixture[$this->getId()]) || $variationListFixture[$this->getId()]['flushStamp'] !== $this->getCreated()) {
+        if (!isset($variationListFixture[$this->getId()]) || (int) $variationListFixture[$this->getId()]['flushStamp'] !== $this->getCreated()) {
             return null;
         }
         return $variationListFixture[$this->getId()]['variation'];


### PR DESCRIPTION
Paired with @kris-lab 

@njam the problem arises when you flush a split test while there is such a high load on the master database that the proxy switches to an outdated slave, so that you put the "old" flushStamp into the cached split test model.

After the database recovers, the flushStamp you put into the variation fixtures is the new one, and you get no chance to match the split test's flushStamp again, since it has the old one in the cache.

So invalidating the cached split test data should help!