### PR TITLE
Don't load JS files individually in debug mode

### DIFF
--- a/library/CM/Http/Response/Resource/Javascript/Library.php
+++ b/library/CM/Http/Response/Resource/Javascript/Library.php
@@ -4,13 +4,7 @@ class CM_Http_Response_Resource_Javascript_Library extends CM_Http_Response_Reso
 
     protected function _process() {
         if ($this->getRequest()->getPath() === '/library.js') {
-            $query = $this->getRequest()->getQuery();
-            $skipLibraries = !empty($query['debug']);
-            if ($skipLibraries) {
-                $this->_setAsset(new CM_Asset_Javascript_Internal($this->getSite()));
-            } else {
-                $this->_setAsset(new CM_Asset_Javascript_Library($this->getSite()));
-            }
+            $this->_setAsset(new CM_Asset_Javascript_Library($this->getSite()));
             return;
         }
         if ($this->getRequest()->getPathPart(0) === 'translations') {

--- a/library/CM/SmartyPlugins/function.resourceJs.php
+++ b/library/CM/SmartyPlugins/function.resourceJs.php
@@ -5,40 +5,11 @@ function smarty_function_resourceJs(array $params, Smarty_Internal_Template $tem
     $render = $template->smarty->getTemplateVars('render');
     $type = (string) $params['type'];
     $file = (string) $params['file'];
-    return smarty_helper_resourceJs($type, $file, $render);
-}
 
-/**
- * @param string    $type
- * @param string    $file
- * @param CM_Frontend_Render $render
- * @return string
- * @throws CM_Exception_Invalid
- */
-function smarty_helper_resourceJs($type, $file, $render) {
     if (!in_array($type, array('vendor', 'library'))) {
         throw new CM_Exception_Invalid('Invalid type `' . $type . '` provided');
     }
-    if (CM_Bootloader::getInstance()->isDebug() && $type === 'library' && $file === 'library.js') {
-        return smarty_helper_resourceJs_libraryDebug($render);
-    }
+
     $url = $render->getUrlResource($type . '-js', $file);
     return '<script type="text/javascript" src="' . $url . '" crossorigin="anonymous"></script>' . PHP_EOL;
-}
-
-/**
- * @param CM_Frontend_Render $render
- * @return string
- */
-function smarty_helper_resourceJs_libraryDebug(CM_Frontend_Render $render) {
-    $paths = CM_Asset_Javascript_Library::getIncludedPaths($render->getSite());
-    $content = '';
-    foreach ($paths as $path) {
-        $path = str_replace(DIR_ROOT, '/', $path);
-        $path = str_replace(DIRECTORY_SEPARATOR, '/', $path);
-        $path .= '?' . CM_App::getInstance()->getDeployVersion();
-        $content .= '<script type="text/javascript" src="' . $path . '"></script>' . PHP_EOL;
-    }
-    $content .= smarty_helper_resourceJs('library', 'library.js?debug=true', $render);
-    return $content;
 }


### PR DESCRIPTION
@tomaszdurka @vogdb

I would suggest to remove the individual loading of all library files in debug mode.
Doing so has some disadvantages like that the browser loads *a lot* of files one by one, which takes especially long on mobile devices.
The advantage of loading them individually is only that the line numbers match the ones in the original file. I don't think that is very important.
What do you think?

Related:
https://github.com/cargomedia/puppet-packages/blob/master/modules/cm/manifests/vhost.pp#L74