### PR TITLE
Fix scrollShadow issue on iOS Safari

### DIFF
--- a/client-vendor/after-body/jquery.scrollShadow/jquery.scrollShadow.css
+++ b/client-vendor/after-body/jquery.scrollShadow/jquery.scrollShadow.css
@@ -4,7 +4,6 @@
 
 .scrollShadow {
   overflow: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 .scrollShadow::before, .scrollShadow::after {


### PR DESCRIPTION
Issue with `position: absolute;` and  `webkit-overflow-scrolling: touch;`
Demo, if you somebody wants to do a bug report. http://jsfiddle.net/vfz1t4tj/4/

