### PR TITLE
Simplify procedure of running "online" update-scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~4.3.5",
-    "tomaszdurka/mocka": "~0.10.0"
+    "tomaszdurka/mocka": "~0.11.0"
   },
   "autoload": {
     "psr-0": {

--- a/library/CM/Db/Cli.php
+++ b/library/CM/Db/Cli.php
@@ -26,7 +26,7 @@ class CM_Db_Cli extends CM_Cli_Runnable_Abstract {
         $app = CM_App::getInstance();
         $output = $this->_getStreamOutput();
         $output->writeln('Running database updates…');
-        $app->runUpdateScripts(function ($version) use ($output) {
+        $app->runUpdateScripts(true, function ($version) use ($output) {
             $output->writeln('  Running update ' . $version . '…');
         });
     }
@@ -36,7 +36,7 @@ class CM_Db_Cli extends CM_Cli_Runnable_Abstract {
      * @param string|null $namespace
      */
     public function runUpdate($version, $namespace = null) {
-        $versionBumps = CM_App::getInstance()->runUpdateScript($namespace, $version);
+        $versionBumps = CM_App::getInstance()->runUpdateScript($namespace, $version, false);
         if ($versionBumps > 0) {
             $db = CM_Db_Db::getClient()->getDatabaseName();
             CM_Db_Db::exec('DROP DATABASE IF EXISTS `' . $db . '_test`');

--- a/library/CM/Provision/UpdateScript.php
+++ b/library/CM/Provision/UpdateScript.php
@@ -1,0 +1,30 @@
+<?php
+
+class CM_Provision_UpdateScript {
+
+    /** @var boolean */
+    private $_blocking;
+
+    /** @var callable */
+    private $_body;
+
+    /**
+     * @param callable     $body
+     * @param boolean|null $blocking
+     */
+    public function __construct(callable $body, $blocking = null) {
+        $this->_body = $body;
+        $this->_blocking = (boolean) $blocking;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isBlocking() {
+        return $this->_blocking;
+    }
+
+    public function run() {
+        call_user_func($this->_body);
+    }
+}

--- a/tests/library/CM/Provision/UpdateScriptTest.php
+++ b/tests/library/CM/Provision/UpdateScriptTest.php
@@ -1,0 +1,20 @@
+<?php
+
+class CM_Provision_UpdateScriptTest extends CMTest_TestCase {
+
+    public function testRun() {
+        $functionMock = new \Mocka\FunctionMock();
+        $updateScript = new CM_Provision_UpdateScript($functionMock);
+        $updateScript->run();
+        $this->assertSame(1, $functionMock->getCallCount());
+    }
+
+    public function testIsBlocking() {
+        $updateScript = new CM_Provision_UpdateScript(function() {});
+        $this->assertSame(false, $updateScript->isBlocking());
+        $updateScript = new CM_Provision_UpdateScript(function() {}, false);
+        $this->assertSame(false, $updateScript->isBlocking());
+        $updateScript = new CM_Provision_UpdateScript(function() {}, true);
+        $this->assertSame(true, $updateScript->isBlocking());
+    }
+}


### PR DESCRIPTION
The goal is to simplify app-deployment and subsequent running of "online-scripts".
Currently we add a `return;` statement to the beginning of update-scripts to skip them during deployment and manually edit and run the file on the server to run it.

New procedure is to return a `CM_Provision_UpdateScript` in the update-script with blocking set to true, which will cause the regular update-routine called with `bin/cm db run-udpates` to skip the script.
The script can then be run using `bin/dm db run-update <version>` after deployment has finished.

##### Example
```php
<?php

$script = new CM_Provision_UpdateScript(function () {
    echo "Running blocking updatescript\n";
}, true);

return $script;
```

please have a look @njam