### PR TITLE
Update supported browsers

### DIFF
--- a/library/CM/Http/Request/Abstract.php
+++ b/library/CM/Http/Request/Abstract.php
@@ -450,7 +450,7 @@ abstract class CM_Http_Request_Abstract {
         if (preg_match('#Opera Mini#', $userAgent)) {
             return false;
         }
-        if (preg_match('#MSIE (?<version>[\d\.]{1,6})#', $userAgent, $matches) && $matches['version'] < 10) {
+        if (preg_match('#MSIE (?<version>[\d\.]{1,6})#', $userAgent, $matches) && $matches['version'] < 11) {
             return false;
         }
         if (preg_match('#Android (?<version>[\d\.]{1,6})#', $userAgent, $matches) && $matches['version'] < 4) {

--- a/tests/library/CM/Http/Request/AbstractTest.php
+++ b/tests/library/CM/Http/Request/AbstractTest.php
@@ -222,7 +222,7 @@ class CM_Http_Request_AbstractTest extends CMTest_TestCase {
             'MSIE 6.0'                                            => false,
             'MSIE 9.0'                                            => false,
             'MSIE 9.1'                                            => false,
-            'MSIE 10.0'                                           => true,
+            'MSIE 10.0'                                           => false,
             'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0)'  => true,
             'Mozilla/5.0 (Linux; U; Android 2.3.3; zh-tw; HTC)'   => false,
             'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus)'    => true,

--- a/tests/library/CM/Http/Request/AbstractTest.php
+++ b/tests/library/CM/Http/Request/AbstractTest.php
@@ -223,6 +223,7 @@ class CM_Http_Request_AbstractTest extends CMTest_TestCase {
             'MSIE 9.0'                                            => false,
             'MSIE 9.1'                                            => false,
             'MSIE 10.0'                                           => false,
+            'Edge'                                                => true,
             'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0)'  => true,
             'Mozilla/5.0 (Linux; U; Android 2.3.3; zh-tw; HTC)'   => false,
             'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus)'    => true,


### PR DESCRIPTION
### Mobile

Chrome (Android): 45+
Safari (iOS 8+): *
Android Browser (Android 4.0+): 4.0
IE (Windows Phone 8+): 10+
#### unsupported:

Chrome (Android): 44
Safari (iOS 7): *
Android Browser (Android 3.x): 3.x
IE (Windows Phone 7): 9
UC Browser
BlackBerry
Opera
Opera Mini
YE
Amazon Silk

### Desktop

Chrome: 45+
Firefox: 40+
Internet Explorer: 11+
Safari: 8+