### PR TITLE
Remove message about "IE compatibility mode"

### DIFF
--- a/layout/default/Layout/Abstract/default.tpl
+++ b/layout/default/Layout/Abstract/default.tpl
@@ -61,7 +61,6 @@
       <div id="browserNotSupported">
         <h2><span class="icon-warning"></span> {translate 'Your browser is no longer supported.'}</h2>
         <p>{translate 'We recommend upgrading to the latest Internet Explorer, Google Chrome, Firefox, or Opera. Click here for <a href="{$url}">more information</a>.' url='http://whatbrowser.org'}
-        <p>{translate 'If you are using IE 9 or later, make sure you <a href="{$url}">turn off "Compatibility View"</a>.' url='http://windows.microsoft.com/en-us/internet-explorer/use-compatibility-view'}</p>
       </div>
     {/if}
 

--- a/resources/db/update/50.php
+++ b/resources/db/update/50.php
@@ -1,0 +1,3 @@
+<?php
+
+CM_Model_LanguageKey::deleteByName('If you are using IE 9 or later, make sure you <a href="{$url}">turn off "Compatibility View"</a>.');


### PR DESCRIPTION
@christopheschwyzer I'd suggest to remove this. The "IE 9" was outdated anyway, and I think IE doesn't trigger "compatibility mode" anymore?