### PR TITLE
Model default data is not validated during commit

### DIFF
--- a/library/CM/Model/Abstract.php
+++ b/library/CM/Model/Abstract.php
@@ -42,7 +42,6 @@ abstract class CM_Model_Abstract extends CM_Class_Abstract
             $this->_id = self::_castIdRaw($id);
         }
         if (null !== $data) {
-            $this->_validateFields($data);
             $this->_setData($data);
         }
         foreach ($this->_getAssets() as $asset) {
@@ -266,19 +265,16 @@ abstract class CM_Model_Abstract extends CM_Class_Abstract
         if (null === $this->_data) {
             if ($cache = $this->_getCache()) {
                 if (false !== ($data = $cache->load($this->getType(), $this->getIdRaw()))) {
-                    $this->_validateFields($data);
                     $this->_setData($data);
                 }
             }
             if (null === $this->_data) {
                 if ($persistence = $this->_getPersistence()) {
                     if (false !== ($data = $persistence->load($this->getType(), $this->getIdRaw()))) {
-                        $this->_validateFields($data);
                         $this->_setData($data);
                     }
                 } else {
                     if (is_array($data = $this->_loadData())) {
-                        $this->_validateFields($data);
                         $this->_setData($data);
                     }
                 }
@@ -299,6 +295,7 @@ abstract class CM_Model_Abstract extends CM_Class_Abstract
      * @param array $data
      */
     protected function _setData(array $data) {
+        $this->_validateFields($data);
         $this->_data = $data;
     }
 

--- a/library/CM/Model/Abstract.php
+++ b/library/CM/Model/Abstract.php
@@ -66,6 +66,7 @@ abstract class CM_Model_Abstract extends CM_Class_Abstract
             }
             $this->_onChange();
         } else {
+            $this->_validateFields($this->_getData());
             $this->_id = self::_castIdRaw($persistence->create($this->getType(), $this->_getSchemaData()));
 
             if ($cache = $this->_getCache()) {

--- a/library/CM/Model/Abstract.php
+++ b/library/CM/Model/Abstract.php
@@ -66,7 +66,7 @@ abstract class CM_Model_Abstract extends CM_Class_Abstract
             }
             $this->_onChange();
         } else {
-            $this->_validateFields($this->_getData());
+            $this->_validateFields($this->_getData(), true);
             $this->_id = self::_castIdRaw($persistence->create($this->getType(), $this->_getSchemaData()));
 
             if ($cache = $this->_getCache()) {
@@ -434,12 +434,20 @@ abstract class CM_Model_Abstract extends CM_Class_Abstract
     }
 
     /**
-     * @param array $data
+     * @param array     $data
+     * @param bool|null $checkMissingFields
      */
-    protected function _validateFields(array $data) {
+    protected function _validateFields(array $data, $checkMissingFields = null) {
         if ($schema = $this->_getSchema()) {
-            foreach ($data as $key => $value) {
-                $schema->validateField($key, $value);
+            if ($checkMissingFields) {
+                foreach ($schema->getFieldNames() as $key) {
+                    $value = isset($data[$key]) ? $data[$key] : null;
+                    $schema->validateField($key, $value);
+                }
+            } else {
+                foreach ($data as $key => $value) {
+                    $schema->validateField($key, $value);
+                }
             }
         }
     }

--- a/tests/library/CM/Model/AbstractTest.php
+++ b/tests/library/CM/Model/AbstractTest.php
@@ -121,6 +121,26 @@ class CM_Model_AbstractTest extends CMTest_TestCase {
         $this->assertSame(1, $methodValidateFields->getCallCount());
     }
 
+    public function testCreateValidatesFields() {
+        $modelMock = $this->mockObject('CM_Model_Abstract');
+        $methodValidateFields = $modelMock->mockMethod('_validateFields');
+        $methodValidateFields->set(function ($data) {
+            $this->assertSame([], $data);
+        });
+        $modelMock->mockMethod('_getPersistence')->set(function () {
+            return new CM_Model_StorageAdapter_Database();
+        });
+        $modelMock->mockMethod('getType')->set(function () {
+            return 12;
+        });
+        $modelMock->mockMethod('_getSchema')->set(function () {
+            return new CM_Model_Schema_Definition([]);
+        });
+        /** @var CM_Model_Abstract $modelMock */
+        $modelMock->commit();
+        $this->assertSame(1, $methodValidateFields->getCallCount());
+    }
+
     public function testCommit() {
         $schema = new CM_Model_Schema_Definition(array('foo' => array()));
         $idRaw = array('id' => '909');

--- a/tests/library/CM/Model/AbstractTest.php
+++ b/tests/library/CM/Model/AbstractTest.php
@@ -108,6 +108,19 @@ class CM_Model_AbstractTest extends CMTest_TestCase {
         $this->assertSame($data, $getData->invoke($modelMock));
     }
 
+    public function testSetDataValidatesFields() {
+        $data = array('foo' => 12, 'bar' => 23);
+
+        $modelMock = $this->mockObject('CM_Model_Abstract');
+        $methodValidateFields = $modelMock->mockMethod('_validateFields');
+        $methodValidateFields->set(function ($dataActual) use ($data) {
+            $this->assertEquals($dataActual, $data);
+        });
+
+        $this->forceInvokeMethod($modelMock, '_setData', [$data]);
+        $this->assertSame(1, $methodValidateFields->getCallCount());
+    }
+
     public function testCommit() {
         $schema = new CM_Model_Schema_Definition(array('foo' => array()));
         $idRaw = array('id' => '909');

--- a/tests/library/CM/Model/AbstractTest.php
+++ b/tests/library/CM/Model/AbstractTest.php
@@ -124,8 +124,9 @@ class CM_Model_AbstractTest extends CMTest_TestCase {
     public function testCreateValidatesFields() {
         $modelMock = $this->mockObject('CM_Model_Abstract');
         $methodValidateFields = $modelMock->mockMethod('_validateFields');
-        $methodValidateFields->set(function ($data) {
+        $methodValidateFields->set(function ($data, $checkMissingFields) {
             $this->assertSame([], $data);
+            $this->assertSame(true, $checkMissingFields);
         });
         $modelMock->mockMethod('_getPersistence')->set(function () {
             return new CM_Model_StorageAdapter_Database();
@@ -139,6 +140,25 @@ class CM_Model_AbstractTest extends CMTest_TestCase {
         /** @var CM_Model_Abstract $modelMock */
         $modelMock->commit();
         $this->assertSame(1, $methodValidateFields->getCallCount());
+    }
+
+    /**
+     * @expectedException CM_Model_Exception_Validation
+     * @expectedExceptionMessage Field `foo` is mandatory
+     */
+    public function testCreateMissingField() {
+        $modelMock = $this->mockObject('CM_Model_Abstract');
+        $modelMock->mockMethod('_getPersistence')->set(function () {
+            return new CM_Model_StorageAdapter_Database();
+        });
+        $modelMock->mockMethod('getType')->set(function () {
+            return 12;
+        });
+        $modelMock->mockMethod('_getSchema')->set(function () {
+            return new CM_Model_Schema_Definition(['foo' => ['type' => 'int']]);
+        });
+        /** @var CM_Model_Abstract $modelMock */
+        $modelMock->commit();
     }
 
     public function testCommit() {


### PR DESCRIPTION
Data field values are only validated when setting the value. 
It's possible to commit invalid (empty) value when commiting without `_set`.