### PR TITLE
Indication for lazy loading images

### DIFF
--- a/layout/default/css/contentPlaceholder.less
+++ b/layout/default/css/contentPlaceholder.less
@@ -15,6 +15,7 @@
     left: 0;
     width: 100%;
     height: 100%;
+    background-color: @colorBgBody;
   }
 
   &.stretch {


### PR DESCRIPTION
Currently the space used for lazily loaded images is just white. On white background one doesn't see that something should load in that place.

I would suggest to make those boxes background light grey.

@christopheschwyzer @vogdb wdyt? can we do it with CSS?