### PR TITLE
CM_App.ajax: Should cancel promise when "xhr.status === 0"

### DIFF
--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -847,7 +847,7 @@ var CM_App = CM_Class_Abstract.extend({
         }
       }).fail(function(xhr, textStatus) {
         if (xhr.status === 0) {
-          return; // Ignore interrupted ajax-request caused by leaving a page
+          reject(Promise.CancellationError());
         }
 
         var msg = cm.language.get('An unexpected connection problem occurred.');


### PR DESCRIPTION
Currently we silently ignore AJAX errors with `xhr.status === 0`:
```js
      }).fail(function(xhr, textStatus) {
        if (xhr.status === 0) {
          return; // Ignore interrupted ajax-request caused by leaving a page
        }
```

In that case the promise will never be resolved nor rejected. This is problematic especially when you want to clean up resources in a *finally* block.

How about cancelling the promise in that case (i.e. rejecting it with this "Cancellation" error)? This case usually is kind of a cancellation - the user navigates away and the browser therefore cancels the request.

cc @tomaszdurka 