### PR TITLE
Promise behaviour of Form.submit()

### DIFF
--- a/library/CM/Form/Abstract.js
+++ b/library/CM/Form/Abstract.js
@@ -45,7 +45,9 @@ var CM_Form_Abstract = CM_View_Abstract.extend({
       $btn.on(event, {action: name}, function(event) {
         event.preventDefault();
         event.stopPropagation();
-        return handler.submit(event.data.action).catch(function(error){});
+        return handler.submit(event.data.action).catch(function(error) {
+          //error is already handled and displayed in `submit`
+        });
       });
     }, this);
 

--- a/library/CM/Form/Abstract.js
+++ b/library/CM/Form/Abstract.js
@@ -191,7 +191,6 @@ var CM_Form_Abstract = CM_View_Abstract.extend({
               }
             }
 
-            handler.trigger('error error.' + action.name);
             throw cm.error.create('error error.' + action.name);
           }
 

--- a/library/CM/Form/Abstract.js
+++ b/library/CM/Form/Abstract.js
@@ -46,7 +46,7 @@ var CM_Form_Abstract = CM_View_Abstract.extend({
         event.preventDefault();
         event.stopPropagation();
         return handler.submit(event.data.action).catch(CM_Exception_FormFieldValidation, function(error) {
-          //this error type is already handled and displayed in `submit`
+          // this error type is already handled and displayed in `submit`
         });
       });
     }, this);

--- a/library/CM/Form/Abstract.js
+++ b/library/CM/Form/Abstract.js
@@ -45,7 +45,7 @@ var CM_Form_Abstract = CM_View_Abstract.extend({
       $btn.on(event, {action: name}, function(event) {
         event.preventDefault();
         event.stopPropagation();
-        return handler.submit(event.data.action);
+        return handler.submit(event.data.action).catch(function(error){});
       });
     }, this);
 
@@ -170,7 +170,7 @@ var CM_Form_Abstract = CM_View_Abstract.extend({
     }
 
     if (_.size(errorList)) {
-      return Promise.resolve();
+      return Promise.reject();
     } else {
       if (options.disableUI) {
         this.disable();
@@ -192,7 +192,7 @@ var CM_Form_Abstract = CM_View_Abstract.extend({
             }
 
             handler.trigger('error error.' + action.name);
-            return;
+            throw cm.error.create('error error.' + action.name);
           }
 
           if (response.exec) {
@@ -212,6 +212,7 @@ var CM_Form_Abstract = CM_View_Abstract.extend({
         .catch(function(error){
           handler._stopErrorPropagation = false;
           handler.trigger('error error.' + action.name, error.msg, error.type, error.isPublic);
+          throw error;
         })
         .finally(function(){
           if (options.disableUI) {

--- a/library/CM/Form/Abstract.js
+++ b/library/CM/Form/Abstract.js
@@ -45,8 +45,8 @@ var CM_Form_Abstract = CM_View_Abstract.extend({
       $btn.on(event, {action: name}, function(event) {
         event.preventDefault();
         event.stopPropagation();
-        return handler.submit(event.data.action).catch(function(error) {
-          //error is already handled and displayed in `submit`
+        return handler.submit(event.data.action).catch(CM_Exception_FormFieldValidation, function(error) {
+          //this error type is already handled and displayed in `submit`
         });
       });
     }, this);
@@ -172,7 +172,7 @@ var CM_Form_Abstract = CM_View_Abstract.extend({
     }
 
     if (_.size(errorList)) {
-      return Promise.reject();
+      return Promise.reject(new CM_Exception_FormFieldValidation(errorList));
     } else {
       if (options.disableUI) {
         this.disable();
@@ -193,7 +193,7 @@ var CM_Form_Abstract = CM_View_Abstract.extend({
               }
             }
 
-            throw new CM_Exception();
+            throw new CM_Exception_FormFieldValidation(response.errors);
           }
 
           if (response.exec) {
@@ -210,7 +210,7 @@ var CM_Form_Abstract = CM_View_Abstract.extend({
           handler.trigger('success success.' + action.name, response.data);
           return response.data;
         })
-        .catch(CM_Exception, function(error){
+        .catch(CM_Exception_FormFieldValidation, function(error){
           handler._stopErrorPropagation = false;
           handler.trigger('error error.' + action.name, error.message, error.name, error.isPublic);
           if (!handler._stopErrorPropagation) {


### PR DESCRIPTION
`CM_Form_Abstract.submit()` returns a Promise which behaves like this:
- Client side validation errors: resolve
- Server side validation errors: resolve
- Successful submit: resolve

Why do we not reject on validation errors?
I have a usage where I submit a form directly and use the returned Promise to control the further control flow. In that case I would expect that the promise only resolves on successful submit. 
wdyt?