### PR TITLE
Pass the last runtime to clockwork callbacks

### DIFF
--- a/library/CM/Clockwork/Event.php
+++ b/library/CM/Clockwork/Event.php
@@ -49,7 +49,7 @@ class CM_Clockwork_Event {
     /**
      * @param DateTime|null  $lastRuntime
      */
-    public function run($lastRuntime) {
+    public function run(DateTime $lastRuntime=null) {
         foreach ($this->_callbacks as $callback) {
             call_user_func($callback, $lastRuntime);
         }

--- a/library/CM/Clockwork/Event.php
+++ b/library/CM/Clockwork/Event.php
@@ -47,9 +47,9 @@ class CM_Clockwork_Event {
     }
 
     /**
-     * @param DateTime|null  $lastRuntime
+     * @param DateTime|null $lastRuntime
      */
-    public function run(DateTime $lastRuntime=null) {
+    public function run(DateTime $lastRuntime = null) {
         foreach ($this->_callbacks as $callback) {
             call_user_func($callback, $lastRuntime);
         }

--- a/library/CM/Clockwork/Event.php
+++ b/library/CM/Clockwork/Event.php
@@ -46,9 +46,12 @@ class CM_Clockwork_Event {
         $this->_callbacks[] = $callback;
     }
 
-    public function run() {
+    /**
+     * @param DateTime|null  $lastRuntime
+     */
+    public function run($lastRuntime) {
         foreach ($this->_callbacks as $callback) {
-            call_user_func($callback);
+            call_user_func($callback, $lastRuntime);
         }
     }
 

--- a/library/CM/Clockwork/Manager.php
+++ b/library/CM/Clockwork/Manager.php
@@ -65,7 +65,6 @@ class CM_Clockwork_Manager {
         foreach ($resultList as $identifier => $result) {
             $event = $this->_getRunningEvent($identifier);
             $this->_markStopped($event);
-            $this->_storage->setRuntime($event, $this->_getCurrentDateTime());
         }
     }
 
@@ -195,6 +194,7 @@ class CM_Clockwork_Manager {
     protected function _runEvent(CM_Clockwork_Event $event) {
         $process = $this->_getProcess();
         $lastRuntime = $this->_storage->getLastRuntime($event);
+        $this->_storage->setRuntime($event, $this->_getCurrentDateTime());
         $forkHandler = $process->fork(function () use ($event, $lastRuntime) {
             $event->run($lastRuntime);
         });

--- a/library/CM/Clockwork/Manager.php
+++ b/library/CM/Clockwork/Manager.php
@@ -133,6 +133,7 @@ class CM_Clockwork_Manager {
 
     /**
      * @return DateTime
+     * @return DateTime
      */
     protected function _getCurrentDateTime() {
         return $this->_getCurrentDateTimeUTC()->setTimezone($this->_timeZone);
@@ -193,8 +194,9 @@ class CM_Clockwork_Manager {
      */
     protected function _runEvent(CM_Clockwork_Event $event) {
         $process = $this->_getProcess();
-        $forkHandler = $process->fork(function () use ($event) {
-            $event->run();
+        $lastRuntime = $this->_storage->getLastRuntime($event);
+        $forkHandler = $process->fork(function () use ($event, $lastRuntime) {
+            $event->run($lastRuntime);
         });
         $this->_markRunning($event, $forkHandler->getIdentifier());
     }

--- a/tests/library/CM/Clockwork/ManagerTest.php
+++ b/tests/library/CM/Clockwork/ManagerTest.php
@@ -42,7 +42,7 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
 
         $lastRuntimeActual = null;
         $callbackCallCount = 0;
-        $event->registerCallback(function($lastRuntime) use (&$lastRuntimeActual, &$callbackCallCount) {
+        $event->registerCallback(function ($lastRuntime) use (&$lastRuntimeActual, &$callbackCallCount) {
             $lastRuntimeActual = $lastRuntime;
             $callbackCallCount++;
         });
@@ -59,7 +59,7 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $this->assertSame(2, $callbackCallCount);
         $this->assertSameTime($expectedLastRuntime, $lastRuntimeActual);
 
-        $event->registerCallback(function() use (&$secondCallbackCallCount) {
+        $event->registerCallback(function () use (&$secondCallbackCallCount) {
             $secondCallbackCallCount++;
         });
         $expectedLastRuntime = clone $currently;

--- a/tests/library/CM/Clockwork/ManagerTest.php
+++ b/tests/library/CM/Clockwork/ManagerTest.php
@@ -14,6 +14,63 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         }
     }
 
+    public function testRegisterEventCallbackWithLastRuntime() {
+        $process = $this->mockClass('CM_Process')->newInstanceWithoutConstructor();
+        $forkMock = $process->mockMethod('fork');
+        $forkMock->set(function ($callback) use ($forkMock) {
+            $callback();
+            $forkHandler = $this->mockClass('CM_Process_ForkHandler')->newInstanceWithoutConstructor();
+            $forkHandler->mockMethod('getIdentifier')->set($forkMock->getCallCount());
+            return $forkHandler;
+        });
+
+        /** @var CM_Clockwork_Storage_Abstract $storage */
+        $storage = new CM_Clockwork_Storage_Memory();
+        $currently = new DateTime('midnight', new DateTimeZone('UTC'));
+
+        /** @var CM_Clockwork_Manager $manager */
+        $manager = $this->mockObject('CM_Clockwork_Manager');
+        $manager->mockMethod('_shouldRun')->set(true);
+        $manager->mockMethod('_getProcess')->set($process);
+        $manager->mockMethod('_getCurrentDateTimeUTC')->set(function () use (&$currently) {
+            return $currently;
+        });
+        $manager->setStorage($storage);
+
+        $event = new CM_Clockwork_Event('bar', '1 second');
+        $manager->registerEvent($event);
+
+        $lastRuntimeActual = null;
+        $callbackCallCount = 0;
+        $event->registerCallback(function($lastRuntime) use (&$lastRuntimeActual, &$callbackCallCount) {
+            $lastRuntimeActual = $lastRuntime;
+            $callbackCallCount++;
+        });
+
+        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_WorkloadResult()]);
+        $manager->runEvents();
+        $this->assertSame(1, $callbackCallCount);
+        $this->assertNull($lastRuntimeActual);
+
+        $expectedLastRuntime = clone $currently;
+        $currently->modify('10 seconds');
+        $process->mockMethod('listenForChildren')->set([2 => new CM_Process_WorkloadResult()]);
+        $manager->runEvents();
+        $this->assertSame(2, $callbackCallCount);
+        $this->assertSameTime($expectedLastRuntime, $lastRuntimeActual);
+
+        $event->registerCallback(function() use (&$secondCallbackCallCount) {
+            $secondCallbackCallCount++;
+        });
+        $expectedLastRuntime = clone $currently;
+        $secondCallbackCallCount = 0;
+        $process->mockMethod('listenForChildren')->set([3 => new CM_Process_WorkloadResult()]);
+        $manager->runEvents();
+        $this->assertSame(1, $secondCallbackCallCount);
+        $this->assertSame(3, $callbackCallCount);
+        $this->assertSameTime($expectedLastRuntime, $lastRuntimeActual);
+    }
+
     public function testRunNonBlocking() {
         $process = $this->mockClass('CM_Process')->newInstanceWithoutConstructor();
         $forkMock = $process->mockMethod('fork');


### PR DESCRIPTION
A nice feature could be to have the last execution time passed to clockwork callbacks, some procedure may require it to do periodical processing since the last execution.

If the callback has never been called, we can simply set the argument as `null`.