### PR TITLE
Daemon loops don't process signals

### DIFF
--- a/library/CM/Clockwork/Manager.php
+++ b/library/CM/Clockwork/Manager.php
@@ -84,9 +84,11 @@ class CM_Clockwork_Manager {
     }
 
     public function start() {
+        $process = CM_Process::getInstance();
         while (true) {
             $this->runEvents();
             sleep(1);
+            $process->handleSignals();
         }
     }
 

--- a/library/CM/Clockwork/Manager.php
+++ b/library/CM/Clockwork/Manager.php
@@ -84,11 +84,10 @@ class CM_Clockwork_Manager {
     }
 
     public function start() {
-        $process = CM_Process::getInstance();
         while (true) {
             $this->runEvents();
             sleep(1);
-            $process->handleSignals();
+            $this->_getProcess()->handleSignals();
         }
     }
 

--- a/library/CM/Clockwork/Manager.php
+++ b/library/CM/Clockwork/Manager.php
@@ -192,9 +192,9 @@ class CM_Clockwork_Manager {
      */
     protected function _runEvent(CM_Clockwork_Event $event) {
         $process = $this->_getProcess();
-        $identifier = $process->fork(function () use ($event) {
+        $forkHandler = $process->fork(function () use ($event) {
             $event->run();
         });
-        $this->_markRunning($event, $identifier);
+        $this->_markRunning($event, $forkHandler->getIdentifier());
     }
 }

--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -255,7 +255,7 @@ class CM_Process {
         if (!empty($this->_forkHandlerList)) {
             do {
                 $pid = pcntl_wait($status, $waitOption);
-                pcntl_signal_dispatch();
+                $this->handleSignals();
                 if (-1 === $pid) {
                     throw new CM_Exception('Waiting on child processes failed');
                 } elseif ($pid > 0) {

--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -57,7 +57,7 @@ class CM_Process {
 
     /**
      * @param Closure $workload
-     * @return int
+     * @return CM_Process_ForkHandler
      * @throws CM_Exception
      */
     public function fork(Closure $workload) {
@@ -65,8 +65,7 @@ class CM_Process {
             $this->bind('exit', [$this, 'killChildren']);
         }
         $identifier = ++$this->_forkHandlerCounter;
-        $this->_fork($workload, $identifier);
-        return $identifier;
+        return $this->_fork($workload, $identifier);
     }
 
     /**

--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -174,6 +174,10 @@ class CM_Process {
         return $_SERVER['argv'];
     }
 
+    public function handleSignals() {
+        pcntl_signal_dispatch();
+    }
+
     /**
      * @return CM_Process
      */

--- a/library/CM/Process/ForkHandler.php
+++ b/library/CM/Process/ForkHandler.php
@@ -11,15 +11,23 @@ class CM_Process_ForkHandler {
     /** @var resource */
     private $_ipcStream;
 
+    /** @var int */
+    private $_identifier;
+
     /**
      * @param int      $pid
      * @param Closure  $workload
      * @param resource $ipcStream
+     * @param int|null $identifier
      */
-    public function __construct($pid, Closure $workload, $ipcStream) {
+    public function __construct($pid, Closure $workload, $ipcStream, $identifier = null) {
         $this->_pid = (int) $pid;
         $this->_workload = $workload;
         $this->_ipcStream = $ipcStream;
+        if (null !== $identifier) {
+            $identifier = (int) $identifier;
+        }
+        $this->_identifier = $identifier;
     }
 
     /**
@@ -45,6 +53,17 @@ class CM_Process_ForkHandler {
 
     public function closeIpcStream() {
         fclose($this->_ipcStream);
+    }
+
+    /**
+     * @throws CM_Exception
+     * @return int
+     */
+    public function getIdentifier() {
+        if (null === $this->_identifier) {
+            throw new CM_Exception('Fork-handler has no identifier');
+        }
+        return $this->_identifier;
     }
 
     /**

--- a/tests/library/CM/Clockwork/ManagerTest.php
+++ b/tests/library/CM/Clockwork/ManagerTest.php
@@ -405,6 +405,14 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $this->assertTrue($_shouldRun->invoke($manager, $event));
     }
 
+    public function testTerminate() {
+        $process = CM_Process::getInstance();
+        $process->fork(function () {
+            $clockworkManager = new CM_Clockwork_Manager();
+            $clockworkManager->start();
+        });
+    }
+
     /**
      * @param DateTime     $start
      * @param DateTimeZone $timeZone

--- a/tests/library/CM/Clockwork/ManagerTest.php
+++ b/tests/library/CM/Clockwork/ManagerTest.php
@@ -405,12 +405,22 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $this->assertTrue($_shouldRun->invoke($manager, $event));
     }
 
-    public function testTerminate() {
+    public function testStartTerminatable() {
         $process = CM_Process::getInstance();
-        $process->fork(function () {
+        $forkHandler = $process->fork(function () {
             $clockworkManager = new CM_Clockwork_Manager();
             $clockworkManager->start();
         });
+
+        usleep(1000000 * 0.1);
+        $process->listenForChildren();
+        $this->assertSame(true, $process->isRunning($forkHandler->getPid()));
+
+        posix_kill($forkHandler->getPid(), SIGTERM);
+
+        usleep(1000000 * 0.1);
+        $process->listenForChildren();
+        $this->assertSame(false, $process->isRunning($forkHandler->getPid()));
     }
 
     /**

--- a/tests/library/CM/Clockwork/ManagerTest.php
+++ b/tests/library/CM/Clockwork/ManagerTest.php
@@ -18,7 +18,9 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $process = $this->mockClass('CM_Process')->newInstanceWithoutConstructor();
         $forkMock = $process->mockMethod('fork');
         $forkMock->set(function () use ($forkMock) {
-            return $forkMock->getCallCount();
+            $forkHandler = $this->mockClass('CM_Process_ForkHandler')->newInstanceWithoutConstructor();
+            $forkHandler->mockMethod('getIdentifier')->set($forkMock->getCallCount());
+            return $forkHandler;
         });
         $manager = $this->mockObject('CM_Clockwork_Manager');
         $manager->mockMethod('_shouldRun')->set(true);
@@ -68,7 +70,9 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $process = $this->mockClass('CM_Process')->newInstanceWithoutConstructor();
         $forkMock = $process->mockMethod('fork');
         $forkMock->set(function () use ($forkMock) {
-            return $forkMock->getCallCount();
+            $forkHandler = $this->mockClass('CM_Process_ForkHandler')->newInstanceWithoutConstructor();
+            $forkHandler->mockMethod('getIdentifier')->set($forkMock->getCallCount());
+            return $forkHandler;
         });
         $storage = new CM_Clockwork_Storage_Memory();
         /** @var CM_Clockwork_Storage_Abstract $storage */

--- a/tests/library/CM/ProcessTest.php
+++ b/tests/library/CM/ProcessTest.php
@@ -10,11 +10,14 @@ class CM_ProcessTest extends CMTest_TestCase {
      */
     public function testFork() {
         $process = CM_Process::getInstance();
-        $seq1 = $process->fork(function() {});
-        $seq2 = $process->fork(function() {});
-        $seq3 = $process->fork(function() {});
-        $this->assertSame(1, $seq2 - $seq1);
-        $this->assertSame(1, $seq3 - $seq2);
+        $forkHandler1 = $process->fork(function () {
+            });
+        $forkHandler2 = $process->fork(function () {
+            });
+        $forkHandler3 = $process->fork(function () {
+            });
+        $this->assertSame(1, $forkHandler2->getIdentifier() - $forkHandler1->getIdentifier());
+        $this->assertSame(1, $forkHandler3->getIdentifier() - $forkHandler2->getIdentifier());
     }
 
     /**
@@ -300,7 +303,7 @@ class CM_ProcessTest extends CMTest_TestCase {
     public function testEventHandler() {
         $counter = 0;
         $process = CM_Process::getInstance();
-        $process->bind('foo', function() use (&$counter) {
+        $process->bind('foo', function () use (&$counter) {
             $counter++;
         });
         $process->trigger('foo');


### PR DESCRIPTION
Since we don't install signal handlers any more in child processes (https://github.com/cargomedia/CM/pull/1732) our daemon loops fail to process termination signals.

E.g. `CM_Clockwork_Manager::start()`:
```php
        while (true) {
            $this->runEvents();
            sleep(1);
        }
```
A termination signal interrupts the `sleep()`, then the loop continues from the top and the signal is never processed.

Possible solutions:
- A: Install custom signal handlers also in child processes
- B: Call [`pcntl_signal_dispatch()`](http://php.net/manual/en/function.pcntl-signal-dispatch.php) on every iteration of such loops.

@tomaszdurka @kris-lab @alexispeter wdyt?