### PR TITLE
Fix link parsing in CM_Usertext_Markdown

### DIFF
--- a/library/CM/Usertext/Markdown.php
+++ b/library/CM/Usertext/Markdown.php
@@ -49,7 +49,7 @@ class CM_Usertext_Markdown extends Michelf\MarkdownExtra {
 
     protected function _doAnchors_reference_callback($matches) {
         if (!$this->_skipAnchors) {
-            return parent::_doAnchors_inline_callback($matches);
+            return parent::_doAnchors_reference_callback($matches);
         }
         $link_text = $matches[2];
         return $link_text;


### PR DESCRIPTION
Incorrect link markdown causes errors à la `ErrorException: Noticed exception 'ErrorException' with message 'E_NOTICE: Undefined offset: 3'`
Caused by copy-paste error in _doAnchors_reference_callback() which called the wrong parent-method.

please review @tomaszdurka 
cc @njam 