### PR TITLE
Change serialization for location formField

### DIFF
--- a/library/CM/FormField/Location.js
+++ b/library/CM/FormField/Location.js
@@ -33,7 +33,7 @@ var CM_FormField_Location = CM_FormField_SuggestOne.extend({
       var distanceEnabled = false;
       var items = this.getValue();
       if (items.length > 0) {
-        distanceEnabled = items[0].level >= this.getOption("distanceLevelMin");
+        distanceEnabled = JSON.parse(items[0].id).level >= this.getOption("distanceLevelMin");
       }
       this.getDistanceField().$("input").prop("disabled", !distanceEnabled);
     }

--- a/library/CM/FormField/Location.js
+++ b/library/CM/FormField/Location.js
@@ -76,13 +76,5 @@ var CM_FormField_Location = CM_FormField_SuggestOne.extend({
    */
   _lookupCoordinates: function(lat, lon) {
     return this.ajax('getSuggestionByCoordinates', {lat: lat, lon: lon, levelMin: this.getOption('levelMin'), levelMax: this.getOption('levelMax')});
-  },
-
-  _getSelect2Options: function() {
-    return {
-      id: function(data) {
-        return JSON.stringify(_.pick(data, 'id', 'level'));
-      }
-    }
   }
 });

--- a/library/CM/FormField/Location.js
+++ b/library/CM/FormField/Location.js
@@ -31,31 +31,31 @@ var CM_FormField_Location = CM_FormField_SuggestOne.extend({
   updateDistanceField: function() {
     if (this.getDistanceField()) {
       var distanceEnabled = false;
-      var items = this.getValue();
-      if (items.length > 0) {
-        distanceEnabled = items[0].id.level >= this.getOption("distanceLevelMin");
+      var value = this.getValue();
+      if (value) {
+        distanceEnabled = value.id.level >= this.getOption("distanceLevelMin");
       }
       this.getDistanceField().$("input").prop("disabled", !distanceEnabled);
     }
   },
 
   /**
-   * @return {Array}
+   * @return {Object}
    */
   getValue: function() {
     var value = CM_FormField_SuggestOne.prototype.getValue.call(this);
-    if (_.isString(value[0].id)) {
-      value[0].id = JSON.parse(value[0].id);
+    if (_.isString(value.id)) {
+      value.id = JSON.parse(value.id);
     }
     return value;
   },
 
   /**
-   * @param {Array} value
+   * @param {Object} value
    */
   setValue: function(value) {
-    if (_.isObject(value[0].id)) {
-      value[0].id = JSON.stringify(value[0].id);
+    if (_.isObject(value.id)) {
+      value.id = JSON.stringify(value.id);
     }
     return CM_FormField_SuggestOne.prototype.setValue.call(this, value);
   },

--- a/library/CM/FormField/Location.js
+++ b/library/CM/FormField/Location.js
@@ -9,6 +9,13 @@ var CM_FormField_Location = CM_FormField_SuggestOne.extend({
     'click .detectLocation': 'detectLocation'
   },
 
+  /** @type {Object} */
+  _select2Options: {
+    id: function(data) {
+      return JSON.stringify(_.pick(data, 'id', 'level'));
+    }
+  },
+
   ready: function() {
     CM_FormField_SuggestOne.prototype.ready.call(this);
 
@@ -33,7 +40,7 @@ var CM_FormField_Location = CM_FormField_SuggestOne.extend({
       var distanceEnabled = false;
       var items = this.getValue();
       if (items.length > 0) {
-        distanceEnabled = items[0].id.split(".")[0] >= this.getOption("distanceLevelMin");
+        distanceEnabled = items[0].level >= this.getOption("distanceLevelMin");
       }
       this.getDistanceField().$("input").prop("disabled", !distanceEnabled);
     }

--- a/library/CM/FormField/Location.js
+++ b/library/CM/FormField/Location.js
@@ -33,10 +33,31 @@ var CM_FormField_Location = CM_FormField_SuggestOne.extend({
       var distanceEnabled = false;
       var items = this.getValue();
       if (items.length > 0) {
-        distanceEnabled = JSON.parse(items[0].id).level >= this.getOption("distanceLevelMin");
+        distanceEnabled = items[0].id.level >= this.getOption("distanceLevelMin");
       }
       this.getDistanceField().$("input").prop("disabled", !distanceEnabled);
     }
+  },
+
+  /**
+   * @return {Array}
+   */
+  getValue: function() {
+    var value = CM_FormField_SuggestOne.prototype.getValue.call(this);
+    if (_.isString(value[0].id)) {
+      value[0].id = JSON.parse(value[0].id);
+    }
+    return value;
+  },
+
+  /**
+   * @param {Array} value
+   */
+  setValue: function(value) {
+    if (_.isObject(value[0].id)) {
+      value[0].id = JSON.stringify(value[0].id);
+    }
+    return CM_FormField_SuggestOne.prototype.setValue.call(this, value);
   },
 
   /**

--- a/library/CM/FormField/Location.js
+++ b/library/CM/FormField/Location.js
@@ -9,13 +9,6 @@ var CM_FormField_Location = CM_FormField_SuggestOne.extend({
     'click .detectLocation': 'detectLocation'
   },
 
-  /** @type {Object} */
-  _select2Options: {
-    id: function(data) {
-      return JSON.stringify(_.pick(data, 'id', 'level'));
-    }
-  },
-
   ready: function() {
     CM_FormField_SuggestOne.prototype.ready.call(this);
 
@@ -83,5 +76,13 @@ var CM_FormField_Location = CM_FormField_SuggestOne.extend({
    */
   _lookupCoordinates: function(lat, lon) {
     return this.ajax('getSuggestionByCoordinates', {lat: lat, lon: lon, levelMin: this.getOption('levelMin'), levelMax: this.getOption('levelMax')});
+  },
+
+  _getSelect2Options: function() {
+    return {
+      id: function(data) {
+        return JSON.stringify(_.pick(data, 'id', 'level'));
+      }
+    }
   }
 });

--- a/library/CM/FormField/Location.php
+++ b/library/CM/FormField/Location.php
@@ -36,15 +36,7 @@ class CM_FormField_Location extends CM_FormField_SuggestOne {
     public function validate(CM_Frontend_Environment $environment, $userInput) {
         $value = parent::validate($environment, $userInput);
         $value = json_decode($value, true);
-        $id = isset($value['id']) ? $value['id'] : null;
-        $level = isset($value['level']) ? $value['level'] : null;
-        if (!is_int($id) || !is_int($level)) {
-            throw new CM_Exception_FormFieldValidation('Invalid input format');
-        }
-        if ($level < $this->_options['levelMin'] || $level > $this->_options['levelMax']) {
-            throw new CM_Exception_FormFieldValidation('Invalid location level.');
-        }
-        return new CM_Model_Location($level, $id);
+        return CM_Model_Location::fromArray($value);
     }
 
     /**

--- a/library/CM/FormField/Location.php
+++ b/library/CM/FormField/Location.php
@@ -35,7 +35,11 @@ class CM_FormField_Location extends CM_FormField_SuggestOne {
     public function validate(CM_Frontend_Environment $environment, $userInput) {
         $value = parent::validate($environment, $userInput);
         $value = CM_Params::jsonDecode($value);
-        return CM_Model_Location::fromArray($value);
+        $location = CM_Model_Location::fromArray($value);
+        if ($location->getLevel() < $this->_options['levelMin'] || $location->getLevel() > $this->_options['levelMax']) {
+            throw new CM_Exception_FormFieldValidation('Invalid location level.');
+        }
+        return $location;
     }
 
     /**

--- a/library/CM/FormField/Location.php
+++ b/library/CM/FormField/Location.php
@@ -18,11 +18,13 @@ class CM_FormField_Location extends CM_FormField_SuggestOne {
         for ($level = $location->getLevel(); $level >= CM_Model_Location::LEVEL_COUNTRY; $level--) {
             $names[] = $location->getName($level);
         }
-        $result = $location->toArray();
-        $result['name'] = implode(', ', array_filter($names));
-        $result['img'] = $render->getUrlResource('layout',
-            'img/flags/' . strtolower($location->getAbbreviation(CM_Model_Location::LEVEL_COUNTRY)) . '.png');
-        return $result;
+        return array(
+            'id'    => $location->getId(),
+            'level' => $location->getLevel(),
+            'name'  => implode(', ', array_filter($names)),
+            'img'   => $render->getUrlResource('layout',
+                'img/flags/' . strtolower($location->getAbbreviation(CM_Model_Location::LEVEL_COUNTRY)) . '.png'),
+        );
     }
 
     /**

--- a/library/CM/FormField/Location.php
+++ b/library/CM/FormField/Location.php
@@ -18,12 +18,11 @@ class CM_FormField_Location extends CM_FormField_SuggestOne {
         for ($level = $location->getLevel(); $level >= CM_Model_Location::LEVEL_COUNTRY; $level--) {
             $names[] = $location->getName($level);
         }
-        return array(
-            'id'   => $location->getLevel() . '.' . $location->getId(),
-            'name' => implode(', ', array_filter($names)),
-            'img'  => $render->getUrlResource('layout',
-                    'img/flags/' . strtolower($location->getAbbreviation(CM_Model_Location::LEVEL_COUNTRY)) . '.png'),
-        );
+        $result = $location->toArray();
+        $result['name'] = implode(', ', array_filter($names));
+        $result['img'] = $render->getUrlResource('layout',
+            'img/flags/' . strtolower($location->getAbbreviation(CM_Model_Location::LEVEL_COUNTRY)) . '.png');
+        return $result;
     }
 
     /**
@@ -34,11 +33,12 @@ class CM_FormField_Location extends CM_FormField_SuggestOne {
      */
     public function validate(CM_Frontend_Environment $environment, $userInput) {
         $value = parent::validate($environment, $userInput);
-        if (!preg_match('/^(\d+)\.(\d+)$/', $value, $matches)) {
+        $value = json_decode($value, true);
+        $id = isset($value['id']) ? $value['id'] : null;
+        $level = isset($value['level']) ? $value['level'] : null;
+        if (!is_int($id) || !is_int($level)) {
             throw new CM_Exception_FormFieldValidation('Invalid input format');
         }
-        $level = $matches[1];
-        $id = $matches[2];
         if ($level < $this->_options['levelMin'] || $level > $this->_options['levelMax']) {
             throw new CM_Exception_FormFieldValidation('Invalid location level.');
         }

--- a/library/CM/FormField/Location.php
+++ b/library/CM/FormField/Location.php
@@ -19,8 +19,7 @@ class CM_FormField_Location extends CM_FormField_SuggestOne {
             $names[] = $location->getName($level);
         }
         return array(
-            'id'    => $location->getId(),
-            'level' => $location->getLevel(),
+            'id'    => CM_Params::jsonEncode($location->toArray()),
             'name'  => implode(', ', array_filter($names)),
             'img'   => $render->getUrlResource('layout',
                 'img/flags/' . strtolower($location->getAbbreviation(CM_Model_Location::LEVEL_COUNTRY)) . '.png'),
@@ -35,7 +34,7 @@ class CM_FormField_Location extends CM_FormField_SuggestOne {
      */
     public function validate(CM_Frontend_Environment $environment, $userInput) {
         $value = parent::validate($environment, $userInput);
-        $value = json_decode($value, true);
+        $value = CM_Params::jsonDecode($value);
         return CM_Model_Location::fromArray($value);
     }
 

--- a/library/CM/FormField/Suggest.js
+++ b/library/CM/FormField/Suggest.js
@@ -15,7 +15,7 @@ var CM_FormField_Suggest = CM_FormField_Abstract.extend({
     var prePopulate = this._$input.data('pre-populate');
 
     this._$input.removeClass('textinput');
-    this._$input.select2({
+    this._$input.select2(_.extend({
       separator: '--SELECT2SEPARATOR--',
       width: 'off',
       tags: null,
@@ -47,7 +47,7 @@ var CM_FormField_Suggest = CM_FormField_Abstract.extend({
         }
       },
       formatSelectionTooBig: null
-    }).select2('data', prePopulate);
+    }, this._select2Options)).select2('data', prePopulate);
     this.$('.select2-choices').addClass('textinput');
 
     this._$input.on("change", function(e) {

--- a/library/CM/FormField/Suggest.js
+++ b/library/CM/FormField/Suggest.js
@@ -15,7 +15,7 @@ var CM_FormField_Suggest = CM_FormField_Abstract.extend({
     var prePopulate = this._$input.data('pre-populate');
 
     this._$input.removeClass('textinput');
-    this._$input.select2(_.extend({
+    this._$input.select2({
       separator: '--SELECT2SEPARATOR--',
       width: 'off',
       tags: null,
@@ -47,7 +47,7 @@ var CM_FormField_Suggest = CM_FormField_Abstract.extend({
         }
       },
       formatSelectionTooBig: null
-    }, this._getSelect2Options())).select2('data', prePopulate);
+    }).select2('data', prePopulate);
     this.$('.select2-choices').addClass('textinput');
 
     this._$input.on("change", function(e) {
@@ -137,9 +137,5 @@ var CM_FormField_Suggest = CM_FormField_Abstract.extend({
       output = '<div class="suggestItem-image"><img src="' + item.img + '" /></div>' + output;
     }
     return output;
-  },
-
-  _getSelect2Options: function() {
-    return null;
   }
 });

--- a/library/CM/FormField/Suggest.js
+++ b/library/CM/FormField/Suggest.js
@@ -47,7 +47,7 @@ var CM_FormField_Suggest = CM_FormField_Abstract.extend({
         }
       },
       formatSelectionTooBig: null
-    }, this._select2Options)).select2('data', prePopulate);
+    }, this._getSelect2Options())).select2('data', prePopulate);
     this.$('.select2-choices').addClass('textinput');
 
     this._$input.on("change", function(e) {
@@ -137,5 +137,9 @@ var CM_FormField_Suggest = CM_FormField_Abstract.extend({
       output = '<div class="suggestItem-image"><img src="' + item.img + '" /></div>' + output;
     }
     return output;
+  },
+
+  _getSelect2Options: function() {
+    return null;
   }
 });

--- a/library/CM/FormField/SuggestOne.js
+++ b/library/CM/FormField/SuggestOne.js
@@ -3,5 +3,21 @@
  * @extends CM_FormField_Suggest
  */
 var CM_FormField_SuggestOne = CM_FormField_Suggest.extend({
-  _class: 'CM_FormField_SuggestOne'
+  _class: 'CM_FormField_SuggestOne',
+
+  /**
+   * @return {Object}
+   */
+  getValue: function() {
+    var value = CM_FormField_Suggest.prototype.getValue.call(this);
+    return value[0];
+  },
+
+  /**
+   * @param {Object} value
+   */
+  setValue: function(value) {
+    return CM_FormField_Suggest.prototype.setValue.call(this, [value]);
+  }
+
 });


### PR DESCRIPTION
For: https://github.com/cargomedia/sk/pull/11

Currently we serialize location objects as `$level.$id` in `CM_FormField_Location`.
We should change it to `toArray()`-serialization, which is an array `{level: $level, id: $id, _class: $className}`.

The goal is to get json objects on `change` in JS:
```js
locationFormField.on('change', function(value) {
 // value is a JSON object with "level" and "id"
});
```

@vogdb you wanna do it? Is it possible like this?