### PR TITLE
remove <script type="text/template"> elements from DOM parsing

### DIFF
--- a/library/CM/Dom/NodeList.php
+++ b/library/CM/Dom/NodeList.php
@@ -33,7 +33,7 @@ class CM_Dom_NodeList implements Iterator, Countable, ArrayAccess {
         } else {
             $html = (string) $html;
 
-            $html = preg_replace('#<script[^>]+type=([\'"])text/template\1[^>]*>.*?</script>#si', '', $html);
+            $html = $this->_stripJavascriptTemplate($html);
 
             $this->_doc = new DOMDocument();
             $html = '<?xml version="1.0" encoding="UTF-8"?>' . $html;
@@ -240,5 +240,14 @@ class CM_Dom_NodeList implements Iterator, Countable, ArrayAccess {
 
     public function offsetUnset($offset) {
         unset($this->_elementList[0]);
+    }
+
+    /**
+     * @param string $html
+     * @return string
+     */
+    private function _stripJavascriptTemplate($html) {
+        $html = preg_replace('#<script[^>]+type=([\'"])text/template\1[^>]*>.*?</script>#si', '', $html);
+        return $html;
     }
 }

--- a/library/CM/Dom/NodeList.php
+++ b/library/CM/Dom/NodeList.php
@@ -33,6 +33,8 @@ class CM_Dom_NodeList implements Iterator, Countable, ArrayAccess {
         } else {
             $html = (string) $html;
 
+            $html = preg_replace('#<script[^>]+type=([\'"])text/template\1[^>]*>.*?</script>#si', '', $html);
+
             $this->_doc = new DOMDocument();
             $html = '<?xml version="1.0" encoding="UTF-8"?>' . $html;
 

--- a/tests/library/CM/Dom/NodeListTest.php
+++ b/tests/library/CM/Dom/NodeListTest.php
@@ -57,6 +57,11 @@ class CM_Dom_NodeListTest extends CMTest_TestCase {
         $this->assertSame('<p>hello</p>', $list->getHtml());
     }
 
+    public function testGetHtmlJavascriptTemplate() {
+        $list = new CM_Dom_NodeList('<script type="text/template"><div class="clclcl">TestText</div></script><span class="pr">Left</span>');
+        $this->assertSame('<span class="pr">Left</span>', $list->getHtml());
+    }
+
     public function testGetText() {
         $list = new CM_Dom_NodeList('<div>hello<strong>world</strong></div>');
         $this->assertSame('helloworld', $list->getText());


### PR DESCRIPTION
Exclude  <script type="text/template"> elements from adding to DOM with PHP DOMDocument because is was added incorrectly and broke tests.

@njam, @vogdb please review