### PR TITLE
Allow passing objects as parameters to cm.getUrl()

### DIFF
--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -126,7 +126,7 @@ var CM_App = CM_Class_Abstract.extend({
     params = params || null;
     relative = relative || false;
     if (params) {
-      path += '?' + jQuery.param(params, true);
+      path += '?' + jQuery.param(params);
     }
     if (!relative) {
       path = cm.options.url + path

--- a/tests/library/CM/UtilTest.php
+++ b/tests/library/CM/UtilTest.php
@@ -99,6 +99,7 @@ class CM_UtilTest extends CMTest_TestCase {
     public function testLink() {
         $this->assertSame('/test', CM_Util::link('/test'));
         $this->assertSame('/test?a=1&b=%C3%B8', CM_Util::link('/test', ['a' => 1, 'b' => 'ø']));
+        $this->assertSame('/test?foo%5Bbar%5D=12', CM_Util::link('/test', ['foo' => ['bar' => 12]]));
         $this->assertSame('/test?a=1#anchor', CM_Util::link('/test', ['a' => 1], 'anchor'));
         $this->assertSame('/test#anchor', CM_Util::link('/test', null, 'anchor'));
     }


### PR DESCRIPTION
This will allow to pass params like `{foo: {bar: 12}}` as parameters and result in `?foo[bar]=12`.
I need this for some URLs in sk. 

No existing usages are affected.

@vogdb please review
@christopheschwyzer fyi