### PR TITLE
Move CM_Util::varDump() to CM_Debug_VariableInspector

### DIFF
--- a/library/CM/Debug/VariableInspector.php
+++ b/library/CM/Debug/VariableInspector.php
@@ -1,0 +1,13 @@
+<?php
+
+class CM_Debug_VariableInspector {
+
+    /**
+     * @param mixed      $variable
+     * @param array|null $options
+     * @return string
+     */
+    public function getDebugInfo($variable, array $options = null) {
+        return CM_Util::varDump($variable, $options);
+    }
+}

--- a/library/CM/Debug/VariableInspector.php
+++ b/library/CM/Debug/VariableInspector.php
@@ -8,6 +8,41 @@ class CM_Debug_VariableInspector {
      * @return string
      */
     public function getDebugInfo($variable, array $options = null) {
-        return CM_Util::varDump($variable, $options);
+        $options = array_merge([
+            'recursive' => false,
+            'lengthMax' => null,
+        ], (array) $options);
+        $recursive = (bool) $options['recursive'];
+        $lengthMax = (null === $options['lengthMax']) ? null : (int) $options['lengthMax'];
+
+        if (is_array($variable)) {
+            if ($recursive) {
+                $elementList = Functional\map($variable, function ($value, $key) use ($options) {
+                    return $this->getDebugInfo($key, $options) . ' => ' . $this->getDebugInfo($value, $options);
+                });
+                return '[' . implode(', ', $elementList) . ']';
+            } else {
+                return '[]';
+            }
+        }
+        if (is_object($variable)) {
+            if ($variable instanceof stdClass) {
+                return 'object';
+            }
+            if ($variable instanceof CM_Debug_DebugInfoInterface) {
+                return $variable->getDebugInfo();
+            }
+            return get_class($variable);
+        }
+        if (is_string($variable)) {
+            if (null !== $lengthMax && strlen($variable) > $lengthMax) {
+                $variable = substr($variable, 0, $lengthMax) . '...';
+            }
+            return "'" . $variable . "'";
+        }
+        if (is_bool($variable) || is_numeric($variable)) {
+            return var_export($variable, true);
+        }
+        return gettype($variable);
     }
 }

--- a/library/CM/ExceptionHandling/SerializableException.php
+++ b/library/CM/ExceptionHandling/SerializableException.php
@@ -88,8 +88,9 @@ class CM_ExceptionHandling_SerializableException {
         $this->line = $exception->getLine();
         $this->file = $exception->getFile();
         if ($exception instanceof CM_Exception) {
-            $this->metaInfo = Functional\map($exception->getMetaInfo(), function ($value) {
-                return CM_Util::varDump($value);
+            $variableInspector = new CM_Debug_VariableInspector();
+            $this->metaInfo = Functional\map($exception->getMetaInfo(), function ($value) use ($variableInspector) {
+                return $variableInspector->getDebugInfo($value);
             });
         }
 
@@ -124,8 +125,9 @@ class CM_ExceptionHandling_SerializableException {
             $code .= $row['function'];
             if (array_key_exists('args', $row)) {
                 $arguments = array();
+                $variableInspector = new CM_Debug_VariableInspector();
                 foreach ($row['args'] as $argument) {
-                    $arguments[] = CM_Util::varDump($argument, ['lengthMax' => 30]);
+                    $arguments[] = $variableInspector->getDebugInfo($argument, ['lengthMax' => 30]);
                 }
                 $code .= '(' . implode(', ', $arguments) . ')';
             }

--- a/library/CM/Paging/Log/Abstract.php
+++ b/library/CM/Paging/Log/Abstract.php
@@ -115,8 +115,9 @@ abstract class CM_Paging_Log_Abstract extends CM_Paging_Abstract implements CM_T
      * @return string
      */
     protected function _serialize(array $valueList) {
-        $valueListString = Functional\map($valueList, function ($value) {
-            return CM_Util::varDump($value, ['recursive' => true]);
+        $variableInspector = new CM_Debug_VariableInspector();
+        $valueListString = Functional\map($valueList, function ($value) use($variableInspector) {
+            return $variableInspector->getDebugInfo($value, ['recursive' => true]);
         });
         return serialize($valueListString);
     }

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -412,7 +412,8 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
      */
     public function getDebugInfo() {
         try {
-            return CM_Util::varDump($this->getParamsDecoded(), ['recursive' => true]);
+            $variableInspector = new CM_Debug_VariableInspector();
+            return $variableInspector->getDebugInfo($this->getParamsDecoded(), ['recursive' => true]);
         } catch (Exception $e) {
             return '[Cannot dump params: `' . $e->getMessage() . '`]';
         }

--- a/library/CM/Util.php
+++ b/library/CM/Util.php
@@ -31,51 +31,6 @@ class CM_Util {
     }
 
     /**
-     * @param mixed      $argument
-     * @param array|null $options
-     * @throws CM_Exception_Invalid
-     * @return string
-     */
-    public static function varDump($argument, array $options = null) {
-        $options = array_merge([
-            'recursive' => false,
-            'lengthMax' => null,
-        ], (array) $options);
-        $recursive = (bool) $options['recursive'];
-        $lengthMax = (null === $options['lengthMax']) ? null : (int) $options['lengthMax'];
-
-        if (is_array($argument)) {
-            if ($recursive) {
-                $elementList = Functional\map($argument, function ($value, $key) use ($options) {
-                    return self::varDump($key, $options) . ' => ' . self::varDump($value, $options);
-                });
-                return '[' . implode(', ', $elementList) . ']';
-            } else {
-                return '[]';
-            }
-        }
-        if (is_object($argument)) {
-            if ($argument instanceof stdClass) {
-                return 'object';
-            }
-            if ($argument instanceof CM_Debug_DebugInfoInterface) {
-                return $argument->getDebugInfo();
-            }
-            return get_class($argument);
-        }
-        if (is_string($argument)) {
-            if (null !== $lengthMax && strlen($argument) > $lengthMax) {
-                $argument = substr($argument, 0, $lengthMax) . '...';
-            }
-            return "'" . $argument . "'";
-        }
-        if (is_bool($argument) || is_numeric($argument)) {
-            return var_export($argument, true);
-        }
-        return gettype($argument);
-    }
-
-    /**
      * @param string $pattern OPTIONAL
      * @param string $path    OPTIONAL
      * @return array

--- a/resources/db/update/48.php
+++ b/resources/db/update/48.php
@@ -5,8 +5,9 @@ foreach ($rowList as $row) {
     $metaInfo = @unserialize($row['metaInfo']);
 
     if (is_array($metaInfo)) {
-        $metaInfo = Functional\map($metaInfo, function ($value) {
-            return CM_Util::varDump($value, ['recursive' => true]);
+        $variableInspector = new CM_Debug_VariableInspector();
+        $metaInfo = Functional\map($metaInfo, function ($value) use($variableInspector) {
+            return $variableInspector->getDebugInfo($value, ['recursive' => true]);
         });
     } else {
         $metaInfo = null;

--- a/tests/library/CM/Debug/VariableInspectorTest.php
+++ b/tests/library/CM/Debug/VariableInspectorTest.php
@@ -30,6 +30,7 @@ class CM_Debug_VariableInspectorTest extends CMTest_TestCase {
         $variableInspector = new CM_Debug_VariableInspector();
         $this->assertSame("'foo...'", $variableInspector->getDebugInfo('fooo', ['lengthMax' => 3]));
         $this->assertSame("'fooo'", $variableInspector->getDebugInfo('fooo', ['lengthMax' => 4]));
+        $this->assertSame("'fooo'", $variableInspector->getDebugInfo('fooo', ['lengthMax' => 6]));
         $this->assertSame("'fooo'", $variableInspector->getDebugInfo('fooo', ['lengthMax' => null]));
     }
 

--- a/tests/library/CM/Debug/VariableInspectorTest.php
+++ b/tests/library/CM/Debug/VariableInspectorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+class CM_Debug_VariableInspectorTest extends CMTest_TestCase {
+
+    /**
+     * @dataProvider debugInfoProvider
+     *
+     * @param string $expected
+     * @param mixed  $argument
+     */
+    public function testGetDebugInfo($expected, $argument) {
+        $this->assertSame($expected, CM_Util::varDump($argument));
+    }
+
+    public function debugInfoProvider() {
+        return [
+            ['[]', []],
+            ['[]', ['foo' => 12]],
+            ['true', true],
+            ['12', 12],
+            ['-12', -12],
+            ["'foo'", 'foo'],
+            ['object', new stdClass()],
+            ['SplFixedArray', new SplFixedArray()],
+        ];
+    }
+
+    public function testGetDebugInfoLengthMax() {
+        $this->assertSame("'foo...'", CM_Util::varDump('fooo', ['lengthMax' => 3]));
+        $this->assertSame("'fooo'", CM_Util::varDump('fooo', ['lengthMax' => 4]));
+        $this->assertSame("'fooo'", CM_Util::varDump('fooo', ['lengthMax' => null]));
+    }
+
+    /**
+     * @dataProvider debugInfoProviderRecursive
+     *
+     * @param string $expected
+     * @param mixed  $argument
+     */
+    public function testGetDebugInfoRecursive($expected, $argument) {
+        $this->assertSame($expected, CM_Util::varDump($argument, ['recursive' => true]));
+    }
+
+    public function debugInfoProviderRecursive() {
+        return [
+            ['[]', []],
+            ["['foo' => 12]", ['foo' => 12]],
+            ["['foo' => SplFixedArray]", ['foo' => new SplFixedArray()]],
+            ["['foo' => ['bar' => 12, 0 => 13]]", ['foo' => ['bar' => 12, 13]]],
+        ];
+    }
+}

--- a/tests/library/CM/Debug/VariableInspectorTest.php
+++ b/tests/library/CM/Debug/VariableInspectorTest.php
@@ -9,7 +9,8 @@ class CM_Debug_VariableInspectorTest extends CMTest_TestCase {
      * @param mixed  $argument
      */
     public function testGetDebugInfo($expected, $argument) {
-        $this->assertSame($expected, CM_Util::varDump($argument));
+        $variableInspector = new CM_Debug_VariableInspector();
+        $this->assertSame($expected, $variableInspector->getDebugInfo($argument));
     }
 
     public function debugInfoProvider() {
@@ -26,9 +27,10 @@ class CM_Debug_VariableInspectorTest extends CMTest_TestCase {
     }
 
     public function testGetDebugInfoLengthMax() {
-        $this->assertSame("'foo...'", CM_Util::varDump('fooo', ['lengthMax' => 3]));
-        $this->assertSame("'fooo'", CM_Util::varDump('fooo', ['lengthMax' => 4]));
-        $this->assertSame("'fooo'", CM_Util::varDump('fooo', ['lengthMax' => null]));
+        $variableInspector = new CM_Debug_VariableInspector();
+        $this->assertSame("'foo...'", $variableInspector->getDebugInfo('fooo', ['lengthMax' => 3]));
+        $this->assertSame("'fooo'", $variableInspector->getDebugInfo('fooo', ['lengthMax' => 4]));
+        $this->assertSame("'fooo'", $variableInspector->getDebugInfo('fooo', ['lengthMax' => null]));
     }
 
     /**
@@ -38,7 +40,8 @@ class CM_Debug_VariableInspectorTest extends CMTest_TestCase {
      * @param mixed  $argument
      */
     public function testGetDebugInfoRecursive($expected, $argument) {
-        $this->assertSame($expected, CM_Util::varDump($argument, ['recursive' => true]));
+        $variableInspector = new CM_Debug_VariableInspector();
+        $this->assertSame($expected, $variableInspector->getDebugInfo($argument, ['recursive' => true]));
     }
 
     public function debugInfoProviderRecursive() {

--- a/tests/library/CM/UtilTest.php
+++ b/tests/library/CM/UtilTest.php
@@ -116,51 +116,5 @@ class CM_UtilTest extends CMTest_TestCase {
         }
     }
 
-    /**
-     * @dataProvider varDumpProvider
-     *
-     * @param string $expected
-     * @param mixed  $argument
-     */
-    public function testVarDump($expected, $argument) {
-        $this->assertSame($expected, CM_Util::varDump($argument));
-    }
 
-    public function varDumpProvider() {
-        return [
-            ['[]', []],
-            ['[]', ['foo' => 12]],
-            ['true', true],
-            ['12', 12],
-            ['-12', -12],
-            ["'foo'", 'foo'],
-            ['object', new stdClass()],
-            ['SplFixedArray', new SplFixedArray()],
-        ];
-    }
-
-    public function testVarDumpLengthMax() {
-        $this->assertSame("'foo...'", CM_Util::varDump('fooo', ['lengthMax' => 3]));
-        $this->assertSame("'fooo'", CM_Util::varDump('fooo', ['lengthMax' => 4]));
-        $this->assertSame("'fooo'", CM_Util::varDump('fooo', ['lengthMax' => null]));
-    }
-
-    /**
-     * @dataProvider varDumpProviderRecursive
-     *
-     * @param string $expected
-     * @param mixed  $argument
-     */
-    public function testVarDumpRecursive($expected, $argument) {
-        $this->assertSame($expected, CM_Util::varDump($argument, ['recursive' => true]));
-    }
-
-    public function varDumpProviderRecursive() {
-        return [
-            ['[]', []],
-            ["['foo' => 12]", ['foo' => 12]],
-            ["['foo' => SplFixedArray]", ['foo' => new SplFixedArray()]],
-            ["['foo' => ['bar' => 12, 0 => 13]]", ['foo' => ['bar' => 12, 13]]],
-        ];
-    }
 }


### PR DESCRIPTION
E.g.:
```php
$variableInspector = new CM_Debug_VariableInspector();
$variableInspector->getDebugInfo($variable);
```


@tomaszdurka thoughts?