### PR TITLE
CM_MenuItem::compare() fails when comparing scalars with arrays

### DIFF
--- a/library/CM/MenuEntry.php
+++ b/library/CM/MenuEntry.php
@@ -51,6 +51,8 @@ class CM_MenuEntry {
             $paramsMatch = array_uintersect_assoc($this->getParams(), $params, function ($a, $b) {
                     if (is_array($a) && is_array($b)) {
                         return (array_diff_assoc($a, $b) === array_diff_assoc($b, $a)) ? 0 : -1;
+                    } elseif (is_array($a) || is_array($b)) {
+                        return -1;
                     }
                     return ((string) $a === (string) $b) ? 0 : -1;
                 }) == $this->getParams();

--- a/library/CM/MenuEntry.php
+++ b/library/CM/MenuEntry.php
@@ -49,7 +49,10 @@ class CM_MenuEntry {
         $pathMatch = $path == $pageClassName::getPath();
         if ($pathMatch) {
             $paramsMatch = array_uintersect_assoc($this->getParams(), $params, function ($a, $b) {
-                    return $a != $b ? -1 : 0;
+                    if (is_array($a) && is_array($b)) {
+                        return (array_diff_assoc($a, $b) === array_diff_assoc($b, $a)) ? 0 : -1;
+                    }
+                    return ((string) $a === (string) $b) ? 0 : -1;
                 }) == $this->getParams();
             return $paramsMatch;
         }

--- a/library/CM/MenuEntry.php
+++ b/library/CM/MenuEntry.php
@@ -46,8 +46,12 @@ class CM_MenuEntry {
     public final function compare($path, array $params = array()) {
         /** @var CM_Page_Abstract $pageClassName */
         $pageClassName = $this->getPageName();
-        if ($path == $pageClassName::getPath() && array_intersect_assoc($this->getParams(), $params) == $this->getParams()) {
-            return true;
+        $pathMatch = $path == $pageClassName::getPath();
+        if ($pathMatch) {
+            $paramsMatch = array_uintersect_assoc($this->getParams(), $params, function ($a, $b) {
+                    return $a != $b ? -1 : 0;
+                }) == $this->getParams();
+            return $paramsMatch;
         }
         return false;
     }

--- a/tests/library/CM/MenuEntryTest.php
+++ b/tests/library/CM/MenuEntryTest.php
@@ -34,12 +34,14 @@ class CM_MenuEntryTest extends CMTest_TestCase {
         $this->assertFalse($entry->compare('/mock', ['param1' => ['foo' => 'baz', 'bar' => 'foo']]));
         $this->assertFalse($entry->compare('/mock', ['param1' => ['foo' => 'bar', 'bar' => 'foo']]));
         $this->assertFalse($entry->compare('/mock', ['param1' => ['foo' => 'bar']]));
+        $this->assertFalse($entry->compare('/mock', ['param1' => 'foo']));
 
         // array-param numeric
         $entry = new CM_MenuEntry(['label' => $label, 'page' => $pageName, 'params' => ['param1' => ['foo', 'bar']]], $menu);
         $this->assertFalse($entry->compare('/mock'));
         $this->assertTrue($entry->compare('/mock', ['param1' => ['foo', 'bar']]));
         $this->assertFalse($entry->compare('/mock', ['param1' => ['bar', 'foo']]));
+        $this->assertFalse($entry->compare('/mock', ['param1' => 'foo']));
 
         // strict/nonstrict comparison
         $params = ['param1' => ''];

--- a/tests/library/CM/MenuEntryTest.php
+++ b/tests/library/CM/MenuEntryTest.php
@@ -2,6 +2,28 @@
 
 class CM_MenuEntryTest extends CMTest_TestCase {
 
+    public function testCompare() {
+        $pageName = 'CM_Page_Mock';
+        $label = 'helloworld';
+        $menu = $this->_getMenu();
+
+        $entry = new CM_MenuEntry(['label' => $label, 'page' => $pageName], $menu);
+        $this->assertTrue($entry->compare('/mock'));
+        $this->assertFalse($entry->compare('/foo'));
+        $this->assertTrue($entry->compare('/mock', ['param1' => 'foo']));
+
+        $entry = new CM_MenuEntry(['label' => $label, 'page' => $pageName, 'params' => ['param1' => 'foo']], $menu);
+        $this->assertTrue($entry->compare('/mock', ['param1' => 'foo']));
+        $this->assertFalse($entry->compare('/mock'));
+        $this->assertFalse($entry->compare('/mock', ['param2' => 'foo']));
+        $this->assertTrue($entry->compare('/mock', ['param2' => 'bar', 'param1' => 'foo']));
+
+        $entry = new CM_MenuEntry(['label' => $label, 'page' => $pageName, 'params' => ['param1' => 'foo', 'param2' => 'bar']], $menu);
+        $this->assertFalse($entry->compare('/mock', ['param1' => 'foo']));
+        $this->assertFalse($entry->compare('/mock', ['param2' => 'bar']));
+        $this->assertTrue($entry->compare('/mock', ['param2' => 'bar', 'param1' => 'foo']));
+    }
+
     public function testGetters() {
         $pageName = 'CM_Page_Mock';
         $label = 'helloworld';

--- a/tests/library/CM/MenuEntryTest.php
+++ b/tests/library/CM/MenuEntryTest.php
@@ -7,22 +7,26 @@ class CM_MenuEntryTest extends CMTest_TestCase {
         $label = 'helloworld';
         $menu = $this->_getMenu();
 
+        // no param
         $entry = new CM_MenuEntry(['label' => $label, 'page' => $pageName], $menu);
         $this->assertTrue($entry->compare('/mock'));
         $this->assertFalse($entry->compare('/foo'));
         $this->assertTrue($entry->compare('/mock', ['param1' => 'foo']));
 
+        // one param
         $entry = new CM_MenuEntry(['label' => $label, 'page' => $pageName, 'params' => ['param1' => 'foo']], $menu);
         $this->assertFalse($entry->compare('/mock'));
         $this->assertTrue($entry->compare('/mock', ['param1' => 'foo']));
         $this->assertFalse($entry->compare('/mock', ['param2' => 'foo']));
         $this->assertTrue($entry->compare('/mock', ['param2' => 'bar', 'param1' => 'foo']));
 
+        // two params
         $entry = new CM_MenuEntry(['label' => $label, 'page' => $pageName, 'params' => ['param1' => 'foo', 'param2' => 'bar']], $menu);
         $this->assertFalse($entry->compare('/mock', ['param1' => 'foo']));
         $this->assertFalse($entry->compare('/mock', ['param2' => 'bar']));
         $this->assertTrue($entry->compare('/mock', ['param2' => 'bar', 'param1' => 'foo']));
 
+        // array-param associative
         $entry = new CM_MenuEntry(['label' => $label, 'page' => $pageName, 'params' => ['param1' => ['foo' => 'bar', 'bar' => 'baz']]], $menu);
         $this->assertTrue($entry->compare('/mock', ['param1' => ['foo' => 'bar', 'bar' => 'baz']]));
         $this->assertTrue($entry->compare('/mock', ['param1' => ['bar' => 'baz', 'foo' => 'bar']]));
@@ -31,10 +35,23 @@ class CM_MenuEntryTest extends CMTest_TestCase {
         $this->assertFalse($entry->compare('/mock', ['param1' => ['foo' => 'bar', 'bar' => 'foo']]));
         $this->assertFalse($entry->compare('/mock', ['param1' => ['foo' => 'bar']]));
 
+        // array-param numeric
         $entry = new CM_MenuEntry(['label' => $label, 'page' => $pageName, 'params' => ['param1' => ['foo', 'bar']]], $menu);
         $this->assertFalse($entry->compare('/mock'));
         $this->assertTrue($entry->compare('/mock', ['param1' => ['foo', 'bar']]));
         $this->assertFalse($entry->compare('/mock', ['param1' => ['bar', 'foo']]));
+
+        // strict/nonstrict comparison
+        $params = ['param1' => ''];
+        $entry = new CM_MenuEntry(['label' => $label, 'page' => $pageName, 'params' => ['param1' => 0]], $menu);
+        $this->assertTrue($entry->compare('/mock', ['param1' => 0]));
+        $this->assertFalse($entry->compare('/mock', ['param1' => '']));
+        $this->assertTrue($entry->compare('/mock', ['param1' => '0']));
+
+        $entry = new CM_MenuEntry(['label' => $label, 'page' => $pageName, 'params' => ['param1' => ['foo' => 0]]], $menu);
+        $this->assertTrue($entry->compare('/mock', ['param1' => ['foo' => 0]]));
+        $this->assertFalse($entry->compare('/mock', ['param1' => ['foo' => '']]));
+        $this->assertTrue($entry->compare('/mock', ['param1' => ['foo' => '0']]));
     }
 
     public function testGetters() {

--- a/tests/library/CM/MenuEntryTest.php
+++ b/tests/library/CM/MenuEntryTest.php
@@ -13,8 +13,8 @@ class CM_MenuEntryTest extends CMTest_TestCase {
         $this->assertTrue($entry->compare('/mock', ['param1' => 'foo']));
 
         $entry = new CM_MenuEntry(['label' => $label, 'page' => $pageName, 'params' => ['param1' => 'foo']], $menu);
-        $this->assertTrue($entry->compare('/mock', ['param1' => 'foo']));
         $this->assertFalse($entry->compare('/mock'));
+        $this->assertTrue($entry->compare('/mock', ['param1' => 'foo']));
         $this->assertFalse($entry->compare('/mock', ['param2' => 'foo']));
         $this->assertTrue($entry->compare('/mock', ['param2' => 'bar', 'param1' => 'foo']));
 
@@ -22,6 +22,19 @@ class CM_MenuEntryTest extends CMTest_TestCase {
         $this->assertFalse($entry->compare('/mock', ['param1' => 'foo']));
         $this->assertFalse($entry->compare('/mock', ['param2' => 'bar']));
         $this->assertTrue($entry->compare('/mock', ['param2' => 'bar', 'param1' => 'foo']));
+
+        $entry = new CM_MenuEntry(['label' => $label, 'page' => $pageName, 'params' => ['param1' => ['foo' => 'bar', 'bar' => 'baz']]], $menu);
+        $this->assertTrue($entry->compare('/mock', ['param1' => ['foo' => 'bar', 'bar' => 'baz']]));
+        $this->assertTrue($entry->compare('/mock', ['param1' => ['bar' => 'baz', 'foo' => 'bar']]));
+        $this->assertFalse($entry->compare('/mock', ['param1' => ['foo' => 'bar', 'bar' => 'baz', 'baz' => 'bar']]));
+        $this->assertFalse($entry->compare('/mock', ['param1' => ['foo' => 'baz', 'bar' => 'foo']]));
+        $this->assertFalse($entry->compare('/mock', ['param1' => ['foo' => 'bar', 'bar' => 'foo']]));
+        $this->assertFalse($entry->compare('/mock', ['param1' => ['foo' => 'bar']]));
+
+        $entry = new CM_MenuEntry(['label' => $label, 'page' => $pageName, 'params' => ['param1' => ['foo', 'bar']]], $menu);
+        $this->assertFalse($entry->compare('/mock'));
+        $this->assertTrue($entry->compare('/mock', ['param1' => ['foo', 'bar']]));
+        $this->assertFalse($entry->compare('/mock', ['param1' => ['bar', 'foo']]));
     }
 
     public function testGetters() {


### PR DESCRIPTION
Present implementation fails when comparing scalars with arrays, i.e. when a parameter is defined as scalar value on a menu-item but also has valid array-values (e.g. an object is identified by an id and type) or vice versa.
It fails with an `E_NOTICE: Array to string conversion` because array_intersect_assoc() casts values to strings to do a strict comparison.

Addendum: This obviously applies to all cases were either the parameter on the menu or the one compared to it is an array.