### PR TITLE
Remove background color of contentPlaceholder.

### DIFF
--- a/client-vendor/after-body/jquery.contentPlaceholder/jquery.contentPlaceholder.js
+++ b/client-vendor/after-body/jquery.contentPlaceholder/jquery.contentPlaceholder.js
@@ -15,9 +15,7 @@
         failure_limit: 10
       });
       var self = this;
-      $(this).imagesLoaded(function() {
-        self.classList.add('loaded');
-      }).find('img.lazy').lazyload(options);
+      $(this).find('img.lazy').lazyload(options);
     });
   };
 

--- a/layout/default/css/contentPlaceholder.less
+++ b/layout/default/css/contentPlaceholder.less
@@ -15,13 +15,6 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: @colorBgBody;
-  }
-
-  &.loaded {
-    .contentPlaceholder-size + * {
-      background-color: inherit;
-    }
   }
 
   &.stretch {


### PR DESCRIPTION
I changed image lazyload library from [Unveil](https://github.com/luis-almeida/unveil) to [Lazyload](https://github.com/tuupola/jquery_lazyload). Lazyload shows grey previews instead of real images by default and this behaviour can't be configured. So, I propose to remove the same functionality that is currently implemented by us. I mean:
```less
  .contentPlaceholder-size + * {
    ...
    background-color: @colorBgBody;
  }
```

@christopheschwyzer @njam ?