### PR TITLE
Fix scrollShadow issue on iOS Safari II

### DIFF
--- a/client-vendor/after-body/jquery.scrollShadow/jquery.scrollShadow.css
+++ b/client-vendor/after-body/jquery.scrollShadow/jquery.scrollShadow.css
@@ -4,6 +4,7 @@
 
 .scrollShadow {
   overflow: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .scrollShadow::before, .scrollShadow::after {

--- a/client-vendor/after-body/jquery.scrollShadow/jquery.scrollShadow.css
+++ b/client-vendor/after-body/jquery.scrollShadow/jquery.scrollShadow.css
@@ -7,7 +7,7 @@
   -webkit-overflow-scrolling: touch;
 }
 
-.scrollShadow::before, .scrollShadow::after {
+.scrollShadow:not(.noShadows)::before, .scrollShadow:not(.noShadows)::after {
   position: absolute;
   content: '';
   left: 0;
@@ -18,14 +18,14 @@
   opacity: 0;
 }
 
-.scrollShadow::before {
+.scrollShadow:not(.noShadows)::before {
   top: 0;
 }
 
-.scrollShadow::after {
+.scrollShadow:not(.noShadows)::after {
   bottom: 0;
 }
 
-.scrollShadow.notScrolledTop::before, .scrollShadow.notScrolledBottom::after {
+.scrollShadow:not(.noShadows).notScrolledTop::before, .scrollShadow:not(.noShadows).notScrolledBottom::after {
   opacity: 1;
 }

--- a/client-vendor/after-body/jquery.scrollShadow/jquery.scrollShadow.js
+++ b/client-vendor/after-body/jquery.scrollShadow/jquery.scrollShadow.js
@@ -25,11 +25,10 @@
         this.updateShadow();
         return;
       }
-      var self = this;
 
       var cssClass = 'scrollShadow';
 
-      if (this.iOS) {
+      if (iOS) {
         // Fix for iOS Safari: Absolute positioned elements in combination with -webkit-overflow-scrolling: touch; Demo: http://jsfiddle.net/vfz1t4tj/4/
         cssClass += ' noShadows';
       }
@@ -37,6 +36,7 @@
       this.$element.addClass(cssClass);
       this.$element.wrap('<div class="scrollShadow-wrapper"></div>');
 
+      var self = this;
       this.$element.on('scroll.scrollShadow', _.throttle(function() {
         self.updateShadow();
       }, 200));

--- a/client-vendor/after-body/jquery.scrollShadow/jquery.scrollShadow.js
+++ b/client-vendor/after-body/jquery.scrollShadow/jquery.scrollShadow.js
@@ -30,6 +30,7 @@
       var cssClass = 'scrollShadow';
 
       if (this.iOS) {
+        // Fix for iOS Safari: Absolute positioned elements in combination with -webkit-overflow-scrolling: touch; Demo: http://jsfiddle.net/vfz1t4tj/4/
         cssClass += ' noShadows';
       }
 

--- a/client-vendor/after-body/jquery.scrollShadow/jquery.scrollShadow.js
+++ b/client-vendor/after-body/jquery.scrollShadow/jquery.scrollShadow.js
@@ -8,6 +8,9 @@
    * @param {jQuery} $element
    * @constructor
    */
+
+  var iOS = !navigator.userAgent.match(/(iPad|iPhone|iPod)/i);
+
   var ScrollShadow = function($element) {
     this.$element = $element;
     this.initialized = false;
@@ -24,7 +27,13 @@
       }
       var self = this;
 
-      this.$element.addClass('scrollShadow');
+      var cssClass = 'scrollShadow';
+
+      if (this.iOS) {
+        cssClass += ' noShadows';
+      }
+
+      this.$element.addClass(cssClass);
       this.$element.wrap('<div class="scrollShadow-wrapper"></div>');
 
       this.$element.on('scroll.scrollShadow', _.throttle(function() {
@@ -39,7 +48,7 @@
       if (!this.initialized) {
         return;
       }
-      this.$element.unwrap().removeClass('scrollShadow');
+      this.$element.unwrap().removeClass('scrollShadow noShadows');
       this.$element.off('scroll.scrollShadow');
       this.initialized = false;
     },


### PR DESCRIPTION
follow up https://github.com/cargomedia/cm/pull/1868
As discussed, let's re-add `-webkit-overflow-scrolling: touch;` but hide the _shadows_ on iOS.

