### PR TITLE
Kickbox timeout: Error severity II

### DIFF
--- a/library/CMService/KickBox/Client.php
+++ b/library/CMService/KickBox/Client.php
@@ -97,7 +97,7 @@ class CMService_KickBox_Client implements CM_Service_EmailVerification_ClientInt
      * @param Exception $exception
      */
     protected function _logException(Exception $exception) {
-        if ('RuntimeException' === get_class($exception) && false !== strpos($exception->getMessage(), 'Operation timed out')) {
+        if ('RuntimeException' === get_class($exception) && false !== strpos($exception->getMessage(), ' timed out ')) {
             $exception = new CM_Exception($exception->getMessage(), CM_Exception::WARN);
         }
         CM_Bootloader::getInstance()->getExceptionHandler()->logException($exception);

--- a/tests/library/CMService/KickBox/ClientTest.php
+++ b/tests/library/CMService/KickBox/ClientTest.php
@@ -79,25 +79,32 @@ class CMService_KickBox_ClientTest extends CMTest_TestCase {
 
     public function testLogExceptionTimeout() {
         $kickBoxMock = $this->mockObject('CMService_KickBox_Client', array('', true, false, 0));
-        $exceptionMessage = '[curl] 28: Operation timed out after 1595 milliseconds with 0 out of -1 bytes received [url] https://api.kickbox.io/v1/verify?email=testLogExceptionTimeout%40example.com';
-        $kickBoxMock->mockMethod('_getResponse')->set(function () use ($exceptionMessage) {
-            throw new RuntimeException($exceptionMessage);
-        });
         $exceptionHandlerMock = $this->mockObject('CM_ExceptionHandling_Handler_Cli');
-        $printException = $exceptionHandlerMock->mockMethod('logException')->set(function (Exception $exception) use ($exceptionMessage) {
-            $this->assertTrue($exception instanceof CM_Exception);
-            /** @var CM_Exception $exception */
-            $this->assertSame($exceptionMessage, $exception->getMessage());
-            $this->assertSame(CM_Exception::WARN, $exception->getSeverity());
-        });
+        $printException = $exceptionHandlerMock->mockMethod('logException');
         $exceptionHandler = CM_Bootloader::getInstance()->getExceptionHandler();
         /** @var CM_ExceptionHandling_Handler_Abstract $exceptionHandlerMock */
         CM_Bootloader::getInstance()->setExceptionHandler($exceptionHandlerMock);
+        $i = 0;
+        foreach ([
+                     '[curl] 28: Operation timed out after 1595 milliseconds with 0 out of -1 bytes received [url] https://api.kickbox.io/v1/verify?email=testLogExceptionTimeout%40example.com',
+                     '[curl] 6: name lookup timed out [url] https://api.kickbox.io/v1/verify?email=testLogExceptionTimeout%40example.com',
+                     '[curl] 28: Connection timed out after 7007 milliseconds [url] https://api.kickbox.io/v1/verify?email=testLogExceptionTimeout%40example.com',
+                 ] as $exceptionMessage) {
+            $kickBoxMock->mockMethod('_getResponse')->set(function () use ($exceptionMessage) {
+                throw new RuntimeException($exceptionMessage);
+            });
+            $printException->set(function (Exception $exception) use ($exceptionMessage) {
+                $this->assertTrue($exception instanceof CM_Exception);
+                /** @var CM_Exception $exception */
+                $this->assertSame($exceptionMessage, $exception->getMessage());
+                $this->assertSame(CM_Exception::WARN, $exception->getSeverity());
+            });
 
-        /** @var CMService_KickBox_Client $kickBoxMock */
-        $kickBoxMock->isValid('testLogExceptionTimeout@example.com');
+            /** @var CMService_KickBox_Client $kickBoxMock */
+            $kickBoxMock->isValid('testLogExceptionTimeout@example.com');
 
-        $this->assertSame(1, $printException->getCallCount());
+            $this->assertSame(++$i, $printException->getCallCount());
+        }
         CM_Bootloader::getInstance()->setExceptionHandler($exceptionHandler);
     }
 


### PR DESCRIPTION
Followup from https://github.com/cargomedia/cm/pull/1861

@fauvel I think it's released but doesn't seem to work, is it possible we're catching in the wrong place? Or am I missing something?

```
RuntimeException: [curl] 28: Connection timed out after 7007 milliseconds [url] https://api.kickbox.io/v1/verify?email=example%40yahoo.com in /home/example/releases/20150728135659/vendor/kickbox/kickbox/lib/Kickbox/HttpClient/HttpClient.php on line 119
     0. {main} /home/example/serve/public/index.php:0
     1. CM_Http_Handler->processRequest(CM_Http_Request_Post) /home/example/releases/20150728135659/public/index.php:8
     2. CM_Http_Response_Abstract->process() /home/example/releases/20150728135659/vendor/cargomedia/cm/library/CM/Http/Handler.php:26
     3. CM_Http_Response_View_Abstract->_process() /home/example/releases/20150728135659/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php:47
     4. CM_Http_Response_Abstract->_runWithCatching(Closure, Closure) /home/example/releases/20150728135659/vendor/cargomedia/cm/library/CM/Http/Response/View/Abstract.php:162
     5. CM_Http_Response_View_Abstract->{closure}() /home/example/releases/20150728135659/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php:249
     6. CM_Http_Response_View_Ajax->_processView([]) /home/example/releases/20150728135659/vendor/cargomedia/cm/library/CM/Http/Response/View/Abstract.php:159
     7. CM_FormField_Abstract->ajax_validate(['userInput' => 'example@yahoo.com', 'form' => 'SK_Form_SignUp', 'fieldName' => 'email'], CM_Frontend_JavascriptContainer_View, CM_Http_Response_View_Ajax) /home/example/releases/20150728135659/vendor/cargomedia/cm/library/CM/Http/Response/View/Ajax.php:29
     8. CM_FormField_Email->validate(CM_Frontend_Environment, 'example@yahoo.com') /home/example/releases/20150728135659/vendor/cargomedia/cm/library/CM/FormField/Abstract.php:95
     9. CMService_KickBox_Client->isValid('example@yahoo.com') /home/example/releases/20150728135659/vendor/cargomedia/cm/library/CM/FormField/Email.php:9
    10. CMService_KickBox_Client->_getResponseBody('example@yahoo.com') /home/example/releases/20150728135659/vendor/cargomedia/cm/library/CMService/KickBox/Client.php:38
    11. CMService_KickBox_Client->_getResponse('example@yahoo.com') /home/example/releases/20150728135659/vendor/cargomedia/cm/library/CMService/KickBox/Client.php:80
    12. Kickbox\Api\Kickbox->verify('example@yahoo.com') /home/example/releases/20150728135659/vendor/cargomedia/cm/library/CMService/KickBox/Client.php:71
    13. Kickbox\HttpClient\HttpClient->get('/verify?email=example....', [], []) /home/example/releases/20150728135659/vendor/kickbox/kickbox/lib/Kickbox/Api/Kickbox.php:31
    14. Kickbox\HttpClient\HttpClient->request('/verify?email=example....', NULL, 'GET', []) /home/example/releases/20150728135659/vendor/kickbox/kickbox/lib/Kickbox/HttpClient/HttpClient.php:60
```