### PR TITLE
Clear cache between "unload" and "load" to prevent using old cache entries during "load"

### DIFF
--- a/library/CM/App/Cli.php
+++ b/library/CM/App/Cli.php
@@ -9,13 +9,11 @@ class CM_App_Cli extends CM_Cli_Runnable_Abstract {
         $provisionLoader = CM_App::getInstance()->getProvisionLoader();
         if ($reload) {
             $provisionLoader->unload($this->_getStreamOutput());
-        }
-        $provisionLoader->load($this->_getStreamOutput());
 
-        if ($reload) {
             $cacheCli = new CM_Cache_Cli($this->_getStreamInput(), $this->_getStreamOutput(), $this->_getStreamError());
             $cacheCli->clear();
         }
+        $provisionLoader->load($this->_getStreamOutput());
     }
 
     public function fillCaches() {


### PR DESCRIPTION
Otherwise setupScripts might use cached entries from previous installation and fail.

@fauvel @tomaszdurka please review