### PR TITLE
Throw warning if ajax method is called that doesn't exist

### DIFF
--- a/library/CM/Http/Response/View/Ajax.php
+++ b/library/CM/Http/Response/View/Ajax.php
@@ -27,12 +27,10 @@ class CM_Http_Response_View_Ajax extends CM_Http_Response_View_Abstract {
 
         $this->_setStringRepresentation(get_class($view) . '::' . $ajaxMethodName);
 
-        if (method_exists($view, $ajaxMethodName)) {
-            $data = $view->$ajaxMethodName($params, $componentHandler, $this);
-        } else {
+        if (!method_exists($view, $ajaxMethodName)) {
             throw new CM_Exception_Invalid('Method not found: `' . $ajaxMethodName . '`', CM_Exception::WARN);
         }
-
+        $data = $view->$ajaxMethodName($params, $componentHandler, $this);
         $success['data'] = CM_Params::encode($data);
 
         $frontend = $this->getRender()->getGlobalResponse();

--- a/library/CM/Http/Response/View/Ajax.php
+++ b/library/CM/Http/Response/View/Ajax.php
@@ -26,7 +26,13 @@ class CM_Http_Response_View_Ajax extends CM_Http_Response_View_Abstract {
         $componentHandler = new CM_Frontend_JavascriptContainer_View();
 
         $this->_setStringRepresentation(get_class($view) . '::' . $ajaxMethodName);
-        $data = $view->$ajaxMethodName($params, $componentHandler, $this);
+
+        if (method_exists($view, $ajaxMethodName)) {
+            $data = $view->$ajaxMethodName($params, $componentHandler, $this);
+        } else {
+            throw new CM_Exception_Invalid('Method not found: `' . $ajaxMethodName . '`', CM_Exception::WARN);
+        }
+
         $success['data'] = CM_Params::encode($data);
 
         $frontend = $this->getRender()->getGlobalResponse();

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -191,19 +191,6 @@ EOL;
         $this->assertContains('new CM_Component_Graph', $successContent['data']['js']);
     }
 
-    public function testNonexistentAjaxMethodException() {
-        $page = new CM_Page_View_Ajax_Test_MockRedirectSelf();
-        $request = $this->createRequestAjax($page, 'someReallyBadMethod', ['params' => 'foo']);
-        $response = new CM_Http_Response_View_Ajax($request, $this->getServiceManager());
-
-        $exception = $this->catchException(function () use ($response) {
-            $response->process();
-        });
-
-        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
-        $this->assertSame('Method not found: `ajax_someReallyBadMethod`', $exception->getMessage());
-    }
-
     /**
      * @param string $code
      * @return CM_Service_Manager

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -191,6 +191,19 @@ EOL;
         $this->assertContains('new CM_Component_Graph', $successContent['data']['js']);
     }
 
+    public function testNonexistentAjaxMethodException() {
+        $page = new CM_Page_View_Ajax_Test_MockRedirectSelf();
+        $request = $this->createRequestAjax($page, 'someReallyBadMethod', ['params' => 'foo']);
+        $response = new CM_Http_Response_View_Ajax($request, $this->getServiceManager());
+
+        $exception = $this->catchException(function () use ($response) {
+            $response->process();
+        });
+
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertSame('Method not found: `ajax_someReallyBadMethod`', $exception->getMessage());
+    }
+
     /**
      * @param string $code
      * @return CM_Service_Manager

--- a/tests/library/CM/Http/Response/View/AjaxTest.php
+++ b/tests/library/CM/Http/Response/View/AjaxTest.php
@@ -2,10 +2,6 @@
 
 class CM_Http_Response_View_AjaxTest extends CMTest_TestCase {
 
-    public function tearDown() {
-        CMTest_TH::clearEnv();
-    }
-
     /**
      * @expectedException CM_Exception_Invalid
      * @expectedExceptionMessage Illegal method: `_ad_!!!##`

--- a/tests/library/CM/Http/Response/View/AjaxTest.php
+++ b/tests/library/CM/Http/Response/View/AjaxTest.php
@@ -7,8 +7,10 @@ class CM_Http_Response_View_AjaxTest extends CMTest_TestCase {
      * @expectedExceptionMessage Illegal method: `_ad_!!!##`
      */
     public function testSuspiciousMethodException() {
-        $page = new CM_Page_View_Ajax_Test_Mock_Ajax();
-        $request = $this->createRequestAjax($page, '_ad_!!!##', ['params' => 'foo']);
+        /** @var CM_View_Abstract|PHPUnit_Framework_MockObject_MockObject $view */
+        $view = $this->getMockForAbstractClass('CM_View_Abstract');
+
+        $request = $this->createRequestAjax($view, '_ad_!!!##', ['params' => 'foo']);
         $response = new CM_Http_Response_View_Ajax($request, $this->getServiceManager());
         $response->process();
     }
@@ -18,17 +20,11 @@ class CM_Http_Response_View_AjaxTest extends CMTest_TestCase {
      * @expectedExceptionMessage Method not found: `ajax_someReallyBadMethod`
      */
     public function testNonexistentAjaxMethodException() {
-        $page = new CM_Page_View_Ajax_Test_Mock_Ajax();
-        $request = $this->createRequestAjax($page, 'someReallyBadMethod', ['params' => 'foo']);
+        /** @var CM_View_Abstract|PHPUnit_Framework_MockObject_MockObject $view */
+        $view = $this->getMockForAbstractClass('CM_View_Abstract');
+
+        $request = $this->createRequestAjax($view, 'someReallyBadMethod', ['params' => 'foo']);
         $response = new CM_Http_Response_View_Ajax($request, $this->getServiceManager());
         $response->process();
     }
 }
-
-class CM_Page_View_Ajax_Test_Mock_Ajax extends CM_Page_Abstract {
-
-    public function getLayout(CM_Frontend_Environment $environment, $layoutName = null) {
-        return new CM_Layout_Mock1();
-    }
-}
-

--- a/tests/library/CM/Http/Response/View/AjaxTest.php
+++ b/tests/library/CM/Http/Response/View/AjaxTest.php
@@ -1,0 +1,38 @@
+<?php
+
+class CM_Http_Response_View_AjaxTest extends CMTest_TestCase {
+
+    public function tearDown() {
+        CMTest_TH::clearEnv();
+    }
+
+    /**
+     * @expectedException CM_Exception_Invalid
+     * @expectedExceptionMessage Illegal method: `_ad_!!!##`
+     */
+    public function testSuspiciousMethodException() {
+        $page = new CM_Page_View_Ajax_Test_Mock_Ajax();
+        $request = $this->createRequestAjax($page, '_ad_!!!##', ['params' => 'foo']);
+        $response = new CM_Http_Response_View_Ajax($request, $this->getServiceManager());
+        $response->process();
+    }
+
+    /**
+     * @expectedException CM_Exception_Invalid
+     * @expectedExceptionMessage Method not found: `ajax_someReallyBadMethod`
+     */
+    public function testNonexistentAjaxMethodException() {
+        $page = new CM_Page_View_Ajax_Test_Mock_Ajax();
+        $request = $this->createRequestAjax($page, 'someReallyBadMethod', ['params' => 'foo']);
+        $response = new CM_Http_Response_View_Ajax($request, $this->getServiceManager());
+        $response->process();
+    }
+}
+
+class CM_Page_View_Ajax_Test_Mock_Ajax extends CM_Page_Abstract {
+
+    public function getLayout(CM_Frontend_Environment $environment, $layoutName = null) {
+        return new CM_Layout_Mock1();
+    }
+}
+


### PR DESCRIPTION
Handled in `CM_Http_Response_View_Ajax`.
Currently fails with:
```
ErrorException: E_ERROR: Call to undefined method SK_Component_Chat::ajax_getChatDataList() in /home/example/releases/20150908135405/vendor/cargomedia/cm/library/CM/Http/Response/View/Ajax.php on line 29 
```

Instead I suggest we check if the method exists, and otherwise throw a warning, because this is user input and we have no control over it.

@fvovan could you look into this?