### PR TITLE
Use CM_I18N_Phrase in CM_Exception

### DIFF
--- a/library/CM/Action/Abstract.php
+++ b/library/CM/Action/Abstract.php
@@ -181,7 +181,9 @@ abstract class CM_Action_Abstract extends CM_Class_Abstract implements CM_ArrayC
 
         $isAllowed = call_user_func_array(array($this, '_isAllowed'), $arguments);
         if (false === $isAllowed) {
-            throw new CM_Exception_NotAllowed('Action not allowed', null, null, new CM_I18n_Phrase('The content you tried to interact with has become private.'));
+            throw new CM_Exception_NotAllowed('Action not allowed', null, null, [
+                'messagePublic' => new CM_I18n_Phrase('The content you tried to interact with has become private.'),
+            ]);
         }
         if (true !== $isAllowed) {
             $this->_checkActionLimits();

--- a/library/CM/Action/Abstract.php
+++ b/library/CM/Action/Abstract.php
@@ -181,7 +181,7 @@ abstract class CM_Action_Abstract extends CM_Class_Abstract implements CM_ArrayC
 
         $isAllowed = call_user_func_array(array($this, '_isAllowed'), $arguments);
         if (false === $isAllowed) {
-            throw new CM_Exception_NotAllowed('Action not allowed', null, array('messagePublic' => 'The content you tried to interact with has become private.'));
+            throw new CM_Exception_NotAllowed('Action not allowed', new CM_I18n_Phrase('The content you tried to interact with has become private.'));
         }
         if (true !== $isAllowed) {
             $this->_checkActionLimits();

--- a/library/CM/Action/Abstract.php
+++ b/library/CM/Action/Abstract.php
@@ -181,7 +181,7 @@ abstract class CM_Action_Abstract extends CM_Class_Abstract implements CM_ArrayC
 
         $isAllowed = call_user_func_array(array($this, '_isAllowed'), $arguments);
         if (false === $isAllowed) {
-            throw new CM_Exception_NotAllowed('Action not allowed', new CM_I18n_Phrase('The content you tried to interact with has become private.'));
+            throw new CM_Exception_NotAllowed('Action not allowed', null, null, new CM_I18n_Phrase('The content you tried to interact with has become private.'));
         }
         if (true !== $isAllowed) {
             $this->_checkActionLimits();

--- a/library/CM/Captcha.php
+++ b/library/CM/Captcha.php
@@ -14,7 +14,7 @@ class CM_Captcha {
         $this->_id = (int) $id;
         $this->_text = CM_Db_Db::select('cm_captcha', 'number', array('captcha_id' => $this->getId()))->fetchColumn();
         if (!$this->_text) {
-            throw new CM_Exception_Nonexistent('Invalid captcha id `' . $id . '`', null, array('severity' => CM_Exception::WARN));
+            throw new CM_Exception_Nonexistent('Invalid captcha id `' . $id . '`', null, CM_Exception::WARN);
         }
         $this->_fontPath = CM_Util::getModulePath('CM') . 'resources/font/comicsans.ttf';
     }

--- a/library/CM/Captcha.php
+++ b/library/CM/Captcha.php
@@ -14,7 +14,7 @@ class CM_Captcha {
         $this->_id = (int) $id;
         $this->_text = CM_Db_Db::select('cm_captcha', 'number', array('captcha_id' => $this->getId()))->fetchColumn();
         if (!$this->_text) {
-            throw new CM_Exception_Nonexistent('Invalid captcha id `' . $id . '`', null, CM_Exception::WARN);
+            throw new CM_Exception_Nonexistent('Invalid captcha id `' . $id . '`', CM_Exception::WARN);
         }
         $this->_fontPath = CM_Util::getModulePath('CM') . 'resources/font/comicsans.ttf';
     }

--- a/library/CM/Clockwork/Manager.php
+++ b/library/CM/Clockwork/Manager.php
@@ -45,7 +45,7 @@ class CM_Clockwork_Manager {
             return $event->getName() == $eventName;
         });
         if ($duplicateEventName) {
-            throw new CM_Exception('Duplicate event-name', null, null, ['name' => $eventName]);
+            throw new CM_Exception('Duplicate event-name', null, ['name' => $eventName]);
         }
         $this->_events[] = $event;
     }
@@ -99,7 +99,7 @@ class CM_Clockwork_Manager {
     protected function _getRunningEvent($identifier) {
         $eventName = array_search($identifier, \Functional\pluck($this->_eventsRunning, 'identifier'));
         if (false === $eventName) {
-            throw new CM_Exception('Could not find event', null, null, ['identifier' => $identifier]);
+            throw new CM_Exception('Could not find event', null, ['identifier' => $identifier]);
         }
         return $this->_eventsRunning[$eventName]['event'];
     }

--- a/library/CM/Clockwork/Manager.php
+++ b/library/CM/Clockwork/Manager.php
@@ -45,7 +45,7 @@ class CM_Clockwork_Manager {
             return $event->getName() == $eventName;
         });
         if ($duplicateEventName) {
-            throw new CM_Exception('Duplicate event-name', ['name' => $eventName]);
+            throw new CM_Exception('Duplicate event-name', null, null, ['name' => $eventName]);
         }
         $this->_events[] = $event;
     }
@@ -99,7 +99,7 @@ class CM_Clockwork_Manager {
     protected function _getRunningEvent($identifier) {
         $eventName = array_search($identifier, \Functional\pluck($this->_eventsRunning, 'identifier'));
         if (false === $eventName) {
-            throw new CM_Exception('Could not find event', ['identifier' => $identifier]);
+            throw new CM_Exception('Could not find event', null, null, ['identifier' => $identifier]);
         }
         return $this->_eventsRunning[$eventName]['event'];
     }

--- a/library/CM/Component/Example.php
+++ b/library/CM/Component/Example.php
@@ -42,7 +42,7 @@ class CM_Component_Example extends CM_Component_Abstract {
         if (!in_array($exception, array('CM_Exception', 'CM_Exception_AuthRequired'), true)) {
             $exception = 'CM_Exception';
         }
-        throw new $exception($message, new CM_I18n_Phrase($messagePublic));
+        throw new $exception($message, null, null, new CM_I18n_Phrase($messagePublic));
     }
 
     public function ajax_ping(CM_Params $params, CM_Frontend_JavascriptContainer_View $handler, CM_Http_Response_View_Ajax $response) {

--- a/library/CM/Component/Example.php
+++ b/library/CM/Component/Example.php
@@ -42,7 +42,9 @@ class CM_Component_Example extends CM_Component_Abstract {
         if (!in_array($exception, array('CM_Exception', 'CM_Exception_AuthRequired'), true)) {
             $exception = 'CM_Exception';
         }
-        throw new $exception($message, null, null, new CM_I18n_Phrase($messagePublic));
+        throw new $exception($message, null, null, [
+            'messagePublic' => new CM_I18n_Phrase($messagePublic)
+        ]);
     }
 
     public function ajax_ping(CM_Params $params, CM_Frontend_JavascriptContainer_View $handler, CM_Http_Response_View_Ajax $response) {

--- a/library/CM/Component/Example.php
+++ b/library/CM/Component/Example.php
@@ -42,7 +42,7 @@ class CM_Component_Example extends CM_Component_Abstract {
         if (!in_array($exception, array('CM_Exception', 'CM_Exception_AuthRequired'), true)) {
             $exception = 'CM_Exception';
         }
-        throw new $exception($message, null, ['messagePublic' => $messagePublic]);
+        throw new $exception($message, new CM_I18n_Phrase($messagePublic));
     }
 
     public function ajax_ping(CM_Params $params, CM_Frontend_JavascriptContainer_View $handler, CM_Http_Response_View_Ajax $response) {

--- a/library/CM/Config/Node.php
+++ b/library/CM/Config/Node.php
@@ -50,7 +50,7 @@ class CM_Config_Node {
                 return $base . '[' . $key . ']';
             };
         } else {
-            throw new CM_Exception_Invalid('Invalid property type', null, null, ['property' => $property]);
+            throw new CM_Exception_Invalid('Invalid property type', null, ['property' => $property]);
         }
         foreach ($property as $key => $value) {
             if (is_array($value)) {

--- a/library/CM/Config/Node.php
+++ b/library/CM/Config/Node.php
@@ -50,7 +50,7 @@ class CM_Config_Node {
                 return $base . '[' . $key . ']';
             };
         } else {
-            throw new CM_Exception_Invalid('Invalid property type', ['property' => $property]);
+            throw new CM_Exception_Invalid('Invalid property type', null, null, ['property' => $property]);
         }
         foreach ($property as $key => $value) {
             if (is_array($value)) {

--- a/library/CM/Dom/NodeList.php
+++ b/library/CM/Dom/NodeList.php
@@ -229,7 +229,7 @@ class CM_Dom_NodeList implements Iterator, Countable, ArrayAccess {
 
     public function offsetSet($offset, $value) {
         if (!$value instanceof DOMNode) {
-            throw new CM_Exception_Invalid('Element is not an instance of `DOMNode`', ['element' => $value]);
+            throw new CM_Exception_Invalid('Element is not an instance of `DOMNode`', null, null, ['element' => $value]);
         }
         if (null === $offset) {
             $this->_elementList[] = $value;

--- a/library/CM/Dom/NodeList.php
+++ b/library/CM/Dom/NodeList.php
@@ -229,7 +229,7 @@ class CM_Dom_NodeList implements Iterator, Countable, ArrayAccess {
 
     public function offsetSet($offset, $value) {
         if (!$value instanceof DOMNode) {
-            throw new CM_Exception_Invalid('Element is not an instance of `DOMNode`', null, null, ['element' => $value]);
+            throw new CM_Exception_Invalid('Element is not an instance of `DOMNode`', null, ['element' => $value]);
         }
         if (null === $offset) {
             $this->_elementList[] = $value;

--- a/library/CM/Emoticon.php
+++ b/library/CM/Emoticon.php
@@ -58,7 +58,7 @@ class CM_Emoticon extends CM_Class_Abstract {
             $dataList = static::getEmoticonData();
             $name = $this->getName();
             if (empty($dataList[$name])) {
-                throw new CM_Exception_Invalid('Nonexistent Emoticon', ['name' => $name]);
+                throw new CM_Exception_Invalid('Nonexistent Emoticon', null, null, ['name' => $name]);
             }
             $data = $dataList[$name];
         }
@@ -149,11 +149,12 @@ class CM_Emoticon extends CM_Class_Abstract {
                     $codeList[$code] = $name;
                     $dataList[$name]['codes'][] = $code;
                 } else {
-                    throw new CM_Exception('Emoticon codes overlap',
+                    throw new CM_Exception('Emoticon codes overlap', null, null,
                         [
                             'overlapping emoticons' => [$name, $codeList[$code]],
                             'code'                  => $code
-                        ]);
+                        ]
+                    );
                 }
             }
         }

--- a/library/CM/Emoticon.php
+++ b/library/CM/Emoticon.php
@@ -58,7 +58,7 @@ class CM_Emoticon extends CM_Class_Abstract {
             $dataList = static::getEmoticonData();
             $name = $this->getName();
             if (empty($dataList[$name])) {
-                throw new CM_Exception_Invalid('Nonexistent Emoticon', null, null, ['name' => $name]);
+                throw new CM_Exception_Invalid('Nonexistent Emoticon', null, ['name' => $name]);
             }
             $data = $dataList[$name];
         }
@@ -149,12 +149,10 @@ class CM_Emoticon extends CM_Class_Abstract {
                     $codeList[$code] = $name;
                     $dataList[$name]['codes'][] = $code;
                 } else {
-                    throw new CM_Exception('Emoticon codes overlap', null, null,
-                        [
-                            'overlapping emoticons' => [$name, $codeList[$code]],
-                            'code'                  => $code
-                        ]
-                    );
+                    throw new CM_Exception('Emoticon codes overlap', null, [
+                        'overlapping emoticons' => [$name, $codeList[$code]],
+                        'code'                  => $code
+                    ]);
                 }
             }
         }

--- a/library/CM/Exception.php
+++ b/library/CM/Exception.php
@@ -16,18 +16,19 @@ class CM_Exception extends Exception {
     private $_messagePublic;
 
     /**
-     * @param string|null         $message
-     * @param int|null            $severity
-     * @param array|null          $metaInfo
-     * @param CM_I18n_Phrase|null $messagePublic
+     * @param string|null $message
+     * @param int|null    $severity
+     * @param array|null  $metaInfo
+     * @param array|null  $options
      */
-    public function __construct($message = null, $severity = null, array $metaInfo = null, CM_I18n_Phrase $messagePublic = null) {
-        $this->_metaInfo = null !== $metaInfo ? $metaInfo : array();
+    public function __construct($message = null, $severity = null, array $metaInfo = null, array $options = null) {
+        $this->_validateOptions($options);
 
+        $this->_metaInfo = null !== $metaInfo ? $metaInfo : array();
         if (null !== $severity) {
             $this->setSeverity((int) $severity);
         }
-        $this->_messagePublic = $messagePublic;
+        $this->_messagePublic = $options['messagePublic'];
         parent::__construct($message);
     }
 
@@ -89,6 +90,32 @@ class CM_Exception extends Exception {
             default:
                 return new CM_Paging_Log_Fatal();
                 break;
+        }
+    }
+
+    /**
+     * @param array|null $options
+     * @throws CM_Exception_InvalidParam
+     */
+    private function _validateOptions(array $options = null) {
+        if (is_null($options)) {
+            return;
+        }
+
+        $validKeysToTypes = [
+            'messagePublic' => 'CM_I18n_Phrase',
+        ];
+
+        if (count($validKeysToTypes) < count($options)) {
+            throw new CM_Exception_InvalidParam('$options parameter contains invalid key(s)');
+        }
+
+        foreach ($options as $optionKey => $optionValue) {
+            if (!array_key_exists($optionKey, $validKeysToTypes)) {
+                throw new CM_Exception_InvalidParam('Invalid key for $options: `' . $optionKey . '`');
+            } elseif ($validKeysToTypes[$optionKey] !== null && !($options[$optionKey] instanceof $validKeysToTypes[$optionKey])) {
+                throw new CM_Exception_InvalidParam('Invalid type for key `' . $optionKey . '`');
+            }
         }
     }
 }

--- a/library/CM/Exception.php
+++ b/library/CM/Exception.php
@@ -22,14 +22,12 @@ class CM_Exception extends Exception {
      * @param array|null  $options
      */
     public function __construct($message = null, $severity = null, array $metaInfo = null, array $options = null) {
-        $this->_validateOptions($options);
-
-        $this->_metaInfo = null !== $metaInfo ? $metaInfo : array();
         if (null !== $severity) {
             $this->setSeverity((int) $severity);
         }
+        $this->_metaInfo = null !== $metaInfo ? $metaInfo : array();
         if (isset($options['messagePublic'])) {
-            $this->_messagePublic = $options['messagePublic'];
+            $this->_setMessagePublic($options['messagePublic']);
         }
         parent::__construct($message);
     }
@@ -96,28 +94,9 @@ class CM_Exception extends Exception {
     }
 
     /**
-     * @param array|null $options
-     * @throws CM_Exception_InvalidParam
+     * @param CM_I18n_Phrase $messagePublic
      */
-    private function _validateOptions(array $options = null) {
-        if (is_null($options)) {
-            return;
-        }
-
-        $validKeysToTypes = [
-            'messagePublic' => 'CM_I18n_Phrase',
-        ];
-
-        if (count($validKeysToTypes) < count($options)) {
-            throw new CM_Exception_InvalidParam('$options parameter contains invalid key(s)');
-        }
-
-        foreach ($options as $optionKey => $optionValue) {
-            if (!array_key_exists($optionKey, $validKeysToTypes)) {
-                throw new CM_Exception_InvalidParam('Invalid key for $options: `' . $optionKey . '`');
-            } elseif ($validKeysToTypes[$optionKey] !== null && !($options[$optionKey] instanceof $validKeysToTypes[$optionKey])) {
-                throw new CM_Exception_InvalidParam('Invalid type for key `' . $optionKey . '`');
-            }
-        }
+    private function _setMessagePublic(CM_I18n_Phrase $messagePublic) {
+        $this->_messagePublic = $messagePublic;
     }
 }

--- a/library/CM/Exception.php
+++ b/library/CM/Exception.php
@@ -17,11 +17,11 @@ class CM_Exception extends Exception {
 
     /**
      * @param string|null         $message
-     * @param CM_I18n_Phrase|null $messagePublic
      * @param int|null            $severity
      * @param array|null          $metaInfo
+     * @param CM_I18n_Phrase|null $messagePublic
      */
-    public function __construct($message = null, CM_I18n_Phrase $messagePublic = null, $severity = null, array $metaInfo = null) {
+    public function __construct($message = null, $severity = null, array $metaInfo = null, CM_I18n_Phrase $messagePublic = null) {
         $this->_metaInfo = null !== $metaInfo ? $metaInfo : array();
 
         if (null !== $severity) {

--- a/library/CM/Exception.php
+++ b/library/CM/Exception.php
@@ -28,7 +28,9 @@ class CM_Exception extends Exception {
         if (null !== $severity) {
             $this->setSeverity((int) $severity);
         }
-        $this->_messagePublic = $options['messagePublic'];
+        if (isset($options['messagePublic'])) {
+            $this->_messagePublic = $options['messagePublic'];
+        }
         parent::__construct($message);
     }
 

--- a/library/CM/Exception.php
+++ b/library/CM/Exception.php
@@ -13,24 +13,21 @@ class CM_Exception extends Exception {
     private $_metaInfo;
 
     /** @var CM_I18n_Phrase|null */
-    private $_messagePublicPhrase;
+    private $_messagePublic;
 
     /**
-     * @param string|null $message
-     * @param array|null  $metaInfo
-     * @param array|null  $options
+     * @param string|null         $message
+     * @param CM_I18n_Phrase|null $messagePublic
+     * @param int|null            $severity
+     * @param array|null          $metaInfo
      */
-    public function __construct($message = null, array $metaInfo = null, array $options = null) {
+    public function __construct($message = null, CM_I18n_Phrase $messagePublic = null, $severity = null, array $metaInfo = null) {
         $this->_metaInfo = null !== $metaInfo ? $metaInfo : array();
 
-        if (isset($options['messagePublic'])) {
-            $phraseVariables = isset($options['messagePublicVariables']) ? (array) $options['messagePublicVariables'] : [];
-            $this->_messagePublicPhrase = new CM_I18n_Phrase($options['messagePublic'], $phraseVariables);
+        if (null !== $severity) {
+            $this->setSeverity((int) $severity);
         }
-
-        if (isset($options['severity'])) {
-            $this->setSeverity($options['severity']);
-        }
+        $this->_messagePublic = $messagePublic;
         parent::__construct($message);
     }
 
@@ -42,14 +39,14 @@ class CM_Exception extends Exception {
         if (!$this->isPublic()) {
             return 'Internal server error';
         }
-        return $this->_messagePublicPhrase->translate($render);
+        return $this->_messagePublic->translate($render);
     }
 
     /**
      * @return boolean
      */
     public function isPublic() {
-        return (null !== $this->_messagePublicPhrase);
+        return (null !== $this->_messagePublic);
     }
 
     /**

--- a/library/CM/Exception.php
+++ b/library/CM/Exception.php
@@ -6,17 +6,14 @@ class CM_Exception extends Exception {
     const ERROR = 2;
     const FATAL = 3;
 
-    /** @var string|null */
-    private $_messagePublic;
-
-    /** @var array|null */
-    private $_messagePublicVariables;
-
     /** @var int */
     protected $_severity = self::ERROR;
 
     /** @var array */
     private $_metaInfo;
+
+    /** @var CM_I18n_Phrase|null */
+    private $_messagePublicPhrase;
 
     /**
      * @param string|null $message
@@ -25,8 +22,12 @@ class CM_Exception extends Exception {
      */
     public function __construct($message = null, array $metaInfo = null, array $options = null) {
         $this->_metaInfo = null !== $metaInfo ? $metaInfo : array();
-        $this->_messagePublic = isset($options['messagePublic']) ? (string) $options['messagePublic'] : null;
-        $this->_messagePublicVariables = isset($options['messagePublicVariables']) ? (array) $options['messagePublicVariables'] : null;
+
+        if (isset($options['messagePublic'])) {
+            $phraseVariables = isset($options['messagePublicVariables']) ? (array) $options['messagePublicVariables'] : [];
+            $this->_messagePublicPhrase = new CM_I18n_Phrase($options['messagePublic'], $phraseVariables);
+        }
+
         if (isset($options['severity'])) {
             $this->setSeverity($options['severity']);
         }
@@ -41,14 +42,14 @@ class CM_Exception extends Exception {
         if (!$this->isPublic()) {
             return 'Internal server error';
         }
-        return $render->getTranslation($this->_messagePublic, $this->_messagePublicVariables);
+        return $this->_messagePublicPhrase->translate($render);
     }
 
     /**
      * @return boolean
      */
     public function isPublic() {
-        return (null !== $this->_messagePublic);
+        return (null !== $this->_messagePublicPhrase);
     }
 
     /**

--- a/library/CM/Exception/Blocked.php
+++ b/library/CM/Exception/Blocked.php
@@ -6,6 +6,6 @@ class CM_Exception_Blocked extends CM_Exception {
      * @param CM_Model_User $user
      */
     public function __construct(CM_Model_User $user) {
-        parent::__construct('Blocked', new CM_I18n_Phrase('{$username} has blocked you.', ['username' => $user->getDisplayName()]));
+        parent::__construct('Blocked', null, null, new CM_I18n_Phrase('{$username} has blocked you.', ['username' => $user->getDisplayName()]));
     }
 }

--- a/library/CM/Exception/Blocked.php
+++ b/library/CM/Exception/Blocked.php
@@ -6,6 +6,8 @@ class CM_Exception_Blocked extends CM_Exception {
      * @param CM_Model_User $user
      */
     public function __construct(CM_Model_User $user) {
-        parent::__construct('Blocked', null, null, new CM_I18n_Phrase('{$username} has blocked you.', ['username' => $user->getDisplayName()]));
+        parent::__construct('Blocked', null, null, [
+            'messagePublic' => new CM_I18n_Phrase('{$username} has blocked you.', ['username' => $user->getDisplayName()]),
+        ]);
     }
 }

--- a/library/CM/Exception/Blocked.php
+++ b/library/CM/Exception/Blocked.php
@@ -6,9 +6,6 @@ class CM_Exception_Blocked extends CM_Exception {
      * @param CM_Model_User $user
      */
     public function __construct(CM_Model_User $user) {
-        parent::__construct('Blocked', null, array(
-            'messagePublic'          => '{$username} has blocked you.',
-            'messagePublicVariables' => array('username' => $user->getDisplayName()),
-        ));
+        parent::__construct('Blocked', new CM_I18n_Phrase('{$username} has blocked you.', ['username' => $user->getDisplayName()]));
     }
 }

--- a/library/CM/Exception/FormFieldValidation.php
+++ b/library/CM/Exception/FormFieldValidation.php
@@ -3,11 +3,9 @@
 class CM_Exception_FormFieldValidation extends CM_Exception {
 
     /**
-     * @param string     $messagePublic
-     * @param array|null $variables
+     * @param CM_I18n_Phrase $messagePublic
      */
-    public function __construct($messagePublic, array $variables = null) {
-        $messagePublic = (string) $messagePublic;
-        parent::__construct('FormField Validation failed', new CM_I18n_Phrase($messagePublic, $variables));
+    public function __construct(CM_I18n_Phrase $messagePublic) {
+        parent::__construct('FormField Validation failed', $messagePublic);
     }
 }

--- a/library/CM/Exception/FormFieldValidation.php
+++ b/library/CM/Exception/FormFieldValidation.php
@@ -6,6 +6,8 @@ class CM_Exception_FormFieldValidation extends CM_Exception {
      * @param CM_I18n_Phrase $messagePublic
      */
     public function __construct(CM_I18n_Phrase $messagePublic) {
-        parent::__construct('FormField Validation failed', null, null, $messagePublic);
+        parent::__construct('FormField Validation failed', null, null, [
+            'messagePublic' => $messagePublic,
+        ]);
     }
 }

--- a/library/CM/Exception/FormFieldValidation.php
+++ b/library/CM/Exception/FormFieldValidation.php
@@ -7,9 +7,7 @@ class CM_Exception_FormFieldValidation extends CM_Exception {
      * @param array|null $variables
      */
     public function __construct($messagePublic, array $variables = null) {
-        parent::__construct('FormField Validation failed', null, array(
-            'messagePublic'          => $messagePublic,
-            'messagePublicVariables' => $variables
-        ));
+        $messagePublic = (string) $messagePublic;
+        parent::__construct('FormField Validation failed', new CM_I18n_Phrase($messagePublic, $variables));
     }
 }

--- a/library/CM/Exception/FormFieldValidation.php
+++ b/library/CM/Exception/FormFieldValidation.php
@@ -6,6 +6,6 @@ class CM_Exception_FormFieldValidation extends CM_Exception {
      * @param CM_I18n_Phrase $messagePublic
      */
     public function __construct(CM_I18n_Phrase $messagePublic) {
-        parent::__construct('FormField Validation failed', $messagePublic);
+        parent::__construct('FormField Validation failed', null, null, $messagePublic);
     }
 }

--- a/library/CM/FormField/Birthdate.php
+++ b/library/CM/FormField/Birthdate.php
@@ -21,7 +21,7 @@ class CM_FormField_Birthdate extends CM_FormField_Date {
         $userInput = parent::validate($environment, $userInput);
         $age = $userInput->diff(new DateTime())->y;
         if ($age < $this->_minAge || $age > $this->_maxAge) {
-            throw new CM_Exception_FormFieldValidation('Invalid birthdate');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid birthdate'));
         }
         return $userInput;
     }

--- a/library/CM/FormField/Captcha.php
+++ b/library/CM/FormField/Captcha.php
@@ -13,10 +13,10 @@ class CM_FormField_Captcha extends CM_FormField_Abstract {
         try {
             $captcha = new CM_Captcha($id);
         } catch (CM_Exception_Nonexistent $e) {
-            throw new CM_Exception_FormFieldValidation('Invalid captcha reference');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid captcha reference'));
         }
         if (!$captcha->check($text)) {
-            throw new CM_Exception_FormFieldValidation('Number doesn\'t match captcha');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Number doesn\'t match captcha'));
         }
 
         return $userInput;

--- a/library/CM/FormField/Color.php
+++ b/library/CM/FormField/Color.php
@@ -4,7 +4,7 @@ class CM_FormField_Color extends CM_FormField_Abstract {
 
     public function validate(CM_Frontend_Environment $environment, $userInput) {
         if (!preg_match('/^#[abcdef\d]{6}$/i', $userInput)) {
-            throw new CM_Exception_FormFieldValidation('Invalid color');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid color'));
         }
         return (string) $userInput;
     }

--- a/library/CM/FormField/Email.php
+++ b/library/CM/FormField/Email.php
@@ -7,7 +7,7 @@ class CM_FormField_Email extends CM_FormField_Text {
 
         $emailVerification = $this->_getEmailVerification();
         if (!$emailVerification->isValid($userInput)) {
-            throw new CM_Exception_FormFieldValidation('Invalid email address');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid email address'));
         }
 
         return $userInput;

--- a/library/CM/FormField/FileImage.php
+++ b/library/CM/FormField/FileImage.php
@@ -9,7 +9,7 @@ class CM_FormField_FileImage extends CM_FormField_File {
             $image = new CM_Image_Image($file->read());
             $image->validate();
         } catch (CM_Exception $e) {
-            throw new CM_Exception_FormFieldValidation('Invalid image');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid image'));
         }
     }
 

--- a/library/CM/FormField/Float.php
+++ b/library/CM/FormField/Float.php
@@ -5,7 +5,7 @@ class CM_FormField_Float extends CM_FormField_Text {
     public function validate(CM_Frontend_Environment $environment, $userInput) {
         $userInput = parent::validate($environment, $userInput);
         if (!is_numeric($userInput)) {
-            throw new CM_Exception_FormFieldValidation('Not numeric');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Not numeric'));
         }
         return (float) $userInput;
     }

--- a/library/CM/FormField/GeoPoint.php
+++ b/library/CM/FormField/GeoPoint.php
@@ -10,16 +10,16 @@ class CM_FormField_GeoPoint extends CM_FormField_Abstract {
      */
     public function validate(CM_Frontend_Environment $environment, $userInput) {
         if (!isset($userInput['latitude']) || !is_numeric($userInput['latitude'])) {
-            throw new CM_Exception_FormFieldValidation('Latitude needs to be numeric');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Latitude needs to be numeric'));
         }
         if (!isset($userInput['longitude']) || !is_numeric($userInput['longitude'])) {
-            throw new CM_Exception_FormFieldValidation('Longitude needs to be numeric');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Longitude needs to be numeric'));
         }
 
         try {
             $point = new CM_Geo_Point($userInput['latitude'], $userInput['longitude']);
         } catch (CM_Exception_Invalid $e) {
-            throw new CM_Exception_FormFieldValidation('Invalid latitude or longitude value');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid latitude or longitude value'));
         }
 
         return $point;

--- a/library/CM/FormField/Integer.php
+++ b/library/CM/FormField/Integer.php
@@ -8,11 +8,11 @@ class CM_FormField_Integer extends CM_FormField_Abstract {
 
     public function validate(CM_Frontend_Environment $environment, $userInput) {
         if (!is_numeric($userInput)) {
-            throw new CM_Exception_FormFieldValidation('Invalid number');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid number'));
         }
         $value = (int) $userInput;
         if ($value < $this->_options['min'] || $value > $this->_options['max']) {
-            throw new CM_Exception_FormFieldValidation('Value not in range.');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Value not in range.'));
         }
         return $value;
     }

--- a/library/CM/FormField/Location.php
+++ b/library/CM/FormField/Location.php
@@ -35,12 +35,12 @@ class CM_FormField_Location extends CM_FormField_SuggestOne {
     public function validate(CM_Frontend_Environment $environment, $userInput) {
         $value = parent::validate($environment, $userInput);
         if (!preg_match('/^(\d+)\.(\d+)$/', $value, $matches)) {
-            throw new CM_Exception_FormFieldValidation('Invalid input format');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid input format'));
         }
         $level = $matches[1];
         $id = $matches[2];
         if ($level < $this->_options['levelMin'] || $level > $this->_options['levelMax']) {
-            throw new CM_Exception_FormFieldValidation('Invalid location level.');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid location level.'));
         }
         return new CM_Model_Location($level, $id);
     }

--- a/library/CM/FormField/Set/Select.php
+++ b/library/CM/FormField/Set/Select.php
@@ -7,7 +7,7 @@ class CM_FormField_Set_Select extends CM_FormField_Set {
 
     public function validate(CM_Frontend_Environment $environment, $userInput) {
         if (!in_array($userInput, $this->_getValues())) {
-            throw new CM_Exception_FormFieldValidation('Invalid value');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid value'));
         }
         return $userInput;
     }

--- a/library/CM/FormField/Suggest.php
+++ b/library/CM/FormField/Suggest.php
@@ -24,7 +24,7 @@ abstract class CM_FormField_Suggest extends CM_FormField_Abstract {
         $values = explode('--SELECT2SEPARATOR--', $userInput);
         $values = array_unique($values);
         if ($this->_options['cardinality'] && count($values) > $this->_options['cardinality']) {
-            throw new CM_Exception_FormFieldValidation('Too many elements.');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Too many elements.'));
         }
         return $values;
     }

--- a/library/CM/FormField/Text.php
+++ b/library/CM/FormField/Text.php
@@ -16,15 +16,15 @@ class CM_FormField_Text extends CM_FormField_Abstract {
 
     public function validate(CM_Frontend_Environment $environment, $userInput) {
         if (isset($this->_options['lengthMax']) && mb_strlen($userInput) > $this->_options['lengthMax']) {
-            throw new CM_Exception_FormFieldValidation('Too long');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Too long'));
         }
         if (isset($this->_options['lengthMin']) && mb_strlen($userInput) < $this->_options['lengthMin']) {
-            throw new CM_Exception_FormFieldValidation('Too short');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Too short'));
         }
         if (!empty($this->_options['forbidBadwords'])) {
             $badwordList = new CM_Paging_ContentList_Badwords();
             if ($badword = $badwordList->getMatch($userInput)) {
-                throw new CM_Exception_FormFieldValidation('The word `{$badword}` is not allowed', array('badword' => $badword));
+                throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('The word `{$badword}` is not allowed', ['badword' => $badword]));
             }
         }
         return $userInput;

--- a/library/CM/FormField/TreeSelect.php
+++ b/library/CM/FormField/TreeSelect.php
@@ -12,7 +12,7 @@ class CM_FormField_TreeSelect extends CM_FormField_Abstract {
 
     public function validate(CM_Frontend_Environment $environment, $userInput) {
         if (!$this->_tree->findNodeById($userInput)) {
-            throw new CM_Exception_FormFieldValidation('Invalid value');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid value'));
         }
         return $userInput;
     }

--- a/library/CM/FormField/Url.php
+++ b/library/CM/FormField/Url.php
@@ -6,7 +6,7 @@ class CM_FormField_Url extends CM_FormField_Text {
         $userInput = parent::validate($environment, $userInput);
 
         if (false === filter_var($userInput, FILTER_VALIDATE_URL)) {
-            throw new CM_Exception_FormFieldValidation('Invalid url');
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid url'));
         }
 
         return $userInput;

--- a/library/CM/Frontend/Render.php
+++ b/library/CM/Frontend/Render.php
@@ -447,7 +447,7 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
                 return $classnameWithNamespace;
             }
         }
-        throw new CM_Exception_Invalid('The class was not found in any namespace.', null, null, ['name' => $classname]);
+        throw new CM_Exception_Invalid('The class was not found in any namespace.', null, ['name' => $classname]);
     }
 
     /**

--- a/library/CM/Frontend/Render.php
+++ b/library/CM/Frontend/Render.php
@@ -398,7 +398,8 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
         $templateName = (string) $templateName;
         foreach ($view->getClassHierarchy() as $className) {
             if (!preg_match('/^([a-zA-Z]+)_([a-zA-Z]+)_(.+)$/', $className, $matches)) {
-                throw new CM_Exception('Cannot detect namespace/view-class/view-name for className:`' . $className . '` templateName: `' . $templateName . '`.');
+                throw new CM_Exception('Cannot detect namespace/view-class/view-name for className:`' . $className . '` templateName: `' .
+                    $templateName . '`.');
             }
             $templatePathRelative = $matches[2] . DIRECTORY_SEPARATOR . $matches[3] . DIRECTORY_SEPARATOR . $templateName . '.tpl';
             $namespace = $matches[1];
@@ -446,7 +447,7 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
                 return $classnameWithNamespace;
             }
         }
-        throw new CM_Exception_Invalid('The class was not found in any namespace.', array('name' => $classname));
+        throw new CM_Exception_Invalid('The class was not found in any namespace.', null, null, ['name' => $classname]);
     }
 
     /**

--- a/library/CM/Http/Request/Post.php
+++ b/library/CM/Http/Request/Post.php
@@ -37,8 +37,7 @@ class CM_Http_Request_Post extends CM_Http_Request_Abstract {
         if ($this->_bodyQuery === null) {
             if ($this->_bodyEncoding == self::ENCODING_JSON) {
                 if (!is_array($this->_bodyQuery = json_decode($this->getBody(), true))) {
-                    throw new CM_Exception_Invalid('Cannot extract query from body `' . $this->getBody() .
-                    '`.', null, array('severity' => CM_Exception::WARN));
+                    throw new CM_Exception_Invalid('Cannot extract query from body `' . $this->getBody() . '`.', null, CM_Exception::WARN);
                 }
             } elseif ($this->_bodyEncoding == self::ENCODING_FORM) {
                 parse_str($this->getBody(), $this->_bodyQuery);

--- a/library/CM/Http/Request/Post.php
+++ b/library/CM/Http/Request/Post.php
@@ -37,7 +37,7 @@ class CM_Http_Request_Post extends CM_Http_Request_Abstract {
         if ($this->_bodyQuery === null) {
             if ($this->_bodyEncoding == self::ENCODING_JSON) {
                 if (!is_array($this->_bodyQuery = json_decode($this->getBody(), true))) {
-                    throw new CM_Exception_Invalid('Cannot extract query from body `' . $this->getBody() . '`.', null, CM_Exception::WARN);
+                    throw new CM_Exception_Invalid('Cannot extract query from body `' . $this->getBody() . '`.', CM_Exception::WARN);
                 }
             } elseif ($this->_bodyEncoding == self::ENCODING_FORM) {
                 parse_str($this->getBody(), $this->_bodyQuery);

--- a/library/CM/Http/Response/Resource/Css/Library.php
+++ b/library/CM/Http/Response/Resource/Css/Library.php
@@ -8,7 +8,7 @@ class CM_Http_Response_Resource_Css_Library extends CM_Http_Response_Resource_Cs
                 $this->_setAsset(new CM_Asset_Css_Library($this->getRender()));
                 break;
             default:
-                throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', null, CM_Exception::WARN);
+                throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', CM_Exception::WARN);
         }
     }
 

--- a/library/CM/Http/Response/Resource/Css/Library.php
+++ b/library/CM/Http/Response/Resource/Css/Library.php
@@ -8,7 +8,7 @@ class CM_Http_Response_Resource_Css_Library extends CM_Http_Response_Resource_Cs
                 $this->_setAsset(new CM_Asset_Css_Library($this->getRender()));
                 break;
             default:
-                throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', null, array('severity' => CM_Exception::WARN));
+                throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', null, CM_Exception::WARN);
         }
     }
 

--- a/library/CM/Http/Response/Resource/Css/Vendor.php
+++ b/library/CM/Http/Response/Resource/Css/Vendor.php
@@ -8,7 +8,7 @@ class CM_Http_Response_Resource_Css_Vendor extends CM_Http_Response_Resource_Css
                 $this->_setAsset(new CM_Asset_Css_Vendor($this->getRender()));
                 break;
             default:
-                throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', null, array('severity' => CM_Exception::WARN));
+                throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', null, CM_Exception::WARN);
         }
     }
 

--- a/library/CM/Http/Response/Resource/Css/Vendor.php
+++ b/library/CM/Http/Response/Resource/Css/Vendor.php
@@ -8,7 +8,7 @@ class CM_Http_Response_Resource_Css_Vendor extends CM_Http_Response_Resource_Css
                 $this->_setAsset(new CM_Asset_Css_Vendor($this->getRender()));
                 break;
             default:
-                throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', null, CM_Exception::WARN);
+                throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', CM_Exception::WARN);
         }
     }
 

--- a/library/CM/Http/Response/Resource/Javascript/Library.php
+++ b/library/CM/Http/Response/Resource/Javascript/Library.php
@@ -15,7 +15,7 @@ class CM_Http_Response_Resource_Javascript_Library extends CM_Http_Response_Reso
             $this->_setAsset(new CM_Asset_Javascript_Translations($language));
             return;
         }
-        throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', null, array('severity' => CM_Exception::WARN));
+        throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', null, CM_Exception::WARN);
     }
 
     public static function match(CM_Http_Request_Abstract $request) {

--- a/library/CM/Http/Response/Resource/Javascript/Library.php
+++ b/library/CM/Http/Response/Resource/Javascript/Library.php
@@ -15,7 +15,7 @@ class CM_Http_Response_Resource_Javascript_Library extends CM_Http_Response_Reso
             $this->_setAsset(new CM_Asset_Javascript_Translations($language));
             return;
         }
-        throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', null, CM_Exception::WARN);
+        throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', CM_Exception::WARN);
     }
 
     public static function match(CM_Http_Request_Abstract $request) {

--- a/library/CM/Http/Response/Resource/Javascript/Vendor.php
+++ b/library/CM/Http/Response/Resource/Javascript/Vendor.php
@@ -11,7 +11,7 @@ class CM_Http_Response_Resource_Javascript_Vendor extends CM_Http_Response_Resou
                 $this->_setAsset(new CM_Asset_Javascript_VendorAfterBody($this->getSite()));
                 break;
             default:
-                throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', null, CM_Exception::WARN);
+                throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', CM_Exception::WARN);
         }
     }
 

--- a/library/CM/Http/Response/Resource/Javascript/Vendor.php
+++ b/library/CM/Http/Response/Resource/Javascript/Vendor.php
@@ -11,7 +11,7 @@ class CM_Http_Response_Resource_Javascript_Vendor extends CM_Http_Response_Resou
                 $this->_setAsset(new CM_Asset_Javascript_VendorAfterBody($this->getSite()));
                 break;
             default:
-                throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', null, array('severity' => CM_Exception::WARN));
+                throw new CM_Exception_Invalid('Invalid path `' . $this->getRequest()->getPath() . '` provided', null, CM_Exception::WARN);
         }
     }
 

--- a/library/CM/Http/Response/Resource/Layout.php
+++ b/library/CM/Http/Response/Resource/Layout.php
@@ -10,7 +10,7 @@ class CM_Http_Response_Resource_Layout extends CM_Http_Response_Resource_Abstrac
         if ($pathRaw = $this->getRender()->getLayoutPath('resource/' . $path, null, null, true, false)) {
             $file = new CM_File($pathRaw);
             if (in_array($file->getExtension(), $this->_getFiletypesForbidden())) {
-                throw new CM_Exception_Nonexistent('Forbidden filetype', ['path' => $path], ['severity' => CM_Exception::WARN]);
+                throw new CM_Exception_Nonexistent('Forbidden filetype', null, CM_Exception::WARN, ['path' => $path]);
             }
             $content = $file->read();
             $mimeType = $file->getMimeType();
@@ -18,7 +18,7 @@ class CM_Http_Response_Resource_Layout extends CM_Http_Response_Resource_Abstrac
             $content = $this->getRender()->fetchTemplate($pathTpl);
             $mimeType = CM_File::getMimeTypeByContent($content);
         } else {
-            throw new CM_Exception_Nonexistent('Invalid filename', ['path' => $path], ['severity' => CM_Exception::WARN]);
+            throw new CM_Exception_Nonexistent('Invalid filename', null, CM_Exception::WARN, ['path' => $path]);
         }
         $this->setHeader('Content-Type', $mimeType);
         $this->_setContent($content);

--- a/library/CM/Http/Response/Resource/Layout.php
+++ b/library/CM/Http/Response/Resource/Layout.php
@@ -10,7 +10,7 @@ class CM_Http_Response_Resource_Layout extends CM_Http_Response_Resource_Abstrac
         if ($pathRaw = $this->getRender()->getLayoutPath('resource/' . $path, null, null, true, false)) {
             $file = new CM_File($pathRaw);
             if (in_array($file->getExtension(), $this->_getFiletypesForbidden())) {
-                throw new CM_Exception_Nonexistent('Forbidden filetype', null, CM_Exception::WARN, ['path' => $path]);
+                throw new CM_Exception_Nonexistent('Forbidden filetype', CM_Exception::WARN, ['path' => $path]);
             }
             $content = $file->read();
             $mimeType = $file->getMimeType();
@@ -18,7 +18,7 @@ class CM_Http_Response_Resource_Layout extends CM_Http_Response_Resource_Abstrac
             $content = $this->getRender()->fetchTemplate($pathTpl);
             $mimeType = CM_File::getMimeTypeByContent($content);
         } else {
-            throw new CM_Exception_Nonexistent('Invalid filename', null, CM_Exception::WARN, ['path' => $path]);
+            throw new CM_Exception_Nonexistent('Invalid filename', CM_Exception::WARN, ['path' => $path]);
         }
         $this->setHeader('Content-Type', $mimeType);
         $this->_setContent($content);

--- a/library/CM/Http/Response/Upload.php
+++ b/library/CM/Http/Response/Upload.php
@@ -42,7 +42,7 @@ class CM_Http_Response_Upload extends CM_Http_Response_Abstract {
 
             $fileTmp = new CM_File($fileInfo['tmp_name']);
             if ($fileTmp->getSize() > self::MAX_FILE_SIZE) {
-                throw new CM_Exception_FormFieldValidation('File too big');
+                throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('File too big'));
             }
 
             $file = CM_File_UserContent_Temp::create($fileInfo['name'], $fileTmp->read());

--- a/library/CM/Http/Response/View/Abstract.php
+++ b/library/CM/Http/Response/View/Abstract.php
@@ -190,24 +190,24 @@ abstract class CM_Http_Response_View_Abstract extends CM_Http_Response_Abstract 
         }
         $query = $this->_request->getQuery();
         if (!array_key_exists('viewInfoList', $query)) {
-            throw new CM_Exception_Invalid('viewInfoList param not found.', null, CM_Exception::WARN);
+            throw new CM_Exception_Invalid('viewInfoList param not found.', CM_Exception::WARN);
         }
         $viewInfoList = $query['viewInfoList'];
         if (!array_key_exists($className, $viewInfoList)) {
-            throw new CM_Exception_Invalid('View `' . $className . '` not set.', null, CM_Exception::WARN);
+            throw new CM_Exception_Invalid('View `' . $className . '` not set.', CM_Exception::WARN);
         }
         $viewInfo = $viewInfoList[$className];
         if (!is_array($viewInfo)) {
-            throw new CM_Exception_Invalid('View `' . $className . '` is not an array', null, CM_Exception::WARN);
+            throw new CM_Exception_Invalid('View `' . $className . '` is not an array', CM_Exception::WARN);
         }
         if (!isset($viewInfo['id'])) {
-            throw new CM_Exception_Invalid('View id `' . $className . '` not set.', null, CM_Exception::WARN);
+            throw new CM_Exception_Invalid('View id `' . $className . '` not set.', CM_Exception::WARN);
         }
         if (!isset($viewInfo['className']) || !class_exists($viewInfo['className']) || !is_a($viewInfo['className'], 'CM_View_Abstract', true)) {
-            throw new CM_Exception_Invalid('View className `' . $className . '` is illegal: `' . $viewInfo['className'] .'`.', null, CM_Exception::WARN);
+            throw new CM_Exception_Invalid('View className `' . $className . '` is illegal: `' . $viewInfo['className'] .'`.', CM_Exception::WARN);
         }
         if (!isset($viewInfo['params'])) {
-            throw new CM_Exception_Invalid('View params `' . $className . '` not set.', null, CM_Exception::WARN);
+            throw new CM_Exception_Invalid('View params `' . $className . '` not set.', CM_Exception::WARN);
         }
         if (!isset($viewInfo['parentId'])) {
             $viewInfo['parentId'] = null;

--- a/library/CM/Http/Response/View/Abstract.php
+++ b/library/CM/Http/Response/View/Abstract.php
@@ -190,25 +190,24 @@ abstract class CM_Http_Response_View_Abstract extends CM_Http_Response_Abstract 
         }
         $query = $this->_request->getQuery();
         if (!array_key_exists('viewInfoList', $query)) {
-            throw new CM_Exception_Invalid('viewInfoList param not found.', null, array('severity' => CM_Exception::WARN));
+            throw new CM_Exception_Invalid('viewInfoList param not found.', null, CM_Exception::WARN);
         }
         $viewInfoList = $query['viewInfoList'];
         if (!array_key_exists($className, $viewInfoList)) {
-            throw new CM_Exception_Invalid('View `' . $className . '` not set.', null, array('severity' => CM_Exception::WARN));
+            throw new CM_Exception_Invalid('View `' . $className . '` not set.', null, CM_Exception::WARN);
         }
         $viewInfo = $viewInfoList[$className];
         if (!is_array($viewInfo)) {
-            throw new CM_Exception_Invalid('View `' . $className . '` is not an array', null, array('severity' => CM_Exception::WARN));
+            throw new CM_Exception_Invalid('View `' . $className . '` is not an array', null, CM_Exception::WARN);
         }
         if (!isset($viewInfo['id'])) {
-            throw new CM_Exception_Invalid('View id `' . $className . '` not set.', null, array('severity' => CM_Exception::WARN));
+            throw new CM_Exception_Invalid('View id `' . $className . '` not set.', null, CM_Exception::WARN);
         }
         if (!isset($viewInfo['className']) || !class_exists($viewInfo['className']) || !is_a($viewInfo['className'], 'CM_View_Abstract', true)) {
-            throw new CM_Exception_Invalid('View className `' . $className . '` is illegal: `' . $viewInfo['className'] .
-                '`.', null, array('severity' => CM_Exception::WARN));
+            throw new CM_Exception_Invalid('View className `' . $className . '` is illegal: `' . $viewInfo['className'] .'`.', null, CM_Exception::WARN);
         }
         if (!isset($viewInfo['params'])) {
-            throw new CM_Exception_Invalid('View params `' . $className . '` not set.', null, array('severity' => CM_Exception::WARN));
+            throw new CM_Exception_Invalid('View params `' . $className . '` not set.', null, CM_Exception::WARN);
         }
         if (!isset($viewInfo['parentId'])) {
             $viewInfo['parentId'] = null;

--- a/library/CM/Http/Response/View/Ajax.php
+++ b/library/CM/Http/Response/View/Ajax.php
@@ -6,13 +6,13 @@ class CM_Http_Response_View_Ajax extends CM_Http_Response_View_Abstract {
         $success = array();
         $query = $this->_request->getQuery();
         if (!isset($query['method'])) {
-            throw new CM_Exception_Invalid('No method specified', null, array('severity' => CM_Exception::WARN));
+            throw new CM_Exception_Invalid('No method specified', null, CM_Exception::WARN);
         }
         if (!preg_match('/^[\w_]+$/i', $query['method'])) {
-            throw new CM_Exception_Invalid('Illegal method: `' . $query['method'] . '`', null, array('severity' => CM_Exception::WARN));
+            throw new CM_Exception_Invalid('Illegal method: `' . $query['method'] . '`', null, CM_Exception::WARN);
         }
         if (!isset($query['params']) || !is_array($query['params'])) {
-            throw new CM_Exception_Invalid('Illegal params', null, array('severity' => CM_Exception::WARN));
+            throw new CM_Exception_Invalid('Illegal params', null, CM_Exception::WARN);
         }
 
         $view = $this->_getView();

--- a/library/CM/Http/Response/View/Ajax.php
+++ b/library/CM/Http/Response/View/Ajax.php
@@ -6,13 +6,13 @@ class CM_Http_Response_View_Ajax extends CM_Http_Response_View_Abstract {
         $success = array();
         $query = $this->_request->getQuery();
         if (!isset($query['method'])) {
-            throw new CM_Exception_Invalid('No method specified', null, CM_Exception::WARN);
+            throw new CM_Exception_Invalid('No method specified', CM_Exception::WARN);
         }
         if (!preg_match('/^[\w_]+$/i', $query['method'])) {
-            throw new CM_Exception_Invalid('Illegal method: `' . $query['method'] . '`', null, CM_Exception::WARN);
+            throw new CM_Exception_Invalid('Illegal method: `' . $query['method'] . '`', CM_Exception::WARN);
         }
         if (!isset($query['params']) || !is_array($query['params'])) {
-            throw new CM_Exception_Invalid('Illegal params', null, CM_Exception::WARN);
+            throw new CM_Exception_Invalid('Illegal params', CM_Exception::WARN);
         }
 
         $view = $this->_getView();

--- a/library/CM/I18n/Phrase.php
+++ b/library/CM/I18n/Phrase.php
@@ -14,12 +14,10 @@ class CM_I18n_Phrase {
      */
     public function __construct($phrase, array $variables = null) {
         $this->_phrase = (string) $phrase;
-
-        if (null !== $variables) {
-            $this->_variables = $variables;
-        } else {
+        if (null === $variables) {
             $this->_variables = [];
         }
+        $this->_variables = $variables;
     }
 
     /**

--- a/library/CM/I18n/Phrase.php
+++ b/library/CM/I18n/Phrase.php
@@ -10,11 +10,11 @@ class CM_I18n_Phrase {
 
     /**
      * @param string $phrase
-     * @param string[] $variables
+     * @param string[]|null $variables
      */
-    public function __construct($phrase, array $variables = []) {
+    public function __construct($phrase, array $variables = null) {
         $this->_phrase = (string) $phrase;
-        $this->_variables = $variables;
+        $this->_variables = is_null($variables) ? [] : $variables;
     }
 
     /**

--- a/library/CM/I18n/Phrase.php
+++ b/library/CM/I18n/Phrase.php
@@ -12,7 +12,7 @@ class CM_I18n_Phrase {
      * @param string $phrase
      * @param string[] $variables
      */
-    public function __construct($phrase, array $variables) {
+    public function __construct($phrase, array $variables = []) {
         $this->_phrase = (string) $phrase;
         $this->_variables = $variables;
     }

--- a/library/CM/I18n/Phrase.php
+++ b/library/CM/I18n/Phrase.php
@@ -15,7 +15,7 @@ class CM_I18n_Phrase {
     public function __construct($phrase, array $variables = null) {
         $this->_phrase = (string) $phrase;
         if (null === $variables) {
-            $this->_variables = [];
+            $variables = [];
         }
         $this->_variables = $variables;
     }

--- a/library/CM/I18n/Phrase.php
+++ b/library/CM/I18n/Phrase.php
@@ -9,12 +9,17 @@ class CM_I18n_Phrase {
     protected $_variables;
 
     /**
-     * @param string $phrase
+     * @param string        $phrase
      * @param string[]|null $variables
      */
     public function __construct($phrase, array $variables = null) {
         $this->_phrase = (string) $phrase;
-        $this->_variables = is_null($variables) ? [] : $variables;
+
+        if (null !== $variables) {
+            $this->_variables = $variables;
+        } else {
+            $this->_variables = [];
+        }
     }
 
     /**

--- a/library/CM/Jobdistribution/Job/Abstract.php
+++ b/library/CM/Jobdistribution/Job/Abstract.php
@@ -106,7 +106,7 @@ abstract class CM_Jobdistribution_Job_Abstract extends CM_Class_Abstract {
         } catch (CM_Exception_Nonexistent $ex) {
             throw new CM_Exception_Nonexistent(
                 'Cannot decode workload for Job `' . get_class($this) . '`: Original exception message `' . $ex->getMessage() .
-                '`', null, null, CM_Exception::WARN);
+                '`', null, CM_Exception::WARN);
         }
         return CM_Params::encode($this->_executeJob($params), true);
     }

--- a/library/CM/Jobdistribution/Job/Abstract.php
+++ b/library/CM/Jobdistribution/Job/Abstract.php
@@ -106,7 +106,7 @@ abstract class CM_Jobdistribution_Job_Abstract extends CM_Class_Abstract {
         } catch (CM_Exception_Nonexistent $ex) {
             throw new CM_Exception_Nonexistent(
                 'Cannot decode workload for Job `' . get_class($this) . '`: Original exception message `' . $ex->getMessage() .
-                '`', null, CM_Exception::WARN);
+                '`', CM_Exception::WARN);
         }
         return CM_Params::encode($this->_executeJob($params), true);
     }

--- a/library/CM/Jobdistribution/Job/Abstract.php
+++ b/library/CM/Jobdistribution/Job/Abstract.php
@@ -104,9 +104,8 @@ abstract class CM_Jobdistribution_Job_Abstract extends CM_Class_Abstract {
         try {
             $params = CM_Params::factory(CM_Params::jsonDecode($workload), true);
         } catch (CM_Exception_Nonexistent $ex) {
-            throw new CM_Exception_Nonexistent(
-                'Cannot decode workload for Job `' . get_class($this) . '`: Original exception message `' . $ex->getMessage() .
-                '`', CM_Exception::WARN);
+            throw new CM_Exception_Nonexistent('Cannot decode workload for Job `' . get_class($this) . '`: Original exception message `' .
+                $ex->getMessage() . '`', CM_Exception::WARN);
         }
         return CM_Params::encode($this->_executeJob($params), true);
     }

--- a/library/CM/Maintenance/Cli.php
+++ b/library/CM/Maintenance/Cli.php
@@ -96,7 +96,7 @@ class CM_Maintenance_Cli extends CM_Cli_Runnable_Abstract {
                     $maxMind->upgrade();
                 } catch (Exception $exception) {
                     if (!is_a($exception, 'CM_Exception')) {
-                        $exception = new CM_Exception($exception->getMessage(), null, null, [
+                        $exception = new CM_Exception($exception->getMessage(), null, [
                             'file'  => $exception->getFile(),
                             'line'  => $exception->getLine(),
                             'trace' => $exception->getTraceAsString(),

--- a/library/CM/Maintenance/Cli.php
+++ b/library/CM/Maintenance/Cli.php
@@ -96,7 +96,7 @@ class CM_Maintenance_Cli extends CM_Cli_Runnable_Abstract {
                     $maxMind->upgrade();
                 } catch (Exception $exception) {
                     if (!is_a($exception, 'CM_Exception')) {
-                        $exception = new CM_Exception($exception->getMessage(), [
+                        $exception = new CM_Exception($exception->getMessage(), null, null, [
                             'file'  => $exception->getFile(),
                             'line'  => $exception->getLine(),
                             'trace' => $exception->getTraceAsString(),

--- a/library/CM/Memcache/Client.php
+++ b/library/CM/Memcache/Client.php
@@ -13,7 +13,7 @@ class CM_Memcache_Client extends CM_Class_Abstract {
         foreach ($servers as $server) {
             $this->_memcache->addServer($server['host'], $server['port'], true, 1, 1, 15, true, function ($host, $port) {
                 $warning = new CM_Exception('Cannot connect to memcached host `' . $host . '` on port `' . $port .
-                    '`', null, array('severity' => CM_Exception::WARN));
+                    '`', null, CM_Exception::WARN);
                 CM_Bootloader::getInstance()->getExceptionHandler()->handleException($warning);
             });
         }

--- a/library/CM/Memcache/Client.php
+++ b/library/CM/Memcache/Client.php
@@ -12,8 +12,7 @@ class CM_Memcache_Client extends CM_Class_Abstract {
         $this->_memcache = new Memcache();
         foreach ($servers as $server) {
             $this->_memcache->addServer($server['host'], $server['port'], true, 1, 1, 15, true, function ($host, $port) {
-                $warning = new CM_Exception('Cannot connect to memcached host `' . $host . '` on port `' . $port .
-                    '`', null, CM_Exception::WARN);
+                $warning = new CM_Exception('Cannot connect to memcached host `' . $host . '` on port `' . $port . '`', CM_Exception::WARN);
                 CM_Bootloader::getInstance()->getExceptionHandler()->handleException($warning);
             });
         }

--- a/library/CM/Model/Currency.php
+++ b/library/CM/Model/Currency.php
@@ -23,7 +23,7 @@ class CM_Model_Currency extends CM_Model_Abstract {
     public function setCountryMapping(CM_Model_Location $location) {
         $country = $location->get(CM_Model_Location::LEVEL_COUNTRY);
         if (null === $country) {
-            throw new CM_Exception_Invalid('Location has no country', ['location' => $location->getName()]);
+            throw new CM_Exception_Invalid('Location has no country', null, null, ['location' => $location->getName()]);
         }
         CM_Db_Db::replace('cm_model_currency_country', ['currencyId' => $this->getId(), 'countryId' => $country->getId()]);
     }

--- a/library/CM/Model/Currency.php
+++ b/library/CM/Model/Currency.php
@@ -23,7 +23,7 @@ class CM_Model_Currency extends CM_Model_Abstract {
     public function setCountryMapping(CM_Model_Location $location) {
         $country = $location->get(CM_Model_Location::LEVEL_COUNTRY);
         if (null === $country) {
-            throw new CM_Exception_Invalid('Location has no country', null, null, ['location' => $location->getName()]);
+            throw new CM_Exception_Invalid('Location has no country', null, ['location' => $location->getName()]);
         }
         CM_Db_Db::replace('cm_model_currency_country', ['currencyId' => $this->getId(), 'countryId' => $country->getId()]);
     }

--- a/library/CM/Model/SplittestVariation.php
+++ b/library/CM/Model/SplittestVariation.php
@@ -24,7 +24,7 @@ class CM_Model_SplittestVariation extends CM_Model_Abstract {
         $state = (bool) $state;
         $variationsEnabled = $this->getSplittest()->getVariationsEnabled();
         if (!$state && $state != $this->getEnabled() && $variationsEnabled->getCount() <= 1) {
-            throw new CM_Exception('No variations for Splittest', null, array('messagePublic' => 'At least one variation needs to be enabled'));
+            throw new CM_Exception('No variations for Splittest', new CM_I18n_Phrase('At least one variation needs to be enabled'));
         }
         CM_Db_Db::update('cm_splittestVariation', array('enabled' => $state), array('id' => $this->getId()));
         $this->_change();

--- a/library/CM/Model/SplittestVariation.php
+++ b/library/CM/Model/SplittestVariation.php
@@ -24,7 +24,9 @@ class CM_Model_SplittestVariation extends CM_Model_Abstract {
         $state = (bool) $state;
         $variationsEnabled = $this->getSplittest()->getVariationsEnabled();
         if (!$state && $state != $this->getEnabled() && $variationsEnabled->getCount() <= 1) {
-            throw new CM_Exception('No variations for Splittest', new CM_I18n_Phrase('At least one variation needs to be enabled'));
+            throw new CM_Exception('No variations for Splittest', null, null, [
+                'messagePublic' => new CM_I18n_Phrase('At least one variation needs to be enabled'),
+            ]);
         }
         CM_Db_Db::update('cm_splittestVariation', array('enabled' => $state), array('id' => $this->getId()));
         $this->_change();

--- a/library/CM/Model/Stream/Publish.php
+++ b/library/CM/Model/Stream/Publish.php
@@ -55,7 +55,7 @@ class CM_Model_Stream_Publish extends CM_Model_Stream_Abstract {
         $start = (int) $data['start'];
 
         if (!$streamChannel->isValid()) {
-            throw new CM_Exception_Invalid('Stream channel not valid', null, CM_Exception::WARN);
+            throw new CM_Exception_Invalid('Stream channel not valid', CM_Exception::WARN);
         }
 
         $allowedUntil = $streamChannel->canPublish($user, time());

--- a/library/CM/Model/Stream/Publish.php
+++ b/library/CM/Model/Stream/Publish.php
@@ -55,7 +55,7 @@ class CM_Model_Stream_Publish extends CM_Model_Stream_Abstract {
         $start = (int) $data['start'];
 
         if (!$streamChannel->isValid()) {
-            throw new CM_Exception_Invalid('Stream channel not valid', null, array('severity' => CM_Exception::WARN));
+            throw new CM_Exception_Invalid('Stream channel not valid', null, CM_Exception::WARN);
         }
 
         $allowedUntil = $streamChannel->canPublish($user, time());

--- a/library/CM/Model/Stream/Subscribe.php
+++ b/library/CM/Model/Stream/Subscribe.php
@@ -61,7 +61,7 @@ class CM_Model_Stream_Subscribe extends CM_Model_Stream_Abstract {
         $streamChannel = $data['streamChannel'];
 
         if (!$streamChannel->isValid()) {
-            throw new CM_Exception_Invalid('Stream channel not valid', null, CM_Exception::WARN);
+            throw new CM_Exception_Invalid('Stream channel not valid', CM_Exception::WARN);
         }
 
         $allowedUntil = $streamChannel->canSubscribe($user, time());

--- a/library/CM/Model/Stream/Subscribe.php
+++ b/library/CM/Model/Stream/Subscribe.php
@@ -61,7 +61,7 @@ class CM_Model_Stream_Subscribe extends CM_Model_Stream_Abstract {
         $streamChannel = $data['streamChannel'];
 
         if (!$streamChannel->isValid()) {
-            throw new CM_Exception_Invalid('Stream channel not valid', null, array('severity' => CM_Exception::WARN));
+            throw new CM_Exception_Invalid('Stream channel not valid', null, CM_Exception::WARN);
         }
 
         $allowedUntil = $streamChannel->canSubscribe($user, time());

--- a/library/CM/MongoDb/Client.php
+++ b/library/CM/MongoDb/Client.php
@@ -332,7 +332,7 @@ class CM_MongoDb_Client extends CM_Class_Abstract {
      */
     protected function _checkResultForErrors($result) {
         if (true !== $result && empty($result['ok'])) {
-            throw new CM_MongoDb_Exception('Cannot perform mongodb operation', null, null, ['result' => $result]);
+            throw new CM_MongoDb_Exception('Cannot perform mongodb operation', null, ['result' => $result]);
         }
     }
 

--- a/library/CM/MongoDb/Client.php
+++ b/library/CM/MongoDb/Client.php
@@ -332,7 +332,7 @@ class CM_MongoDb_Client extends CM_Class_Abstract {
      */
     protected function _checkResultForErrors($result) {
         if (true !== $result && empty($result['ok'])) {
-            throw new CM_MongoDb_Exception('Cannot perform mongodb operation', ['result' => $result]);
+            throw new CM_MongoDb_Exception('Cannot perform mongodb operation', null, null, ['result' => $result]);
         }
     }
 

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -229,7 +229,7 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
                     try {
                         $arguments = $namedArgs->matchNamedArgs($constructor, $arguments);
                     } catch (CM_Exception_Invalid $ex) {
-                        throw new CM_Exception_InvalidParam("Not enough parameters", ['parameters' => $param, 'class' => $className]);
+                        throw new CM_Exception_InvalidParam("Not enough parameters", null, null, ['parameters' => $param, 'class' => $className]);
                     }
                 }
 

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -229,7 +229,7 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
                     try {
                         $arguments = $namedArgs->matchNamedArgs($constructor, $arguments);
                     } catch (CM_Exception_Invalid $ex) {
-                        throw new CM_Exception_InvalidParam("Not enough parameters", null, null, ['parameters' => $param, 'class' => $className]);
+                        throw new CM_Exception_InvalidParam("Not enough parameters", null, ['parameters' => $param, 'class' => $className]);
                     }
                 }
 

--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -267,7 +267,7 @@ class CM_Process {
                         $this->unbind('exit', [$this, 'killChildren']);
                     }
                     if ($keepAlive) {
-                        $warning = new CM_Exception('Respawning dead child `' . $pid . '`.', null, array('severity' => CM_Exception::WARN));
+                        $warning = new CM_Exception('Respawning dead child `' . $pid . '`.', null, CM_Exception::WARN);
                         CM_Bootloader::getInstance()->getExceptionHandler()->handleException($warning);
                         usleep(self::RESPAWN_TIMEOUT * 1000000);
                         $this->_fork($forkHandler->getWorkload(), $forkHandler->getIdentifier());

--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -267,7 +267,7 @@ class CM_Process {
                         $this->unbind('exit', [$this, 'killChildren']);
                     }
                     if ($keepAlive) {
-                        $warning = new CM_Exception('Respawning dead child `' . $pid . '`.', null, CM_Exception::WARN);
+                        $warning = new CM_Exception('Respawning dead child `' . $pid . '`.', CM_Exception::WARN);
                         CM_Bootloader::getInstance()->getExceptionHandler()->handleException($warning);
                         usleep(self::RESPAWN_TIMEOUT * 1000000);
                         $this->_fork($forkHandler->getWorkload(), $forkHandler->getIdentifier());

--- a/library/CM/Site/Abstract.php
+++ b/library/CM/Site/Abstract.php
@@ -190,7 +190,7 @@ abstract class CM_Site_Abstract extends CM_Class_Abstract implements CM_ArrayCon
         try {
             $class = self::_getClassName($type);
         } catch (CM_Class_Exception_TypeNotConfiguredException $ex) {
-            throw new CM_Class_Exception_TypeNotConfiguredException('Site with type `' . $type . '` not configured', null, CM_Exception::WARN);
+            throw new CM_Class_Exception_TypeNotConfiguredException('Site with type `' . $type . '` not configured', CM_Exception::WARN);
         }
         return new $class();
     }

--- a/library/CM/Site/Abstract.php
+++ b/library/CM/Site/Abstract.php
@@ -190,7 +190,7 @@ abstract class CM_Site_Abstract extends CM_Class_Abstract implements CM_ArrayCon
         try {
             $class = self::_getClassName($type);
         } catch (CM_Class_Exception_TypeNotConfiguredException $ex) {
-            throw new CM_Class_Exception_TypeNotConfiguredException('Site with type `' . $type . '` not configured', null, null, CM_Exception::WARN);
+            throw new CM_Class_Exception_TypeNotConfiguredException('Site with type `' . $type . '` not configured', null, CM_Exception::WARN);
         }
         return new $class();
     }

--- a/library/CMService/KickBox/Client.php
+++ b/library/CMService/KickBox/Client.php
@@ -79,7 +79,7 @@ class CMService_KickBox_Client implements CM_Service_EmailVerification_ClientInt
         try {
             $response = $this->_getResponse($email);
             if ($response->code !== 200 || !is_array($response->body)) {
-                throw new CM_Exception('Invalid KickBox email validation response', array(
+                throw new CM_Exception('Invalid KickBox email validation response', null, null, array(
                     'email'   => $email,
                     'code'    => $response->code,
                     'headers' => $response->headers,

--- a/library/CMService/KickBox/Client.php
+++ b/library/CMService/KickBox/Client.php
@@ -79,12 +79,12 @@ class CMService_KickBox_Client implements CM_Service_EmailVerification_ClientInt
         try {
             $response = $this->_getResponse($email);
             if ($response->code !== 200 || !is_array($response->body)) {
-                throw new CM_Exception('Invalid KickBox email validation response', null, null, array(
+                throw new CM_Exception('Invalid KickBox email validation response', null, [
                     'email'   => $email,
                     'code'    => $response->code,
                     'headers' => $response->headers,
                     'body'    => $response->body,
-                ));
+                ]);
             }
         } catch (Exception $exception) {
             $this->_logException($exception);

--- a/library/CMService/XVerify/Client.php
+++ b/library/CMService/XVerify/Client.php
@@ -80,7 +80,7 @@ class CMService_XVerify_Client implements CM_Service_EmailVerification_ClientInt
                 503 => 'Invalid API Key/Service Not Active',
             );
             if (null === $responseCode || isset($responseCodeInvalidList[$responseCode])) {
-                throw new CM_Exception('Invalid XVerify email validation response', array(
+                throw new CM_Exception('Invalid XVerify email validation response', null, null, array(
                     'email'   => $email,
                     'code'    => $response->getStatusCode(),
                     'headers' => $response->getHeaders(),

--- a/library/CMService/XVerify/Client.php
+++ b/library/CMService/XVerify/Client.php
@@ -80,12 +80,12 @@ class CMService_XVerify_Client implements CM_Service_EmailVerification_ClientInt
                 503 => 'Invalid API Key/Service Not Active',
             );
             if (null === $responseCode || isset($responseCodeInvalidList[$responseCode])) {
-                throw new CM_Exception('Invalid XVerify email validation response', null, null, array(
+                throw new CM_Exception('Invalid XVerify email validation response', null, [
                     'email'   => $email,
                     'code'    => $response->getStatusCode(),
                     'headers' => $response->getHeaders(),
                     'body'    => (string) $response->getBody(),
-                ));
+                ]);
             }
         } catch (Exception $exception) {
             $this->_logException($exception);

--- a/tests/library/CM/ExceptionHandling/Handler/AbstractTest.php
+++ b/tests/library/CM/ExceptionHandling/Handler/AbstractTest.php
@@ -51,7 +51,7 @@ class CM_ExceptionHandling_Handler_AbstractTest extends CMTest_TestCase {
     public function testPrintException() {
         $errorException = new CM_Exception();
         $nativeException = new Exception();
-        $fatalException = new CM_Exception(null, null, CM_Exception::FATAL);
+        $fatalException = new CM_Exception(null, CM_Exception::FATAL);
 
         $exceptionHandler = $this->getMockBuilder('CM_ExceptionHandling_Handler_Abstract')
             ->setMethods(array('logException', '_printException'))->getMockForAbstractClass();
@@ -68,7 +68,7 @@ class CM_ExceptionHandling_Handler_AbstractTest extends CMTest_TestCase {
     public function testPrintExceptionPrintSeverity() {
         $errorException = new CM_Exception();
         $nativeException = new Exception();
-        $fatalException = new CM_Exception(null, null, CM_Exception::FATAL);
+        $fatalException = new CM_Exception(null, CM_Exception::FATAL);
 
         $exceptionHandler = $this->getMockBuilder('CM_ExceptionHandling_Handler_Abstract')
             ->setMethods(array('logException', '_printException'))->getMockForAbstractClass();

--- a/tests/library/CM/ExceptionHandling/Handler/AbstractTest.php
+++ b/tests/library/CM/ExceptionHandling/Handler/AbstractTest.php
@@ -51,7 +51,7 @@ class CM_ExceptionHandling_Handler_AbstractTest extends CMTest_TestCase {
     public function testPrintException() {
         $errorException = new CM_Exception();
         $nativeException = new Exception();
-        $fatalException = new CM_Exception(null, null, array('severity' => CM_Exception::FATAL));
+        $fatalException = new CM_Exception(null, null, CM_Exception::FATAL);
 
         $exceptionHandler = $this->getMockBuilder('CM_ExceptionHandling_Handler_Abstract')
             ->setMethods(array('logException', '_printException'))->getMockForAbstractClass();
@@ -68,7 +68,7 @@ class CM_ExceptionHandling_Handler_AbstractTest extends CMTest_TestCase {
     public function testPrintExceptionPrintSeverity() {
         $errorException = new CM_Exception();
         $nativeException = new Exception();
-        $fatalException = new CM_Exception(null, null, array('severity' => CM_Exception::FATAL));
+        $fatalException = new CM_Exception(null, null, CM_Exception::FATAL);
 
         $exceptionHandler = $this->getMockBuilder('CM_ExceptionHandling_Handler_Abstract')
             ->setMethods(array('logException', '_printException'))->getMockForAbstractClass();

--- a/tests/library/CM/ExceptionHandling/SerializableExceptionTest.php
+++ b/tests/library/CM/ExceptionHandling/SerializableExceptionTest.php
@@ -62,7 +62,7 @@ class CM_ExceptionHandling_SerializableExceptionTest extends CMTest_TestCase {
     }
 
     public function testGetters() {
-        $exception = new CM_Exception('Foo bar', ['foo' => new SplFixedArray(), 'bar' => [1, 2, 3]]);
+        $exception = new CM_Exception('Foo bar', null, null, ['foo' => new SplFixedArray(), 'bar' => [1, 2, 3]]);
         $serializableException = new CM_ExceptionHandling_SerializableException($exception);
         $this->assertSame('Foo bar', $serializableException->getMessage());
         $this->assertSame('CM_Exception', $serializableException->getClass());

--- a/tests/library/CM/ExceptionHandling/SerializableExceptionTest.php
+++ b/tests/library/CM/ExceptionHandling/SerializableExceptionTest.php
@@ -62,7 +62,7 @@ class CM_ExceptionHandling_SerializableExceptionTest extends CMTest_TestCase {
     }
 
     public function testGetters() {
-        $exception = new CM_Exception('Foo bar', null, null, ['foo' => new SplFixedArray(), 'bar' => [1, 2, 3]]);
+        $exception = new CM_Exception('Foo bar', null, ['foo' => new SplFixedArray(), 'bar' => [1, 2, 3]]);
         $serializableException = new CM_ExceptionHandling_SerializableException($exception);
         $this->assertSame('Foo bar', $serializableException->getMessage());
         $this->assertSame('CM_Exception', $serializableException->getClass());

--- a/tests/library/CM/ExceptionTest.php
+++ b/tests/library/CM/ExceptionTest.php
@@ -6,7 +6,7 @@ class CM_ExceptionTest extends CMTest_TestCase {
         $user = CMTest_TH::createUser();
         $metaInfo = array('meta' => 'foo', 'user' => $user);
         $severity = CM_Exception::ERROR;
-        $exception = new CM_Exception('foo', new CM_I18n_Phrase('foo {$bar}', ['bar' => 'foo']), $severity, $metaInfo);
+        $exception = new CM_Exception('foo', $severity, $metaInfo, new CM_I18n_Phrase('foo {$bar}', ['bar' => 'foo']));
         $render = new CM_Frontend_Render();
 
         $this->assertSame('foo', $exception->getMessage());

--- a/tests/library/CM/ExceptionTest.php
+++ b/tests/library/CM/ExceptionTest.php
@@ -15,25 +15,6 @@ class CM_ExceptionTest extends CMTest_TestCase {
         $this->assertSame('foo foo', $exception->getMessagePublic($render));
         $this->assertSame($severity, $exception->getSeverity());
         $this->assertSame($metaInfo, $exception->getMetaInfo());
-
-        $exception = $this->catchException(function () {
-            new CM_Exception(null, null, null, ['foo' => 'bar', 'bar' => 'qux']);
-        });
-        $this->assertInstanceOf('CM_Exception_InvalidParam', $exception);
-        $this->assertSame('$options parameter contains invalid key(s)', $exception->getMessage());
-
-        $exception = $this->catchException(function () {
-            new CM_Exception(null, null, null, ['foo' => 'bar']);
-        });
-        $this->assertInstanceOf('CM_Exception_InvalidParam', $exception);
-        $this->assertSame('Invalid key for $options: `foo`', $exception->getMessage());
-
-        $exception = $this->catchException(function () {
-            new CM_Exception(null, null, null, ['messagePublic' => array('333')]);
-        });
-
-        $this->assertInstanceOf('CM_Exception_InvalidParam', $exception);
-        $this->assertSame('Invalid type for key `messagePublic`', $exception->getMessage());
     }
 
     public function testGetSetSeverity() {

--- a/tests/library/CM/ExceptionTest.php
+++ b/tests/library/CM/ExceptionTest.php
@@ -6,7 +6,9 @@ class CM_ExceptionTest extends CMTest_TestCase {
         $user = CMTest_TH::createUser();
         $metaInfo = array('meta' => 'foo', 'user' => $user);
         $severity = CM_Exception::ERROR;
-        $exception = new CM_Exception('foo', $severity, $metaInfo, new CM_I18n_Phrase('foo {$bar}', ['bar' => 'foo']));
+        $exception = new CM_Exception('foo', $severity, $metaInfo, [
+            'messagePublic' => new CM_I18n_Phrase('foo {$bar}', ['bar' => 'foo']),
+        ]);
         $render = new CM_Frontend_Render();
 
         $this->assertSame('foo', $exception->getMessage());

--- a/tests/library/CM/ExceptionTest.php
+++ b/tests/library/CM/ExceptionTest.php
@@ -5,13 +5,13 @@ class CM_ExceptionTest extends CMTest_TestCase {
     public function testConstructor() {
         $user = CMTest_TH::createUser();
         $metaInfo = array('meta' => 'foo', 'user' => $user);
-        $options = array('messagePublic' => 'foo {$bar}', 'messagePublicVariables' => array('bar' => 'foo'), 'severity' => CM_Exception::ERROR);
-        $exception = new CM_Exception('foo', $metaInfo, $options);
+        $severity = CM_Exception::ERROR;
+        $exception = new CM_Exception('foo', new CM_I18n_Phrase('foo {$bar}', ['bar' => 'foo']), $severity, $metaInfo);
         $render = new CM_Frontend_Render();
 
         $this->assertSame('foo', $exception->getMessage());
         $this->assertSame('foo foo', $exception->getMessagePublic($render));
-        $this->assertSame(CM_Exception::ERROR, $exception->getSeverity());
+        $this->assertSame($severity, $exception->getSeverity());
         $this->assertSame($metaInfo, $exception->getMetaInfo());
     }
 

--- a/tests/library/CM/ExceptionTest.php
+++ b/tests/library/CM/ExceptionTest.php
@@ -15,6 +15,25 @@ class CM_ExceptionTest extends CMTest_TestCase {
         $this->assertSame('foo foo', $exception->getMessagePublic($render));
         $this->assertSame($severity, $exception->getSeverity());
         $this->assertSame($metaInfo, $exception->getMetaInfo());
+
+        $exception = $this->catchException(function () {
+            new CM_Exception(null, null, null, ['foo' => 'bar', 'bar' => 'qux']);
+        });
+        $this->assertInstanceOf('CM_Exception_InvalidParam', $exception);
+        $this->assertSame('$options parameter contains invalid key(s)', $exception->getMessage());
+
+        $exception = $this->catchException(function () {
+            new CM_Exception(null, null, null, ['foo' => 'bar']);
+        });
+        $this->assertInstanceOf('CM_Exception_InvalidParam', $exception);
+        $this->assertSame('Invalid key for $options: `foo`', $exception->getMessage());
+
+        $exception = $this->catchException(function () {
+            new CM_Exception(null, null, null, ['messagePublic' => array('333')]);
+        });
+
+        $this->assertInstanceOf('CM_Exception_InvalidParam', $exception);
+        $this->assertSame('Invalid type for key `messagePublic`', $exception->getMessage());
     }
 
     public function testGetSetSeverity() {

--- a/tests/library/CM/Http/Response/AbstractTest.php
+++ b/tests/library/CM/Http/Response/AbstractTest.php
@@ -96,7 +96,7 @@ class CM_Http_Response_AbstractTest extends CMTest_TestCase {
         try {
             CMTest_TH::callProtectedMethod($response, '_runWithCatching', [
                 function () {
-                    throw new CM_Exception_Nonexistent('foo', null, ['messagePublic' => 'bar']);
+                    throw new CM_Exception_Nonexistent('foo', new CM_I18n_Phrase('bar'));
                 }, $errorCode]);
             $this->fail('Caught public exception with public exception catching disabled');
         } catch (CM_Exception_Nonexistent $ex) {
@@ -123,7 +123,7 @@ class CM_Http_Response_AbstractTest extends CMTest_TestCase {
         try {
             $returnValue = CMTest_TH::callProtectedMethod($response, '_runWithCatching', [
                 function () {
-                    throw new CM_Exception_Nonexistent('foo', null, ['messagePublic' => 'bar']);
+                    throw new CM_Exception_Nonexistent('foo', new CM_I18n_Phrase('bar'));
                 }, $errorCode]);
             $this->assertNull($returnValue);
         } catch (CM_Exception_Nonexistent $ex) {

--- a/tests/library/CM/Http/Response/AbstractTest.php
+++ b/tests/library/CM/Http/Response/AbstractTest.php
@@ -96,7 +96,9 @@ class CM_Http_Response_AbstractTest extends CMTest_TestCase {
         try {
             CMTest_TH::callProtectedMethod($response, '_runWithCatching', [
                 function () {
-                    throw new CM_Exception_Nonexistent('foo', new CM_I18n_Phrase('bar'));
+                    throw new CM_Exception_Nonexistent('foo', null, null, [
+                        'messagePublic' => new CM_I18n_Phrase('bar'),
+                    ]);
                 }, $errorCode]);
             $this->fail('Caught public exception with public exception catching disabled');
         } catch (CM_Exception_Nonexistent $ex) {
@@ -123,7 +125,9 @@ class CM_Http_Response_AbstractTest extends CMTest_TestCase {
         try {
             $returnValue = CMTest_TH::callProtectedMethod($response, '_runWithCatching', [
                 function () {
-                    throw new CM_Exception_Nonexistent('foo', new CM_I18n_Phrase('bar'));
+                    throw new CM_Exception_Nonexistent('foo', null, null, [
+                        'messagePublic' => new CM_I18n_Phrase('bar'),
+                    ]);
                 }, $errorCode]);
             $this->assertNull($returnValue);
         } catch (CM_Exception_Nonexistent $ex) {

--- a/tests/library/CM/Http/Response/RPCTest.php
+++ b/tests/library/CM/Http/Response/RPCTest.php
@@ -28,7 +28,9 @@ class CM_Http_Response_RPCTest extends CMTest_TestCase {
         CM_Config::get()->CM_Http_Response_RPC->exceptionsToCatch = ['CM_Exception_Nonexistent' => []];
         $request = $this->mockObject('CM_Http_Request_Abstract', ['/rpc/' . CM_Site_Abstract::factory()->getType() . '/foo']);
         $request->mockMethod('getQuery')->set(function () {
-            throw new CM_Exception_Invalid('foo', new CM_I18n_Phrase('bar'));
+            throw new CM_Exception_Invalid('foo', null, null, [
+                'messagePublic' => new CM_I18n_Phrase('bar'),
+            ]);
         });
         /** @var CM_Http_Request_Abstract|\Mocka\AbstractClassTrait $request */
         $response = new CM_Http_Response_RPC($request, $this->getServiceManager());

--- a/tests/library/CM/Http/Response/RPCTest.php
+++ b/tests/library/CM/Http/Response/RPCTest.php
@@ -28,7 +28,7 @@ class CM_Http_Response_RPCTest extends CMTest_TestCase {
         CM_Config::get()->CM_Http_Response_RPC->exceptionsToCatch = ['CM_Exception_Nonexistent' => []];
         $request = $this->mockObject('CM_Http_Request_Abstract', ['/rpc/' . CM_Site_Abstract::factory()->getType() . '/foo']);
         $request->mockMethod('getQuery')->set(function () {
-            throw new CM_Exception_Invalid('foo', null, ['messagePublic' => 'bar']);
+            throw new CM_Exception_Invalid('foo', new CM_I18n_Phrase('bar'));
         });
         /** @var CM_Http_Request_Abstract|\Mocka\AbstractClassTrait $request */
         $response = new CM_Http_Response_RPC($request, $this->getServiceManager());

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -28,7 +28,9 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
         CM_Config::get()->CM_Http_Response_View_Abstract->exceptionsToCatch = ['CM_Exception_Nonexistent' => []];
         $response = $this->mockClass('CM_Http_Response_View_Abstract')->newInstanceWithoutConstructor();
         $response->mockMethod('_processView')->set(function () {
-            throw new CM_Exception_Invalid('foo', new CM_I18n_Phrase('bar'));
+            throw new CM_Exception_Invalid('foo', null, null, [
+                'messagePublic' => new CM_I18n_Phrase('bar'),
+            ]);
         });
         $response->mockMethod('getRender')->set(new CM_Frontend_Render());
         /** @var CM_Http_Response_View_Abstract $response */

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -28,13 +28,12 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
         CM_Config::get()->CM_Http_Response_View_Abstract->exceptionsToCatch = ['CM_Exception_Nonexistent' => []];
         $response = $this->mockClass('CM_Http_Response_View_Abstract')->newInstanceWithoutConstructor();
         $response->mockMethod('_processView')->set(function () {
-            throw new CM_Exception_Invalid('foo', null, ['messagePublic' => 'bar']);
+            throw new CM_Exception_Invalid('foo', new CM_I18n_Phrase('bar'));
         });
         $response->mockMethod('getRender')->set(new CM_Frontend_Render());
         /** @var CM_Http_Response_View_Abstract $response */
         CMTest_TH::callProtectedMethod($response, '_process');
         $this->assertViewResponseError($response, 'CM_Exception_Invalid', 'bar', true);
-
 
         $response->mockMethod('_processView')->set(function () {
             throw new CM_Exception_Nonexistent('foo');

--- a/tests/library/CM/I18n/PhraseTest.php
+++ b/tests/library/CM/I18n/PhraseTest.php
@@ -17,5 +17,19 @@ class CM_I18n_PhraseTest extends CMTest_TestCase {
 
         $i18n_phrase->translate($render);
         $this->assertSame(1, $getTranslationMethod->getCallCount());
+
+        $phrase = 'String without params';
+        $i18n_phrase = new CM_I18n_Phrase($phrase);
+        $this->assertInstanceOf('CM_I18n_Phrase', $i18n_phrase);
+
+        /** @var CM_Frontend_Render|\Mocka\AbstractClassTrait $render */
+        $render = $this->mockClass('CM_Frontend_Render')->newInstance();
+        $getTranslationMethod = $render->mockMethod('getTranslation')->set(function ($key, $params) use ($phrase) {
+            $this->assertSame($phrase, $key);
+            $this->assertSame([], $params);
+        });
+
+        $i18n_phrase->translate($render);
+        $this->assertSame(1, $getTranslationMethod->getCallCount());
     }
 }

--- a/tests/library/CMService/KickBox/ClientTest.php
+++ b/tests/library/CMService/KickBox/ClientTest.php
@@ -66,7 +66,7 @@ class CMService_KickBox_ClientTest extends CMTest_TestCase {
         $responseMock = new \Kickbox\HttpClient\Response(array('result' => 'unknown'), 403, array('header' => 'value'));
         $kickBoxMock = $this->getMock('CMService_KickBox_Client', array('_getResponse', '_logException'), array('', true, false, 0));
         $kickBoxMock->expects($this->once())->method('_getResponse')->will($this->returnValue($responseMock));
-        $exception = new CM_Exception('Invalid KickBox email validation response', array(
+        $exception = new CM_Exception('Invalid KickBox email validation response', null, null, array(
             'email'   => 'test@example.com',
             'code'    => 403,
             'headers' => array('header' => 'value'),

--- a/tests/library/CMService/KickBox/ClientTest.php
+++ b/tests/library/CMService/KickBox/ClientTest.php
@@ -66,12 +66,12 @@ class CMService_KickBox_ClientTest extends CMTest_TestCase {
         $responseMock = new \Kickbox\HttpClient\Response(array('result' => 'unknown'), 403, array('header' => 'value'));
         $kickBoxMock = $this->getMock('CMService_KickBox_Client', array('_getResponse', '_logException'), array('', true, false, 0));
         $kickBoxMock->expects($this->once())->method('_getResponse')->will($this->returnValue($responseMock));
-        $exception = new CM_Exception('Invalid KickBox email validation response', null, null, array(
+        $exception = new CM_Exception('Invalid KickBox email validation response', null, [
             'email'   => 'test@example.com',
             'code'    => 403,
             'headers' => array('header' => 'value'),
             'body'    => array('result' => 'unknown'),
-        ));
+        ]);
         $kickBoxMock->expects($this->once())->method('_logException')->with($exception);
         /** @var CMService_KickBox_Client $kickBoxMock */
         $kickBoxMock->isValid('test@example.com');

--- a/tests/library/CMService/XVerify/ClientTest.php
+++ b/tests/library/CMService/XVerify/ClientTest.php
@@ -11,12 +11,12 @@ class CMService_XVerify_ClientTest extends CMTest_TestCase {
 
     public function testEmptyResponse() {
         $responseBodyMock = '';
-        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', array(
+        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', null, null, [
             'email'   => 'testEmptyResponse@example.com',
             'code'    => '500',
             'headers' => array('Content-Length' => array(0), 'Content-Type' => array('application/json')),
             'body'    => '',
-        ));
+        ]);
         $headerList = array('Content-Length' => 0, 'Content-Type' => 'application/json');
         $xVerifyMock = $this->_getXVerifyMock($responseBodyMock, 500, $headerList, $exceptionExpected);
         $this->assertTrue($xVerifyMock->isValid('testEmptyResponse@example.com'));
@@ -24,36 +24,36 @@ class CMService_XVerify_ClientTest extends CMTest_TestCase {
 
     public function testInvalidResponse() {
         $responseBodyMock = '{"address":{"status":"invalid","responsecode":2}}';
-        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', array(
+        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', null, null, [
             'email'   => 'testInvalidResponse@example.com',
             'code'    => '200',
             'headers' => array(),
             'body'    => '{"address":{"status":"invalid","responsecode":2}}',
-        ));
+        ]);
         $xVerifyMock = $this->_getXVerifyMock($responseBodyMock, 200, array(), $exceptionExpected);
         $this->assertTrue($xVerifyMock->isValid('testInvalidResponse@example.com'));
     }
 
     public function testInvalidResponseCode() {
         $responseBodyMock = '{"email":{"status":"bad_request","responsecode":503}}';
-        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', array(
+        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', null, null, [
             'email'   => 'testInvalidResponseCode@example.com',
             'code'    => '200',
             'headers' => array(),
             'body'    => '{"email":{"status":"bad_request","responsecode":503}}',
-        ));
+        ]);
         $xVerifyMock = $this->_getXVerifyMock($responseBodyMock, 200, array(), $exceptionExpected);
         $this->assertTrue($xVerifyMock->isValid('testInvalidResponseCode@example.com'));
     }
 
     public function testMissingResponseCode() {
         $responseBodyMock = '{"email":{"status":"invalid"}}';
-        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', array(
+        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', null, null, [
             'email'   => 'testMissingResponseCode@example.com',
             'code'    => '200',
             'headers' => array(),
             'body'    => '{"email":{"status":"invalid"}}',
-        ));
+        ]);
         $xVerifyMock = $this->_getXVerifyMock($responseBodyMock, 200, array(), $exceptionExpected);
         $this->assertTrue($xVerifyMock->isValid('testMissingResponseCode@example.com'));
     }

--- a/tests/library/CMService/XVerify/ClientTest.php
+++ b/tests/library/CMService/XVerify/ClientTest.php
@@ -11,7 +11,7 @@ class CMService_XVerify_ClientTest extends CMTest_TestCase {
 
     public function testEmptyResponse() {
         $responseBodyMock = '';
-        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', null, null, [
+        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', null, [
             'email'   => 'testEmptyResponse@example.com',
             'code'    => '500',
             'headers' => array('Content-Length' => array(0), 'Content-Type' => array('application/json')),
@@ -24,7 +24,7 @@ class CMService_XVerify_ClientTest extends CMTest_TestCase {
 
     public function testInvalidResponse() {
         $responseBodyMock = '{"address":{"status":"invalid","responsecode":2}}';
-        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', null, null, [
+        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', null, [
             'email'   => 'testInvalidResponse@example.com',
             'code'    => '200',
             'headers' => array(),
@@ -36,7 +36,7 @@ class CMService_XVerify_ClientTest extends CMTest_TestCase {
 
     public function testInvalidResponseCode() {
         $responseBodyMock = '{"email":{"status":"bad_request","responsecode":503}}';
-        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', null, null, [
+        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', null, [
             'email'   => 'testInvalidResponseCode@example.com',
             'code'    => '200',
             'headers' => array(),
@@ -48,7 +48,7 @@ class CMService_XVerify_ClientTest extends CMTest_TestCase {
 
     public function testMissingResponseCode() {
         $responseBodyMock = '{"email":{"status":"invalid"}}';
-        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', null, null, [
+        $exceptionExpected = new CM_Exception('Invalid XVerify email validation response', null, [
             'email'   => 'testMissingResponseCode@example.com',
             'code'    => '200',
             'headers' => array(),


### PR DESCRIPTION
Current constructor of `CM_Exception`:
```php
    /**
     * @param string|null $message
     * @param array|null  $metaInfo
     * @param array|null  $options
     */
    public function __construct($message = null, array $metaInfo = null, array $options = null) {
        $this->_metaInfo = null !== $metaInfo ? $metaInfo : array();
        $this->_messagePublic = isset($options['messagePublic']) ? (string) $options['messagePublic'] : null;
        $this->_messagePublicVariables = isset($options['messagePublicVariables']) ? (array) $options['messagePublicVariables'] : null;
        if (isset($options['severity'])) {
            $this->setSeverity($options['severity']);
        }
        parent::__construct($message);
    }
```

Here we could now use `CM_I18n_Phrase` for `messagePublic` and `messagePublicVariables`. @fvovan wanna look into this when you have some time?

cc @tomaszdurka 