### PR TITLE
GA MP: Send along "hostname"

### DIFF
--- a/library/CMService/GoogleAnalytics/MeasurementProtocol/Client.php
+++ b/library/CMService/GoogleAnalytics/MeasurementProtocol/Client.php
@@ -88,6 +88,9 @@ class CMService_GoogleAnalytics_MeasurementProtocol_Client {
             't'   => [
                 'aliasList' => ['hitType'],
             ],
+            'dh'  => [
+                'aliasList' => ['hostname'],
+            ],
             'ec'  => [
                 'aliasList'   => ['eventCategory'],
                 'hitTypeList' => ['event'],

--- a/tests/library/CMService/GoogleAnalytics/MeasurementProtocol/ClientTest.php
+++ b/tests/library/CMService/GoogleAnalytics/MeasurementProtocol/ClientTest.php
@@ -26,6 +26,7 @@ class CMService_GoogleAnalytics_MeasurementProtocol_ClientTest extends CMTest_Te
                 'ea' => 'MyAction',
                 'el' => 'MyLabel',
                 'ev' => 123,
+                'dh' => 'example.com',
                 't'  => 'event',
             ], $parameterList);
         });
@@ -37,6 +38,7 @@ class CMService_GoogleAnalytics_MeasurementProtocol_ClientTest extends CMTest_Te
             'eventAction'   => 'MyAction',
             'eventLabel'    => 'MyLabel',
             'eventValue'    => 123,
+            'hostname'      => 'example.com',
         ]);
         $this->assertSame(1, $submitRequestMock->getCallCount());
     }


### PR DESCRIPTION
Currently we don't send a hostname to *GA Measurement Protocol* when tracking hits. This is problematic because we then aren't able to filter traffic by "hostname" in views.

It looks like we can send it along as `dh`:
https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#dh

Also note they now have a "debugging" endpoint:
https://developers.google.com/analytics/devguides/collection/protocol/v1/validating-hits

@fauvel maybe something for you?