### PR TITLE
CM_FormField_Site could have ambiguous labels

### DIFF
--- a/library/CM/FormField/Site.php
+++ b/library/CM/FormField/Site.php
@@ -5,7 +5,7 @@ class CM_FormField_Site extends CM_FormField_Set_Select {
     protected function _initialize() {
         $valuesSet = array();
         foreach (CM_Site_Abstract::getAll() as $site) {
-            $valuesSet[$site->getType()] = $site->getName();
+            $valuesSet[$site->getType()] = $site->getHost();
         }
         $this->_params->set('values', $valuesSet);
         $this->_params->set('labelsInValues', true);


### PR DESCRIPTION
In `CM_FormField_Site::_initialize()` we use `$site->getName()` to set labels for the options. It could happen that two sites could have the same name set in the configuration and this would lead to two options with the same label.

Would be good to use `$site->getHost()` instead.

/cc @njam @fvovan 