### PR TITLE
Fix pseudo-element css selectors

### DIFF
--- a/client-vendor/after-body/jquery.scrollShadow/jquery.scrollShadow.css
+++ b/client-vendor/after-body/jquery.scrollShadow/jquery.scrollShadow.css
@@ -7,7 +7,7 @@
   -webkit-overflow-scrolling: touch;
 }
 
-.scrollShadow:before, .scrollShadow:after {
+.scrollShadow::before, .scrollShadow::after {
   position: absolute;
   content: '';
   left: 0;
@@ -18,14 +18,14 @@
   opacity: 0;
 }
 
-.scrollShadow:before {
+.scrollShadow::before {
   top: 0;
 }
 
-.scrollShadow:after {
+.scrollShadow::after {
   bottom: 0;
 }
 
-.scrollShadow.notScrolledTop:before, .scrollShadow.notScrolledBottom:after {
+.scrollShadow.notScrolledTop::before, .scrollShadow.notScrolledBottom::after {
   opacity: 1;
 }

--- a/layout/default/FormField/Abstract/default.less
+++ b/layout/default/FormField/Abstract/default.less
@@ -1,5 +1,5 @@
 &.hasError {
-  .textinput, select + .button, input[type=checkbox] + label:before, input[type=radio] + label:before {
+  .textinput, select + .button, input[type=checkbox] + label::before, input[type=radio] + label::before {
     outline: 1px dashed transparent;
     outline-offset: -1px;
     .animation(highlightErrorField, 1000ms, ease, 0s, 1);

--- a/layout/default/css/form.less
+++ b/layout/default/css/form.less
@@ -174,7 +174,7 @@ input[type=checkbox], input[type=radio] {
     cursor: pointer;
     margin-left: @sizeCheckbox+4px;
 
-    &:before {
+    &::before {
       box-sizing: border-box;
       position: absolute;
       content: "";
@@ -191,12 +191,12 @@ input[type=checkbox], input[type=radio] {
   }
 
   &:focus {
-    &:not(:disabled) + label:before {
+    &:not(:disabled) + label::before {
       .input_focus;
     }
   }
 
-  &:checked + label:before {
+  &:checked + label::before {
     background-color: @colorFocus;
     border-color: @colorFocus;
   }
@@ -207,25 +207,25 @@ input[type=checkbox], input[type=radio] {
 }
 
 input[type=radio] {
-  &:checked + label:before {
+  &:checked + label::before {
     box-shadow: inset 0 0 0 .2em @colorBgEmphasize1;
   }
 
   + label {
-    &:before {
+    &::before {
       border-radius: 50%;
     }
   }
 }
 
 input[type=checkbox] {
-  &:checked + label:before {
+  &:checked + label::before {
     background-image: image('checkbox.svg');
     background-size: contain;
   }
 
   + label {
-    &:before {
+    &::before {
       border-radius: 20%;
     }
   }
@@ -250,12 +250,12 @@ input[type=checkbox].checkbox-switch {
       background-color: @colorBgEmphasize1;
       box-shadow: 0 .1em .1em rgba(0, 0, 0, 0.02) inset;
 
-      &:before, &:after {
+      &::before, &::after {
         position: absolute;
         top: 0;
       }
 
-      &:before {
+      &::before {
         right: 0;
         margin: 0 5px;
         content: 'OFF';
@@ -266,7 +266,7 @@ input[type=checkbox].checkbox-switch {
         color: lighten(@colorFgSubtle, 10);
       }
 
-      &:after {
+      &::after {
         box-sizing: border-box;
         left: 0;
         content: '';
@@ -285,7 +285,7 @@ input[type=checkbox].checkbox-switch {
       vertical-align: middle;
     }
 
-    &:before {
+    &::before {
       display: none;
     }
   }
@@ -294,14 +294,14 @@ input[type=checkbox].checkbox-switch {
     background-color: @colorFocus;
     border-color: @colorFocus;
 
-    &:before {
+    &::before {
       right: 0;
       left: 0;
       content: 'ON';
       color: contrast(darken(@colorFocus, 30), black, white);
     }
 
-    &:after {
+    &::after {
       transform: translateX(@sizeSwitch + 4px);
       background-color: lighten(@colorFocus, 30);
     }
@@ -323,7 +323,7 @@ input[type=checkbox].checkbox-switch {
     color: @fontColorStrong;
     padding-left: 2px;
 
-    &:after {
+    &::after {
       content: ":";
     }
   }

--- a/layout/default/css/jquery.scrollShadow.less
+++ b/layout/default/css/jquery.scrollShadow.less
@@ -1,14 +1,14 @@
 .scrollShadow {
-  &:before, &:after {
+  &::before, &::after {
     background-color: transparent;
     transition: 200ms;
   }
 
-  &:before {
+  &::before {
     background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.1) 0, rgba(0, 0, 0, 0) 100%);
   }
 
-  &:after {
+  &::after {
     background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0.1) 100%);
   }
 }

--- a/layout/default/css/mixins.less
+++ b/layout/default/css/mixins.less
@@ -1,5 +1,5 @@
 .clearfix {
-  &:after {
+  &::after {
     content: "";
     display: table;
     clear: both;
@@ -33,7 +33,7 @@
 }
 
 .triangleBorder(@position, @colorBorder: @colorFgBorder, @colorInner: @colorBg, @size: 9px, @borderSize: 1px) when (@position = top) {
-  &:after, &:before {
+  &::after, &::before {
     border: solid transparent;
     content: " ";
     height: 0;
@@ -44,7 +44,7 @@
     left: 50%;
   }
 
-  &:after {
+  &::after {
     border-color: transparent;
     border-width: @size;
     margin-left: -@size;
@@ -52,7 +52,7 @@
     border-bottom-color: @colorInner;
   }
 
-  &:before {
+  &::before {
     border-width: @size + @borderSize;
     margin-left: -(@size + @borderSize);
     margin-right: -(@size + @borderSize);
@@ -61,7 +61,7 @@
 }
 
 .triangleBorder(@position, @colorBorder: @colorFgBorder, @colorInner: @colorBg, @size: 9px, @borderSize: 1px) when (@position = bottom) {
-  &:after, &:before {
+  &::after, &::before {
     border: solid transparent;
     content: " ";
     height: 0;
@@ -72,7 +72,7 @@
     top: 100%;
   }
 
-  &:after {
+  &::after {
     border-color: transparent;
     border-width: @size;
     margin-left: -@size;
@@ -80,7 +80,7 @@
     border-top-color: @colorInner;
   }
 
-  &:before {
+  &::before {
     border-width: @size + @borderSize;
     margin-left: -(@size + @borderSize);
     margin-right: -(@size + @borderSize);
@@ -89,7 +89,7 @@
 }
 
 .triangleBorder(@position, @colorBorder: @colorFgBorder, @colorInner: @colorBg, @size: 9px, @borderSize: 1px) when (@position = left) {
-  &:after, &:before {
+  &::after, &::before {
     border: solid transparent;
     content: " ";
     height: 0;
@@ -100,7 +100,7 @@
     right: 100%;
   }
 
-  &:after {
+  &::after {
     border-color: transparent;
     border-width: @size;
     margin-top: -@size;
@@ -108,7 +108,7 @@
     border-right-color: @colorInner;
   }
 
-  &:before {
+  &::before {
     border-width: @size + @borderSize;
     margin-top: -(@size + @borderSize);
     margin-bottom: -(@size + @borderSize);
@@ -117,7 +117,7 @@
 }
 
 .triangleBorder(@position, @colorBorder: @colorFgBorder, @colorInner: @colorBg, @size: 9px, @borderSize: 1px) when (@position = right) {
-  &:after, &:before {
+  &::after, &::before {
     border: solid transparent;
     content: " ";
     height: 0;
@@ -128,7 +128,7 @@
     left: 100%;
   }
 
-  &:after {
+  &::after {
     border-width: @size;
     border-color: transparent;
     margin-top: -@size;
@@ -136,7 +136,7 @@
     border-left-color: @colorInner;
   }
 
-  &:before {
+  &::before {
     border-width: @size + @borderSize;
     margin-top: -(@size + @borderSize);
     margin-bottom: -(@size + @borderSize);
@@ -145,7 +145,7 @@
 }
 
 .clipper(@height: 20px, @colorBg: @colorBg) {
-  &:after {
+  &::after {
     pointer-events: none;
     position: absolute;
     content: "";

--- a/layout/default/css/spinner.less
+++ b/layout/default/css/spinner.less
@@ -5,7 +5,7 @@
   min-height: @spinnerSize;
   min-width: @spinnerSize;
 
-  &:before {
+  &::before {
     box-sizing: border-box;
     content: '';
     position: absolute;
@@ -25,7 +25,7 @@
   bottom: 0;
   left: 0;
 
-  &:before {
+  &::before {
     top: 50%;
     left: 50%;
     margin-top: -@spinnerSize/2;


### PR DESCRIPTION
Should use double colon for pseudo-elements: E.g. `::after` instead of `:after`.

Interesting article http://bitsofco.de/2015/pseudo-classes-pseudo-elements-and-colon-notation/?utm_source=CSS-Weekly&utm_campaign=Issue-169&utm_medium=email