### PR TITLE
Fix form event communication.

### DIFF
--- a/library/CM/Form/Abstract.js
+++ b/library/CM/Form/Abstract.js
@@ -212,7 +212,6 @@ var CM_Form_Abstract = CM_View_Abstract.extend({
         .catch(function(error){
           handler._stopErrorPropagation = false;
           handler.trigger('error error.' + action.name, error.msg, error.type, error.isPublic);
-          throw error;
         })
         .finally(function(){
           if (options.disableUI) {


### PR DESCRIPTION
We shouldn't throw on failed submit cause form state is delivered by `cm.event` mechanism and not promise mechanism.