### PR TITLE
Wrong param for Params::getLocation() should raise InvalidParam

### DIFF
--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -213,7 +213,15 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
     public function getObject($key, $className, $default = null, Closure $getter = null) {
         if (!$getter) {
             $getter = function ($className, $param) {
-                return new $className($param);
+                $reflectionClass = new ReflectionClass($className);
+                $countArgs = $reflectionClass->getConstructor()->getNumberOfRequiredParameters();
+                if ($countArgs > 1) {
+                    if (!is_array($param) || count($param) < $countArgs) {
+                        throw new CM_Exception_InvalidParam("Not enough parameters", ['parameters' => $param, 'class' => $className]);
+                    }
+                    return $reflectionClass->newInstanceArgs($param);
+                }
+                return $reflectionClass->newInstance($param);
             };
         }
         $param = $this->_get($key, $default);

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -213,19 +213,20 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
     public function getObject($key, $className, $default = null, Closure $getter = null) {
         if (!$getter) {
             $getter = function ($className, $param) {
+                $arguments = (array) $param;
                 $reflectionClass = new ReflectionClass($className);
-                $namedArgs = new CM_Util_NamedArgs();
                 $constructor = $reflectionClass->getConstructor();
-                $countArgs = $constructor->getNumberOfRequiredParameters();
-                if (is_array($param) || $countArgs > 1) {
+
+                if ($constructor->getNumberOfRequiredParameters() > 1) {
+                    $namedArgs = new CM_Util_NamedArgs();
                     try {
-                        $arguments = $namedArgs->matchNamedArgs($constructor, (array) $param);
+                        $arguments = $namedArgs->matchNamedArgs($constructor, $arguments);
                     } catch (CM_Exception_Invalid $ex) {
                         throw new CM_Exception_InvalidParam("Not enough parameters", ['parameters' => $param, 'class' => $className]);
                     }
-                    return $reflectionClass->newInstanceArgs($arguments);
                 }
-                return $reflectionClass->newInstance($param);
+                
+                return $reflectionClass->newInstanceArgs($arguments);
             };
         }
         $param = $this->_get($key, $default);

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -214,12 +214,16 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
         if (!$getter) {
             $getter = function ($className, $param) {
                 $reflectionClass = new ReflectionClass($className);
-                $countArgs = $reflectionClass->getConstructor()->getNumberOfRequiredParameters();
-                if ($countArgs > 1) {
-                    if (!is_array($param) || count($param) < $countArgs) {
+                $namedArgs = new CM_Util_NamedArgs();
+                $constructor = $reflectionClass->getConstructor();
+                $countArgs = $constructor->getNumberOfRequiredParameters();
+                if (is_array($param) || $countArgs > 1) {
+                    try {
+                        $arguments = $namedArgs->matchNamedArgs($constructor, (array) $param);
+                    } catch (CM_Exception_Invalid $ex) {
                         throw new CM_Exception_InvalidParam("Not enough parameters", ['parameters' => $param, 'class' => $className]);
                     }
-                    return $reflectionClass->newInstanceArgs($param);
+                    return $reflectionClass->newInstanceArgs($arguments);
                 }
                 return $reflectionClass->newInstance($param);
             };

--- a/tests/library/CM/ParamsTest.php
+++ b/tests/library/CM/ParamsTest.php
@@ -172,8 +172,8 @@ class CM_ParamsTest extends CMTest_TestCase {
     }
 
     /**
-     * @expectedException ErrorException
-     * @expectedExceptionMessage Missing argument 2
+     * @expectedException CM_Exception_InvalidParam
+     * @expectedExceptionMessage Not enough parameters
      */
     public function testGetGeoPointException() {
         $params = new CM_Params(array('point' => 'foo'));
@@ -226,6 +226,20 @@ class CM_ParamsTest extends CMTest_TestCase {
             $paramsArray = json_decode(json_encode(array('date' => $dateTime)), true);
             $params = new CM_Params($paramsArray, true);
             $this->assertEquals($params->getDateTime('date'), $dateTime);
+        }
+    }
+
+    public function testGetLocation() {
+        $location = CMTest_TH::createLocation();
+        $params = new CM_Params(['location' => $location, 'locationParameters' => ['level' => $location->getLevel(), 'id' => $location->getId()], 'insufficientParameters' => 1]);
+        $this->assertEquals($location, $params->getLocation('location'));
+        $this->assertEquals($location, $params->getLocation('locationParameters'));
+        try {
+            $params->getLocation('insufficientParameters');
+            $this->fail('Instantiating location with insufficient parameters');
+        } catch (CM_Exception_InvalidParam $ex) {
+            $this->assertSame('Not enough parameters', $ex->getMessage());
+            $this->assertSame(['parameters' => 1, 'class' => 'CM_Model_Location'], $ex->getMetaInfo());
         }
     }
 

--- a/tests/library/CM/ParamsTest.php
+++ b/tests/library/CM/ParamsTest.php
@@ -231,7 +231,7 @@ class CM_ParamsTest extends CMTest_TestCase {
 
     public function testGetLocation() {
         $location = CMTest_TH::createLocation();
-        $params = new CM_Params(['location' => $location, 'locationParameters' => ['level' => $location->getLevel(), 'id' => $location->getId()], 'insufficientParameters' => 1]);
+        $params = new CM_Params(['location' => $location, 'locationParameters' => ['id' => $location->getId(), 'level' => $location->getLevel()], 'insufficientParameters' => 1]);
         $this->assertEquals($location, $params->getLocation('location'));
         $this->assertEquals($location, $params->getLocation('locationParameters'));
         try {


### PR DESCRIPTION
Current error:
```
ErrorException: E_WARNING: Missing argument 2 for CM_Model_Location::__construct(), called in /home/example/releases/20150317115306/vendor/cargomedia/cm/library/CM/Params.php on line 216 and defined in /home/example/releases/20150317115306/vendor/cargomedia/cm/library/CM/Model/Location.php on line 19
[...]
    15. SK_Page_Users_Search->prepare(CM_Frontend_Environment, CM_Frontend_ViewResponse) /home/example/releases/20150317115306/vendor/cargomedia/cm/library/CM/RenderAdapter/Component.php:47
    16. CM_Params->getLocation('location') /home/example/releases/20150317115306/library/SK/library/SK/Page/Users/Search.php:37
    17. CM_Params->getObject('location', 'CM_Model_Location') /home/example/releases/20150317115306/vendor/cargomedia/cm/library/CM/Params.php:318
    18. CM_Params->{closure}('CM_Model_Location', array) /home/example/releases/20150317115306/vendor/cargomedia/cm/library/CM/Params.php:224
    19. CM_Model_Location->__construct(array) /home/example/releases/20150317115306/vendor/cargomedia/cm/library/CM/Params.php:216
    20. CM_ExceptionHandling_Handler_Abstract->handleErrorRaw(2, 'Missing argument 2 f...', '/home/example/relea...', 19, array) /home/example/releases/20150317115306/vendor/cargomedia/cm/library/CM/Model/Location.php:19
```

Should throw exception: `CM_Exception_InvalidParam` (like most failures in `CM_Params`)? So it can be treated a warning if coming from user input.

@fauvel fyi