### PR TITLE
CM_Layout_Abstract: Make sure "_timeoutLoading" is always cleared

### DIFF
--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -46,8 +46,8 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
           return view;
         })
         .catch(function(error) {
+          window.clearTimeout(layout._timeoutLoading);
           if (!(error instanceof Promise.CancellationError)) {
-            window.clearTimeout(layout._timeoutLoading);
             layout._$pagePlaceholder.addClass('error').html('<pre>' + error.message + '</pre>');
             layout._onPageError();
             throw error;


### PR DESCRIPTION
In case of `Promise.CancellationError` it will not be cancelled.
Maybe put it into a `finally` block?