### PR TITLE
Empty translation keys in admin

### DIFF
--- a/library/CM/Component/Example.php
+++ b/library/CM/Component/Example.php
@@ -42,9 +42,11 @@ class CM_Component_Example extends CM_Component_Abstract {
         if (!in_array($exception, array('CM_Exception', 'CM_Exception_AuthRequired'), true)) {
             $exception = 'CM_Exception';
         }
-        throw new $exception($message, null, null, [
-            'messagePublic' => new CM_I18n_Phrase($messagePublic)
-        ]);
+        $exceptionOptions = [];
+        if (null !== $messagePublic) {
+            $exceptionOptions['messagePublic'] = new CM_I18n_Phrase($messagePublic);
+        }
+        throw new $exception($message, null, null, $exceptionOptions);
     }
 
     public function ajax_ping(CM_Params $params, CM_Frontend_JavascriptContainer_View $handler, CM_Http_Response_View_Ajax $response) {

--- a/library/CM/I18n/Phrase.php
+++ b/library/CM/I18n/Phrase.php
@@ -11,12 +11,12 @@ class CM_I18n_Phrase {
     /**
      * @param string        $phrase
      * @param string[]|null $variables
-     * @throws CM_Exception_InvalidParam
+     * @throws CM_Exception_Invalid
      */
     public function __construct($phrase, array $variables = null) {
         $phrase = (string) $phrase;
-        if (empty($phrase)) {
-            throw new CM_Exception_InvalidParam('I18n phrase should not be empty');
+        if ('' === $phrase) {
+            throw new CM_Exception_Invalid('I18n phrase should not be empty');
         }
         $this->_phrase = $phrase;
         if (null === $variables) {

--- a/library/CM/I18n/Phrase.php
+++ b/library/CM/I18n/Phrase.php
@@ -11,9 +11,14 @@ class CM_I18n_Phrase {
     /**
      * @param string        $phrase
      * @param string[]|null $variables
+     * @throws CM_Exception_InvalidParam
      */
     public function __construct($phrase, array $variables = null) {
-        $this->_phrase = (string) $phrase;
+        $phrase = (string) $phrase;
+        if (empty($phrase)) {
+            throw new CM_Exception_InvalidParam('I18n phrase should not be empty');
+        }
+        $this->_phrase = $phrase;
         if (null === $variables) {
             $variables = [];
         }


### PR DESCRIPTION
Probably using CM_I18n_Prase in CM_Exceptions leads to adding empty translation keys to database table. Need to add additional checkings to its constructor