### PR TITLE
Ajax/Promise "throttler" to avoid multiple requests

### DIFF
--- a/client-vendor/after-body/promise-throttler/promise-throttler.js
+++ b/client-vendor/after-body/promise-throttler/promise-throttler.js
@@ -7,17 +7,27 @@
   var storage = {};
 
   /**
-   * @param {String} name
-   * @param {Promise} promise
-   * @returns {Promise}
+   * @callback PromiseThrottled
+   * @param {...Object|String|Number} any number of optional params
+   * @return {Promise}
    */
-  function promiseThrottler(name, promise) {
-    if (!storage[name]) {
-      storage[name] = promise.finally(function() {
-        delete storage[name];
-      });
-    }
-    return storage[name];
+
+  /**
+   * @param {PromiseThrottled} fn
+   * @param {Boolean} cancel
+   * @returns {PromiseThrottled}
+   */
+  function promiseThrottler(fn, cancel) {
+    var promise;
+    return function() {
+      if (cancel && promise && promise.isPending()) {
+        promise.cancel();
+      }
+      if (!promise || !promise.isPending()) {
+        promise = fn.apply(null, arguments);
+      }
+      return promise;
+    };
   }
 
   global.promiseThrottler = promiseThrottler;

--- a/client-vendor/after-body/promise-throttler/promise-throttler.js
+++ b/client-vendor/after-body/promise-throttler/promise-throttler.js
@@ -1,0 +1,20 @@
+/*
+ * Author: CM
+ */
+
+(function(global) {
+
+  var storage = {};
+
+  function promiseThrottler(name, promise) {
+    if (!storage[name]) {
+      storage[name] = promise.finally(function() {
+        delete storage[name];
+      });
+    }
+    return storage[name];
+  }
+
+  global.promiseThrottler = promiseThrottler;
+
+})(window);

--- a/client-vendor/after-body/promise-throttler/promise-throttler.js
+++ b/client-vendor/after-body/promise-throttler/promise-throttler.js
@@ -19,10 +19,11 @@
   function promiseThrottler(fn, options) {
     options = _.defaults(options, {cancel: false});
     var promise;
-    
+
     return function() {
-      if (options.cancel && promise && promise.isPending()) {
+      if (options.cancel && promise && promise.isPending() && promise.isCancellable()) {
         promise.cancel();
+        promise = null;
       }
       if (!promise || !promise.isPending()) {
         promise = fn.apply(null, arguments);

--- a/client-vendor/after-body/promise-throttler/promise-throttler.js
+++ b/client-vendor/after-body/promise-throttler/promise-throttler.js
@@ -4,8 +4,6 @@
 
 (function(global) {
 
-  var storage = {};
-
   /**
    * @callback PromiseThrottled
    * @param {...Object|String|Number} any number of optional params
@@ -14,13 +12,16 @@
 
   /**
    * @param {PromiseThrottled} fn
-   * @param {Boolean} cancel
+   * @param {Object|null} options
+   * @param {Boolean} options.cancel Whether to cancel the previous promise if it is still running.
    * @returns {PromiseThrottled}
    */
-  function promiseThrottler(fn, cancel) {
+  function promiseThrottler(fn, options) {
+    options = _.defaults(options, {cancel: false});
     var promise;
+    
     return function() {
-      if (cancel && promise && promise.isPending()) {
+      if (options.cancel && promise && promise.isPending()) {
         promise.cancel();
       }
       if (!promise || !promise.isPending()) {

--- a/client-vendor/after-body/promise-throttler/promise-throttler.js
+++ b/client-vendor/after-body/promise-throttler/promise-throttler.js
@@ -6,6 +6,11 @@
 
   var storage = {};
 
+  /**
+   * @param {String} name
+   * @param {Promise} promise
+   * @returns {Promise}
+   */
   function promiseThrottler(name, promise) {
     if (!storage[name]) {
       storage[name] = promise.finally(function() {

--- a/library/CM/FormField/Suggest.js
+++ b/library/CM/FormField/Suggest.js
@@ -31,17 +31,14 @@ var CM_FormField_Suggest = CM_FormField_Abstract.extend({
       escapeMarkup: function(item) {
         return item;
       },
-      query: function(options) {
-        if (this._request) {
-          this._request.cancel();
-        }
-        this._request = field.ajax('getSuggestions', {'term': options.term, 'options': field.getOptions()})
+      query: promiseThrottler(function(options) {
+        return field.ajax('getSuggestions', {'term': options.term, 'options': field.getOptions()})
           .then(function(results) {
             options.callback({
               results: results
             });
           });
-      },
+      }, true),
       createSearchChoice: function(term, data) {
         if (field.getOption("enableChoiceCreate")) {
           var existingMatches = $(data).filter(function() {

--- a/library/CM/FormField/Suggest.js
+++ b/library/CM/FormField/Suggest.js
@@ -8,9 +8,6 @@ var CM_FormField_Suggest = CM_FormField_Abstract.extend({
   /** @type {jQuery} */
   _$input: null,
 
-  /** @type {Promise} */
-  _request: null,
-
   ready: function() {
     var field = this;
     var cardinality = this.getOption("cardinality");
@@ -38,7 +35,7 @@ var CM_FormField_Suggest = CM_FormField_Abstract.extend({
               results: results
             });
           });
-      }, true),
+      }, {cancel: true}),
       createSearchChoice: function(term, data) {
         if (field.getOption("enableChoiceCreate")) {
           var existingMatches = $(data).filter(function() {

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -16,8 +16,8 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
   /** @type {Number} timeout ID */
   _timeoutLoading: null,
 
-  _ready: function() {
-    CM_View_Abstract.prototype._ready.call(this);
+  initialize: function() {
+    CM_View_Abstract.prototype.initialize.call(this);
 
     var layout = this;
     this._pageRequest = promiseThrottler(function(path) {

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -13,6 +13,48 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
   /** @type Promise|Null */
   _pageRequest: null,
 
+  /** @type {Number} timeout ID */
+  _timeoutLoading: null,
+
+  _ready: function() {
+    CM_View_Abstract.prototype._ready.call(this);
+
+    var layout = this;
+    this._pageRequest = promiseThrottler(function(path) {
+      return layout.ajaxModal('loadPage', {path: path})
+        .then(function(response) {
+          window.clearTimeout(layout._timeoutLoading);
+          if (response.redirectExternal) {
+            cm.router.route(response.redirectExternal);
+            return;
+          }
+          var view = layout._injectView(response);
+          var reload = (layout.getClass() != response.layoutClass);
+          if (reload) {
+            window.location.replace(response.url);
+            return;
+          }
+          layout._$pagePlaceholder.replaceWith(view.$el);
+          layout._$pagePlaceholder = null;
+          var fragment = response.url.substr(cm.getUrl().length);
+          if (path === fragment + window.location.hash) {
+            fragment = path;
+          }
+          window.history.replaceState(null, null, fragment);
+          layout._onPageSetup(view, response.title, response.url, response.menuEntryHashList, response.jsTracking);
+          view._ready();
+          return view;
+        })
+        .catch(function(error) {
+          if (!(error instanceof Promise.CancellationError)) {
+            window.clearTimeout(layout._timeoutLoading);
+            layout._$pagePlaceholder.addClass('error').html('<pre>' + error.msg + '</pre>');
+            layout._onPageError();
+          }
+        });
+    }, {cancel: true});
+  },
+
   /**
    * @returns {CM_View_Abstract|null}
    */
@@ -44,45 +86,10 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
     } else {
       this._$pagePlaceholder.removeClass('error').html('');
     }
-    var timeoutLoading = this.setTimeout(function() {
+    this._timeoutLoading = this.setTimeout(function() {
       this._$pagePlaceholder.html('<div class="spinner spinner-expanded" />');
     }, 750);
-
-    if (this._pageRequest) {
-      this._pageRequest.cancel();
-    }
-    var layout = this;
-    this._pageRequest = this.ajaxModal('loadPage', {path: path})
-      .then(function(response) {
-        if (response.redirectExternal) {
-          cm.router.route(response.redirectExternal);
-          return;
-        }
-        var view = layout._injectView(response);
-        var reload = (layout.getClass() != response.layoutClass);
-        if (reload) {
-          window.location.replace(response.url);
-          return;
-        }
-        layout._$pagePlaceholder.replaceWith(view.$el);
-        layout._$pagePlaceholder = null;
-        var fragment = response.url.substr(cm.getUrl().length);
-        if (path === fragment + window.location.hash) {
-          fragment = path;
-        }
-        window.history.replaceState(null, null, fragment);
-        layout._onPageSetup(view, response.title, response.url, response.menuEntryHashList, response.jsTracking);
-        view._ready();
-        return view;
-      })
-      .catch(function(error) {
-        if (!(error instanceof Promise.CancellationError)) {
-          layout._$pagePlaceholder.addClass('error').html('<pre>' + error.msg + '</pre>');
-          layout._onPageError();
-        }
-      }).finally(function() {
-        window.clearTimeout(timeoutLoading);
-      });
+    this._pageRequest(path);
   },
 
   /**

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -10,8 +10,8 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
   /** @type jQuery|Null */
   _$pagePlaceholder: null,
 
-  /** @type Promise|Null */
-  _pageRequest: null,
+  /** @type PromiseThrottled|Null */
+  _loadPageThrottled: null,
 
   /** @type {Number} timeout ID */
   _timeoutLoading: null,
@@ -20,7 +20,7 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
     CM_View_Abstract.prototype.initialize.call(this);
 
     var layout = this;
-    this._pageRequest = promiseThrottler(function(path) {
+    this._loadPageThrottled = promiseThrottler(function(path) {
       return layout.ajaxModal('loadPage', {path: path})
         .then(function(response) {
           window.clearTimeout(layout._timeoutLoading);
@@ -90,7 +90,7 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
     this._timeoutLoading = this.setTimeout(function() {
       this._$pagePlaceholder.html('<div class="spinner spinner-expanded" />');
     }, 750);
-    this._pageRequest(path);
+    this._loadPageThrottled(path);
   },
 
   /**


### PR DESCRIPTION
We often times want to avoid multiple concurrent ajax requests of the same time.

Usually we do:
```js
var requestList = {};

/**
 * @returns Promise
 */
function doSomething()  {
 if (requestList['something']) {
  return requestList['something'];
 }
 return requestList['something'] = ajax();
}
```

It would be nice to wrap this into a small script, so we don't need to declare `requestList` every time, plus have a nicer interface. Preferably it would would work as kind of like a "Promise throttling":
```js
/**
 * @returns Promise
 */
function doSomething() {
 return promiseThrottler('something', function() {
  return ajax(); // returns Promise
 });
}
```

@vogdb @tomaszdurka thoughts?
Related to https://github.com/cargomedia/CM/issues/1754