### PR TITLE
Remove test classes from autoloader in production

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,11 @@
   "autoload": {
     "psr-0": {
       "CM_": "library/",
-      "CMService_": "library/",
+      "CMService_": "library/"
+    }
+  },
+  "autoload-dev": {
+    "psr-0": {
       "CMTest_": "tests/helpers/CMTest/library/"
     }
   },


### PR DESCRIPTION
The latest version of composer [won't filter out test classes](https://github.com/composer/composer/commit/8e9659bd8317ad3f623c4d17940380443cf8772c) based on file names any more, so that they will be included in the optimized class autoloader in production, even with the `--no-dev` option. To get rid of them again, the autoloader configuration must be moved to the [autoload-dev](autoload-dev) section.