### PR TITLE
Reload Page on new Application Release

### DIFF
--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -12,6 +12,12 @@ var CM_App = CM_Class_Abstract.extend({
   /** @type Object **/
   options: {},
 
+  /** @type {Boolean} **/
+  _shouldReload: false,
+
+  /** @type {Number|Null} **/
+  _deployVersion: null,
+
   ready: function() {
     this.error.ready();
     this.dom.ready();
@@ -19,6 +25,14 @@ var CM_App = CM_Class_Abstract.extend({
     this.date.ready();
     this.template.ready();
     this.router.ready();
+  },
+
+  updateDeployVersion: function(version) {
+    if (this._deployVersion && this._deployVersion != version) {
+      this._shouldReload = true;
+    } else {
+      this._deployVersion = version;
+    }
   },
 
   /**
@@ -786,6 +800,7 @@ var CM_App = CM_Class_Abstract.extend({
    */
   ajax: function(type, data) {
     var url = this.getUrlAjax(type);
+    var self = this;
 
     return new Promise(function(resolve, reject) {
       var jqXHR = $.ajax(url, {
@@ -796,6 +811,7 @@ var CM_App = CM_Class_Abstract.extend({
         cache: false
       });
       jqXHR.retry({times: 3, statusCodes: [405, 500, 503, 504]}).done(function(response) {
+        self.updateDeployVersion(response.deployVersion);
         if (response.error) {
           reject(new (CM_Exception.factory(response.error.type))(response.error.msg, response.error.isPublic));
         } else {

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -805,7 +805,7 @@ var CM_App = CM_Class_Abstract.extend({
       });
       jqXHR.retry({times: 3, statusCodes: [405, 500, 503, 504]}).done(function(response) {
         if (cm.getDeployVersion() != response.deployVersion) {
-          cm.router._shouldReload = true;
+          cm.router.forceReload();
         }
         if (response.error) {
           reject(new (CM_Exception.factory(response.error.type))(response.error.msg, response.error.isPublic));
@@ -1148,13 +1148,17 @@ var CM_App = CM_Class_Abstract.extend({
       });
     },
 
+    forceReload: function() {
+      cm.router._shouldReload = true;
+    },
+
     /**
      * @param {String} url
      * @param {Boolean|Null} [forceReload]
      * @param {Boolean|Null} [replaceState]
      */
     route: function(url, forceReload, replaceState) {
-      forceReload = this._shouldReload || forceReload || false;
+      forceReload = cm.router._shouldReload || forceReload || false;
       replaceState = replaceState || false;
       var urlBase = cm.getUrl();
       var fragment = url;

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -1149,7 +1149,7 @@ var CM_App = CM_Class_Abstract.extend({
     },
 
     forceReload: function() {
-      cm.router._shouldReload = true;
+      this._shouldReload = true;
     },
 
     /**
@@ -1158,7 +1158,7 @@ var CM_App = CM_Class_Abstract.extend({
      * @param {Boolean|Null} [replaceState]
      */
     route: function(url, forceReload, replaceState) {
-      forceReload = cm.router._shouldReload || forceReload || false;
+      forceReload = this._shouldReload || forceReload || false;
       replaceState = replaceState || false;
       var urlBase = cm.getUrl();
       var fragment = url;

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -79,19 +79,24 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
    * @return Promise
    */
   loadPage: function(path) {
-    cm.event.trigger('navigate', path);
-
-    if (!this._$pagePlaceholder) {
-      this._$pagePlaceholder = $('<div class="router-placeholder" />');
-      this.getPage().replaceWithHtml(this._$pagePlaceholder);
-      this._onPageTeardown();
+    if (cm._shouldReload) {
+      window.location.href = cm.getUrl(path);
+      return Promise.resolve();
     } else {
-      this._$pagePlaceholder.removeClass('error').html('');
+      cm.event.trigger('navigate', path);
+
+      if (!this._$pagePlaceholder) {
+        this._$pagePlaceholder = $('<div class="router-placeholder" />');
+        this.getPage().replaceWithHtml(this._$pagePlaceholder);
+        this._onPageTeardown();
+      } else {
+        this._$pagePlaceholder.removeClass('error').html('');
+      }
+      this._timeoutLoading = this.setTimeout(function() {
+        this._$pagePlaceholder.html('<div class="spinner spinner-expanded" />');
+      }, 750);
+      return this._loadPageThrottled(path);
     }
-    this._timeoutLoading = this.setTimeout(function() {
-      this._$pagePlaceholder.html('<div class="spinner spinner-expanded" />');
-    }, 750);
-    return this._loadPageThrottled(path);
   },
 
   /**

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -79,24 +79,19 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
    * @return Promise
    */
   loadPage: function(path) {
-    if (cm._shouldReload) {
-      window.location.href = cm.getUrl(path);
-      return Promise.resolve();
-    } else {
-      cm.event.trigger('navigate', path);
+    cm.event.trigger('navigate', path);
 
-      if (!this._$pagePlaceholder) {
-        this._$pagePlaceholder = $('<div class="router-placeholder" />');
-        this.getPage().replaceWithHtml(this._$pagePlaceholder);
-        this._onPageTeardown();
-      } else {
-        this._$pagePlaceholder.removeClass('error').html('');
-      }
-      this._timeoutLoading = this.setTimeout(function() {
-        this._$pagePlaceholder.html('<div class="spinner spinner-expanded" />');
-      }, 750);
-      return this._loadPageThrottled(path);
+    if (!this._$pagePlaceholder) {
+      this._$pagePlaceholder = $('<div class="router-placeholder" />');
+      this.getPage().replaceWithHtml(this._$pagePlaceholder);
+      this._onPageTeardown();
+    } else {
+      this._$pagePlaceholder.removeClass('error').html('');
     }
+    this._timeoutLoading = this.setTimeout(function() {
+      this._$pagePlaceholder.html('<div class="spinner spinner-expanded" />');
+    }, 750);
+    return this._loadPageThrottled(path);
   },
 
   /**


### PR DESCRIPTION
Idea **D** via https://github.com/cargomedia/CM/issues/1437

1. Any ajax/form response from the server to the client could include the server's `releaseStamp`. We could return it from `CM_Http_Response_View_Abstract::_process()`.
2. If the client detects that its `releaseStamp` is different from what the server has it will set a flag `shouldReload`.
3. When the client navigates to a different page and the `shouldReload` flag is set then the page will be hard-reloaded (instead of using ajax navigation).

@tomaszdurka @dlondero @vogdb wdyt?

#### Steps
* [x] Return releaseStamp in ajax-requests https://github.com/cargomedia/CM/pull/1841
* [ ] ...