### PR TITLE
Layout::loadPage: Error catching too broad?

### DIFF
--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -281,10 +281,13 @@ var CM_App = CM_Class_Abstract.extend({
     },
     /**
      * @param {Object} content
+     * @param {String} content.msg
+     * @param {String} content.type
+     * @param {Boolean} content.isPublic
      * @return {Error}
      */
     create: function(content) {
-      var error = new Error();
+      var error = new Error(content.msg);
       return _.extend(error, content);
     }
   },
@@ -678,7 +681,7 @@ var CM_App = CM_Class_Abstract.extend({
         e.preventDefault();
         var error = e.originalEvent.detail.reason;
         if (!(error instanceof Promise.CancellationError)) {
-          cm.error.trigger(error.msg, error.type, error.isPublic);
+          throw error;
         }
       });
       $(window).focus(function() {

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -79,6 +79,7 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
         if (!(error instanceof Promise.CancellationError)) {
           layout._$pagePlaceholder.addClass('error').html('<pre>' + error.msg + '</pre>');
           layout._onPageError();
+          throw error;
         }
       }).finally(function() {
         window.clearTimeout(timeoutLoading);


### PR DESCRIPTION
The ajax request in `loadPage()` previously would handle *ajax* error in an error callback:
```js
    this._pageRequest = this.ajaxModal('loadPage', {path: path}, {
      success: function(response) {
[...]
      },
      error: function(msg, type, isPublic) {
[...]
      }
    });
```
If anything went wrong in the `success` handler it would throw an unhandled error and would eventually be logged back to our server as a "JS error".

With the new Promise-based implementation the code looks like this:
```js
    this._pageRequest = this.ajaxModal('loadPage', {path: path})
      .then(function(response) {
[...]
      })
      .catch(function(error) {
[...]
      })
```
Which means that an error in `then` will be catched in `catch` and *not* be logged to the server.

I guess it's good to set the layout into an "error" state in case of *any* errors. Should we additionally throw again to log it to the server?
@vogdb @tomaszdurka wdyt?
cc @fauvel 