### PR TITLE
Breaking: Switch from phpredis client to predis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "kissmetrics/kissmetrics-php": "~0.1.0",
     "guzzlehttp/guzzle": "~4.1.7",
     "kickbox/kickbox": "~1.0.3",
-    "tomaszdurka/codegenerator": "~0.5.0"
+    "tomaszdurka/codegenerator": "~0.5.0",
+    "predis/predis": "~1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.3.5",

--- a/library/CM/Redis/Client.php
+++ b/library/CM/Redis/Client.php
@@ -261,31 +261,34 @@ class CM_Redis_Client extends CM_Class_Abstract {
     /**
      * @param string $channel
      * @param string $msg
+     * @return int
      */
     public function publish($channel, $msg) {
-        $this->_redis->publish($channel, $msg);
+        return $this->_redis->publish($channel, $msg);
     }
 
     /**
      * @param string|string[] $channels
      * @param Closure         $callback
+     * @return mixed
      */
     public function subscribe($channels, Closure $callback) {
         $channels = (array) $channels;
         $this->_subscribeCallback = $callback;
         $this->_redis->setOption(Redis::OPT_READ_TIMEOUT, 86400 * 100);
-        $this->_redis->subscribe($channels, array($this, '_subscribeCallback'));
+        return $this->_redis->subscribe($channels, array($this, '_subscribeCallback'));
     }
 
     /**
      * @param Redis  $redis
      * @param string $channel
      * @param string $message
+     * @return mixed
      */
     public function _subscribeCallback($redis, $channel, $message) {
         try {
             $callback = $this->_subscribeCallback;
-            $callback($channel, $message);
+            return $callback($channel, $message);
         } catch (Exception $e) {
             CM_Bootloader::getInstance()->getExceptionHandler()->handleException($e);
         }

--- a/library/CM/Redis/Client.php
+++ b/library/CM/Redis/Client.php
@@ -21,9 +21,11 @@ class CM_Redis_Client extends CM_Class_Abstract {
 
         try {
             $this->_redis = new Predis\Client([
-                'scheme' => 'tcp',
-                'host'   => $host,
-                'port'   => $port,
+                'scheme'             => 'tcp',
+                'host'               => $host,
+                'port'               => $port,
+                'read_write_timeout' => -1,
+                'timeout'            => 60,
             ], ['profile' => '2.4']);
         } catch (Predis\Connection\ConnectionException $e) {
             throw new CM_Exception('Cannot connect to redis server `' . $host . '` on port `' . $port . '`: ' . $e->getMessage());

--- a/library/CM/Redis/Client.php
+++ b/library/CM/Redis/Client.php
@@ -115,11 +115,7 @@ class CM_Redis_Client extends CM_Class_Abstract {
      * @return string|null
      */
     public function rPop($key) {
-        $result = $this->_redis->rPop($key);
-        if (false === $result) {
-            $result = null;
-        }
-        return $result;
+        return $this->_redis->rPop($key);
     }
 
     /**
@@ -178,6 +174,22 @@ class CM_Redis_Client extends CM_Class_Abstract {
     }
 
     /**
+     * @param string $key
+     * @param string $value
+     */
+    public function zRem($key, $value) {
+        $this->_redis->zRem($key, $value);
+    }
+
+    /**
+     * @param string $key
+     * @return int
+     */
+    public function zCard($key) {
+        return $this->_redis->zCard($key);
+    }
+
+    /**
      * @param string       $key
      * @param string       $start
      * @param string       $end
@@ -197,14 +209,6 @@ class CM_Redis_Client extends CM_Class_Abstract {
             $options['withscores'] = true;
         }
         return $this->_redis->zRangeByScore($key, $start, $end, $options);
-    }
-
-    /**
-     * @param string $key
-     * @param string $value
-     */
-    public function zRem($key, $value) {
-        $this->_redis->zRem($key, $value);
     }
 
     /**
@@ -270,13 +274,10 @@ class CM_Redis_Client extends CM_Class_Abstract {
      * @return string[]
      */
     public function sFlush($key) {
-        $members = $this->_redis->sMembers($key);
         $this->_redis->multi();
-        foreach ($members as $value) {
-            $this->_redis->sRem($key, $value);
-        }
-        $this->_redis->exec();
-        return $members;
+        $this->_redis->sMembers($key);
+        $this->_redis->del($key);
+        return $this->_redis->exec()[0];
     }
 
     /**
@@ -291,7 +292,7 @@ class CM_Redis_Client extends CM_Class_Abstract {
     /**
      * @param string|string[] $channels
      * @param Closure         $callback
-     * @return mixed
+     * @return mixed return something else than null to exit the pubsub loop
      */
     public function subscribe($channels, Closure $callback) {
         $pubsub = $this->_redis->pubSubLoop(['subscribe' => $channels]);

--- a/tests/library/CM/Redis/ClientTest.php
+++ b/tests/library/CM/Redis/ClientTest.php
@@ -7,7 +7,6 @@ class CM_Redis_ClientTest extends CMTest_TestCase {
 
     public function setUp() {
         $this->_client = CM_Service_Manager::getInstance()->getRedis();
-        $this->_client->flush();
     }
 
     public function tearDown() {
@@ -143,6 +142,10 @@ class CM_Redis_ClientTest extends CMTest_TestCase {
         $this->assertSame(0, $this->_client->sCard('foo'));
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testPubSub() {
 
         $process = CM_Process::getInstance();


### PR DESCRIPTION
To avoid having more problems with https://github.com/phpredis/phpredis, we decided to switch to an alternative Redis client, https://github.com/nrk/predis.

The task is related to https://github.com/cargomedia/cm/issues/1920.

Note: the merge request is marked as "Breaking" even if our Redis client API has not changed, but we may have some issues because all cases are probably not well tested. 