### PR TITLE
Fix usertext styles

### DIFF
--- a/layout/default/css/function.usertext.less
+++ b/layout/default/css/function.usertext.less
@@ -1,8 +1,9 @@
 .emoticon {
   width: @emoticonSize;
   height: @emoticonSize;
-  display: inline-block;
-  margin: -((@emoticonSize - 1em)*0.5) 0.1em;
+  margin-left: .1em;
+  margin-right: .1em;
+  vertical-align: top;
 }
 
 .usertext {

--- a/layout/default/css/function.usertext.less
+++ b/layout/default/css/function.usertext.less
@@ -8,9 +8,6 @@
 .usertext {
   .word_wrap;
   hyphens: auto;
-  line-height: @usertextLineheight;
-  font-size: @usertextFontSize;
-  color: @usertextFontColor;
 
   img:not(.emoticon) {
     box-sizing: border-box;
@@ -69,6 +66,9 @@
 
   p {
     margin-bottom: 1em;
+    line-height: @usertextLineheight;
+    font-size: @usertextFontSize;
+    color: @usertextFontColor;
   }
 
   ul, ol {

--- a/layout/default/variables.less
+++ b/layout/default/variables.less
@@ -79,4 +79,4 @@
 @usertextFontSize: @fontSize;
 @usertextFontColor: @colorFg;
 @usertextFontColorHeading: #505050;
-@emoticonSize: 1.4em;
+@emoticonSize: unit(@usertextLineheight, em);


### PR DESCRIPTION
follow up: https://github.com/cargomedia/CM/pull/1781

- `usertext` should inherit color
- emoticonSize should impact `line-height` 
- ~~additional padding on top / bottom of `usertext` to make sure emoticons don't get cut off~~