### PR TITLE
Reduce timeout for Kickbox email validation request

### DIFF
--- a/library/CMService/KickBox/Client.php
+++ b/library/CMService/KickBox/Client.php
@@ -67,7 +67,7 @@ class CMService_KickBox_Client implements CM_Service_EmailVerification_ClientInt
      * @throws Exception
      */
     protected function _getResponse($email) {
-        $kickBox = new \Kickbox\Client($this->_getCode());
+        $kickBox = new \Kickbox\Client($this->_getCode(), [\Guzzle\Http\Client::CURL_OPTIONS => [CURLOPT_TIMEOUT => 7]]);
         return $kickBox->kickbox()->verify($email);
     }
 


### PR DESCRIPTION
They were just down for 10mins:
```
RuntimeException: [curl] 28: Operation timed out after 150218 milliseconds with 0 out of 0 bytes received [url] https://api.kickbox.io/v1/verify?email=example%40gmail.com in /home/example/releases/20150722121906/vendor/kickbox/kickbox/lib/Kickbox/HttpClient/HttpClient.php on line 119
```

@fauvel how about setting this timeout to 0.5 seconds or so?

cc @kris-lab @ppp0 