### PR TITLE
Set minimum-scale=1

### DIFF
--- a/layout/default/Layout/Abstract/default.tpl
+++ b/layout/default/Layout/Abstract/default.tpl
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge; requiresActiveX=true">
     {if isset($pageDescription)}<meta name="description" content="{$pageDescription|escape}">{/if}
     {if isset($pageKeywords)}<meta name="keywords" content="{$pageKeywords|escape}">{/if}
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-title" content="{$render->getSite()->getName()|escape}">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">


### PR DESCRIPTION
This will enable GPU rasterization in Chrome
See https://www.chromium.org/developers/design-documents/chromium-graphics/how-to-get-gpu-rasterization

@christopheschwyzer or @vogdb could you try how it affects the rendering behaviour of our feed page? I tried on a Samsung S6 and am not sure if it's really better..