### PR TITLE
php-style parsing of arrays in url-parameters in frontend

### DIFF
--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -1266,7 +1266,7 @@ var CM_App = CM_Class_Abstract.extend({
      */
     parseQueryParams: function(queryParams) {
       var params = queryString.parse(queryParams);
-      var arrayParamRegex = /^([\d\w]+)\[([\d\w]+)]$/;
+      var arrayParamRegex = /^(\w+)\[(\w+)]$/;
       _.each(params, function(value, key) {
         var result = arrayParamRegex.exec(key);
         if (result) {

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -1268,12 +1268,13 @@ var CM_App = CM_Class_Abstract.extend({
       var params = queryString.parse(queryParams);
       var arrayParamRegex = /^([\d\w]+)\[([\d\w]+)]$/;
       _.each(params, function(value, key) {
-        if (result = arrayParamRegex.exec(key)) {
+        var result = arrayParamRegex.exec(key);
+        if (result) {
           var paramName = result[1];
           var arrayKey = result[2];
           delete params[key];
           if (!params[paramName]) {
-            params[paramName] = {}
+            params[paramName] = {};
           }
           params[paramName][arrayKey] = value;
         }

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -1235,8 +1235,8 @@ var CM_App = CM_Class_Abstract.extend({
         var locationNext = this._getLocationByFragment(fragment);
 
         if (locationCurrent.pathname === locationNext.pathname) {
-          var paramsCurrent = queryString.parse(locationCurrent.search);
-          var paramsNext = queryString.parse(locationNext.search);
+          var paramsCurrent = cm.request.parseQueryParams(locationCurrent.search);
+          var paramsNext = cm.request.parseQueryParams(locationNext.search);
 
           var stateParamNames = pageCurrent.getStateParams();
 
@@ -1255,6 +1255,30 @@ var CM_App = CM_Class_Abstract.extend({
         }
       }
       return cm.getLayout().loadPage(fragment);
+    }
+  },
+
+  request: {
+
+    /**
+     * @param {Object} queryParams
+     * @return {Object}
+     */
+    parseQueryParams: function(queryParams) {
+      var params = queryString.parse(queryParams);
+      var arrayParamRegex = /^([\d\w]+)\[([\d\w]+)]$/;
+      _.each(params, function(value, key) {
+        if (result = arrayParamRegex.exec(key)) {
+          var paramName = result[1];
+          var arrayKey = result[2];
+          delete params[key];
+          if (!params[paramName]) {
+            params[paramName] = {}
+          }
+          params[paramName][arrayKey] = value;
+        }
+      });
+      return params;
     }
   }
 });

--- a/library/CM/Page/Abstract.js
+++ b/library/CM/Page/Abstract.js
@@ -21,7 +21,7 @@ var CM_Page_Abstract = CM_Component_Abstract.extend({
 
     if (this.hasStateParams()) {
       var location = window.location;
-      var params = queryString.parse(location.search);
+      var params = this._parseQueryParams(location.search);
       var state = _.pick(params, _.intersection(_.keys(params), this.getStateParams()));
       this.routeToState(state, location.pathname + location.search);
     }
@@ -88,6 +88,27 @@ var CM_Page_Abstract = CM_Component_Abstract.extend({
    */
   _changeState: function(state) {
     return false;
+  },
+
+  /**
+   * @param {Object} queryParams
+   * @return {Object}
+   */
+  _parseQueryParams: function(queryParams) {
+    var params = queryString.parse(queryParams);
+    var arrayParamRegex = /^([\d\w]+)\[([\d\w]+)]$/;
+    _.each(params, function(value, key) {
+      if (result = arrayParamRegex.exec(key)) {
+        var paramName = result[1];
+        var arrayKey = result[2];
+        delete params[key];
+        if (!params[paramName]) {
+          params[paramName] = {}
+        }
+        params[paramName][arrayKey] = value;
+      }
+    });
+    return params;
   }
 
 });

--- a/library/CM/Page/Abstract.js
+++ b/library/CM/Page/Abstract.js
@@ -21,7 +21,7 @@ var CM_Page_Abstract = CM_Component_Abstract.extend({
 
     if (this.hasStateParams()) {
       var location = window.location;
-      var params = this._parseQueryParams(location.search);
+      var params = cm.request.parseQueryParams(location.search);
       var state = _.pick(params, _.intersection(_.keys(params), this.getStateParams()));
       this.routeToState(state, location.pathname + location.search);
     }
@@ -88,27 +88,6 @@ var CM_Page_Abstract = CM_Component_Abstract.extend({
    */
   _changeState: function(state) {
     return false;
-  },
-
-  /**
-   * @param {Object} queryParams
-   * @return {Object}
-   */
-  _parseQueryParams: function(queryParams) {
-    var params = queryString.parse(queryParams);
-    var arrayParamRegex = /^([\d\w]+)\[([\d\w]+)]$/;
-    _.each(params, function(value, key) {
-      if (result = arrayParamRegex.exec(key)) {
-        var paramName = result[1];
-        var arrayKey = result[2];
-        delete params[key];
-        if (!params[paramName]) {
-          params[paramName] = {}
-        }
-        params[paramName][arrayKey] = value;
-      }
-    });
-    return params;
   }
 
 });


### PR DESCRIPTION
urlParams like `/messages?conversation[id]=1&conversation[type]=2&foo=bar` should be parsed as 
```js
{
  conversation: {id: 1, type; 2},
  foo: bar  
}
```
so state-changes can be handled naturally when working with 2-dimensional parameters.