### PR TITLE
Move tracking code to the body for AdAgnit

### DIFF
--- a/layout/default/Layout/Abstract/default.tpl
+++ b/layout/default/Layout/Abstract/default.tpl
@@ -53,10 +53,9 @@
     {resourceCss file='all.css' type="library"}
     {resourceJs file='before-body.js' type="vendor"}
     {block name='head'}{/block}
-
-    {$render->getServiceManager()->getTrackings()->getHtml($render->getEnvironment())}
   </head>
   <body id="{$viewResponse->getAutoId()}" class="{$viewResponse->getCssClasses()|implode:' '}">
+    {$render->getServiceManager()->getTrackings()->getHtml($render->getEnvironment())}
     {if CM_Http_Request_Abstract::hasInstance() && !CM_Http_Request_Abstract::getInstance()->isSupported()}
       <div id="browserNotSupported">
         <h2><span class="icon-warning"></span> {translate 'Your browser is no longer supported.'}</h2>


### PR DESCRIPTION
Fixes the AdAgnit integration – their (synchronous) script relies on `document.body`.