### PR TITLE
GA tracking: escaping

### DIFF
--- a/library/CMService/GoogleAnalytics/Client.php
+++ b/library/CMService/GoogleAnalytics/Client.php
@@ -114,10 +114,10 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
     public function getJs() {
         $js = '';
         foreach ($this->_fieldList as $fieldName => $fieldValue) {
-            $js .= 'ga("set", "' . $fieldName . '", "' . $fieldValue . '");';
+            $js .= 'ga("set", ' . CM_Params::jsonEncode($fieldName) . ', ' . CM_Params::jsonEncode($fieldValue) . ');';
         }
         foreach ($this->_pageViewList as $pageView) {
-            $js .= 'ga("send", "pageview", "' . $pageView . '");';
+            $js .= 'ga("send", "pageview", ' . CM_Params::jsonEncode($pageView) . ');';
         }
         foreach ($this->_eventList as $event) {
             $js .= 'ga("send", ' . CM_Params::jsonEncode(array_filter([

--- a/library/CMService/GoogleAnalytics/Client.php
+++ b/library/CMService/GoogleAnalytics/Client.php
@@ -176,7 +176,7 @@ EOF;
             $fieldList['userId'] = (string) $user->getId();
         }
 
-        $html .= 'ga("create", "' . $this->_getCode() . '", ' . CM_Params::jsonEncode(array_filter($fieldList)) . ');';
+        $html .= 'ga("create", ' . CM_Params::jsonEncode($this->_getCode()) . ', ' . CM_Params::jsonEncode(array_filter($fieldList)) . ');';
         $html .= $this->getJs();
         $html .= '</script>';
 

--- a/tests/library/CM/Http/Response/PageTest.php
+++ b/tests/library/CM/Http/Response/PageTest.php
@@ -81,7 +81,7 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $response->process();
         $html = $response->getContent();
 
-        $this->assertNotContains('ga("send", "pageview", "/mock5")', $html);
+        $this->assertNotContains('ga("send", "pageview", "\/mock5")', $html);
         $this->assertNotContains("_kmq.push(['identify'", $html);
         $this->assertNotContains("_kmq.push(['alias'", $html);
     }
@@ -104,7 +104,7 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $html = $response->getContent();
 
         $this->assertContains('ga("create", "ga123"', $html);
-        $this->assertContains('ga("send", "pageview", "/v/foo")', $html);
+        $this->assertContains('ga("send", "pageview", "\/v\/foo")', $html);
         $this->assertContains('var _kmq = _kmq || [];', $html);
         $this->assertContains("var _kmk = _kmk || 'km123';", $html);
         $clientId = CM_Http_Request_Abstract::getInstance()->getClientId();
@@ -123,7 +123,7 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $html = $response->getContent();
 
         $this->assertContains('ga("create", "ga123"', $html);
-        $this->assertContains('ga("send", "pageview", "/v/bar")', $html);
+        $this->assertContains('ga("send", "pageview", "\/v\/bar")', $html);
         $this->assertContains('var _kmq = _kmq || [];', $html);
         $this->assertContains("var _kmk = _kmk || 'km123';", $html);
         $clientId = CM_Http_Request_Abstract::getInstance()->getClientId();
@@ -138,7 +138,7 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $html = $response->getContent();
 
         $this->assertContains('ga("create", "ga123"', $html);
-        $this->assertContains('ga("send", "pageview", "/mock5")', $html);
+        $this->assertContains('ga("send", "pageview", "\/mock5")', $html);
         $this->assertContains('var _kmq = _kmq || [];', $html);
         $this->assertContains("var _kmk = _kmk || 'km123';", $html);
         $clientId = CM_Http_Request_Abstract::getInstance()->getClientId();
@@ -158,7 +158,7 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $html = $response->getContent();
 
         $this->assertContains('ga("create", "ga123"', $html);
-        $this->assertContains('ga("send", "pageview", "/mock5")', $html);
+        $this->assertContains('ga("send", "pageview", "\/mock5")', $html);
         $this->assertContains('var _kmq = _kmq || [];', $html);
         $this->assertContains("var _kmk = _kmk || 'km123';", $html);
         $clientId = CM_Http_Request_Abstract::getInstance()->getClientId();

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -97,7 +97,8 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
 
         $this->assertViewResponseSuccess($response);
         $responseContent = CM_Params::decode($response->getContent(), true);
-        $this->assertContains('ga("send", "pageview", "' . $page::getPath() . '")', $responseContent['success']['data']['jsTracking']);
+        $pageview = CM_Params::jsonEncode($page::getPath());
+        $this->assertContains('ga("send", "pageview", ' . $pageview . ')', $responseContent['success']['data']['jsTracking']);
     }
 
     public function testLoadPageTrackingRedirect() {
@@ -110,7 +111,8 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
         $responseContent = CM_Params::decode($response->getContent(), true);
         $jsTracking = $responseContent['success']['data']['jsTracking'];
         $this->assertSame(1, substr_count($jsTracking, 'ga("send", "pageview"'));
-        $this->assertContains('ga("send", "pageview", "' . $page::getPath() . '?count=0")', $jsTracking);
+        $pageview = CM_Params::jsonEncode($page::getPath() . '?count=0');
+        $this->assertContains('ga("send", "pageview", ' . $pageview . ')', $jsTracking);
     }
 
     public function testLoadPageTrackingError() {
@@ -129,7 +131,7 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
         $html = $responseContent['success']['data']['html'];
 
         $this->assertSame(1, substr_count($jsTracking, 'ga("send", "pageview"'));
-        $this->assertContains('ga("send", "pageview", "/iwhdfkjlsh")', $jsTracking);
+        $this->assertContains('ga("send", "pageview", "\/iwhdfkjlsh")', $jsTracking);
         $this->assertContains('CM_Page_View_Ajax_Test_Mock', $html);
     }
 

--- a/tests/library/CMService/GoogleAnalytics/ClientTest.php
+++ b/tests/library/CMService/GoogleAnalytics/ClientTest.php
@@ -50,8 +50,10 @@ class CMService_GoogleAnalytics_ClientTest extends CMTest_TestCase {
         $this->assertNotContains('ga("set", "dimension', $js);
 
         $googleAnalytics->setCustomDimension(3, 'foo');
+        $googleAnalytics->setCustomDimension(4, '{"name":"müller"}');
         $js = $googleAnalytics->getJs($environment);
         $this->assertContains('ga("set", "dimension3", "foo")', $js);
+        $this->assertContains('ga("set", "dimension4", "{\"name\":\"m\u00fcller\"}")', $js);
     }
 
     public function testAddEvent() {
@@ -78,18 +80,18 @@ class CMService_GoogleAnalytics_ClientTest extends CMTest_TestCase {
         $googleAnalytics->addPageView(' / foo');
         $js = $googleAnalytics->getJs($environment);
         $this->assertSame(1, substr_count($js, 'ga("send", "pageview"'));
-        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", " / foo");'));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", " \/ foo");'));
 
         $googleAnalytics->addPageView(' / foo');
         $js = $googleAnalytics->getJs($environment);
         $this->assertSame(2, substr_count($js, 'ga("send", "pageview"'));
-        $this->assertSame(2, substr_count($js, 'ga("send", "pageview", " / foo");'));
+        $this->assertSame(2, substr_count($js, 'ga("send", "pageview", " \/ foo");'));
 
         $googleAnalytics->addPageView(' / bar');
         $js = $googleAnalytics->getJs($environment);
         $this->assertSame(3, substr_count($js, 'ga("send", "pageview"'));
-        $this->assertSame(2, substr_count($js, 'ga("send", "pageview", " / foo");'));
-        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", " / bar");'));
+        $this->assertSame(2, substr_count($js, 'ga("send", "pageview", " \/ foo");'));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", " \/ bar");'));
     }
 
     public function testSetPageView() {
@@ -101,12 +103,12 @@ class CMService_GoogleAnalytics_ClientTest extends CMTest_TestCase {
         $googleAnalytics->addPageView('/foo');
         $js = $googleAnalytics->getJs($environment);
         $this->assertSame(1, substr_count($js, 'ga("send", "pageview"'));
-        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", "/foo");'));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", "\/foo");'));
 
         $googleAnalytics->setPageView('/bar');
         $js = $googleAnalytics->getJs($environment);
         $this->assertSame(1, substr_count($js, 'ga("send", "pageview"'));
-        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", "/bar");'));
+        $this->assertSame(1, substr_count($js, 'ga("send", "pageview", "\/bar");'));
     }
 
     public function testTrackPageViewSetsUser() {
@@ -179,8 +181,8 @@ class CMService_GoogleAnalytics_ClientTest extends CMTest_TestCase {
         $googleAnalytics->trackPageView($environment, '/foo');
         $js = $googleAnalytics->getJs($environment);
         $this->assertContains('ga("set", "userId", "' . $user->getId() . '");', $js);
-        $this->assertContains('ga("send", "pageview", "/foo");', $js);
-        $this->assertContains('ga("send", "pageview", "/v/join/done");', $js);
+        $this->assertContains('ga("send", "pageview", "\/foo");', $js);
+        $this->assertContains('ga("send", "pageview", "\/v\/join\/done");', $js);
         $this->assertContains('ga("send", {"hitType":"event","eventCategory":"User","eventAction":"Create","eventLabel":"foo","eventValue":123,"nonInteraction":true});', $js);
     }
 
@@ -191,7 +193,7 @@ class CMService_GoogleAnalytics_ClientTest extends CMTest_TestCase {
         $this->forceInvokeMethod($googleAnalytics, '_pushHit', [$user, 'pageview', ['path' => '/v/join/done']]);
         $googleAnalytics->trackPageView($environment, '/foo');
         $js = $googleAnalytics->getJs($environment);
-        $this->assertContains('ga("send", "pageview", "/v/join/done");', $js);
+        $this->assertContains('ga("send", "pageview", "\/v\/join\/done");', $js);
     }
 
     public function testTtlExpired() {
@@ -201,6 +203,6 @@ class CMService_GoogleAnalytics_ClientTest extends CMTest_TestCase {
         $this->forceInvokeMethod($googleAnalytics, '_pushHit', [$user, 'pageview', ['path' => '/v/join/done']]);
         $googleAnalytics->trackPageView($environment, '/foo');
         $js = $googleAnalytics->getJs($environment);
-        $this->assertNotContains('ga("send", "pageview", "/v/join/done");', $js);
+        $this->assertNotContains('ga("send", "pageview", "\/v\/join\/done");', $js);
     }
 }


### PR DESCRIPTION
Our GA client doesn't correctly escape custom fields, pageviews and possibly other values.
This seems to be the reason for the missing data when doing AdWords linking.

@fauvel could you check all the places in `getJs()`?

Also when investigating I noticed that when using MP for tracking events the numbers in our database match GA's numbers almost 100%. But when using frontend tracking we have a ~5% discrepancy.
How about switching back to MP, as this was not the reason for the wrong tracking? To see if everything works then - it would give us more precise data!