### PR TITLE
Keep array index order in provision script loader

### DIFF
--- a/library/CM/Provision/Loader.php
+++ b/library/CM/Provision/Loader.php
@@ -67,7 +67,7 @@ class CM_Provision_Loader {
     protected function _getScriptList() {
         $scriptList = $this->_scriptList;
         $runLevelList = \Functional\invoke($scriptList, 'getRunLevel');
-        array_multisort($runLevelList, $scriptList);
+        array_multisort($runLevelList, array_keys($scriptList), $scriptList);
         return $scriptList;
     }
 }

--- a/tests/library/CM/Setup/LoaderTest.php
+++ b/tests/library/CM/Setup/LoaderTest.php
@@ -8,14 +8,20 @@ class CM_Provision_LoaderTest extends CMTest_TestCase {
         $script2->mockMethod('getRunLevel')->set(10);
         $script3 = $this->mockClass('CM_Provision_Script_Abstract')->newInstanceWithoutConstructor();
         $script3->mockMethod('getRunLevel')->set(1);
+        $script4 = $this->mockClass('CM_Provision_Script_Abstract')->newInstanceWithoutConstructor();
+        $script4->mockMethod('getRunLevel')->set(1);
+        $script5 = $this->mockClass('CM_Provision_Script_Abstract')->newInstanceWithoutConstructor();
+        $script5->mockMethod('getRunLevel')->set(1);
 
         $loader = new CM_Provision_Loader();
         $loader->registerScript($script1);
         $loader->registerScript($script2);
         $loader->registerScript($script3);
+        $loader->registerScript($script4);
+        $loader->registerScript($script5);
 
         $scriptList = CMTest_TH::callProtectedMethod($loader, '_getScriptList');
-        $expected = [$script3, $script1, $script2];
+        $expected = [$script3, $script4, $script5, $script1, $script2];
         $this->assertSame($expected, $scriptList);
     }
 


### PR DESCRIPTION
In `CM_Provision_Loader::_getScriptList()` we should keep the original array's order for items with the same run-level.

We could implement a custom callback for ordering that considers the index from the original array.