### PR TITLE
Layout.loadPage(): $pagePlaceholder might not be set

### DIFF
--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -21,9 +21,12 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
 
     var layout = this;
     this._loadPageThrottled = promiseThrottler(function(path) {
+      layout._createPagePlaceholder();
+      layout._chargeSpinnerTimeout();
+
       return layout.ajaxModal('loadPage', {path: path})
         .then(function(response) {
-          window.clearTimeout(layout._timeoutLoading);
+          layout._clearSpinnerTimeout();
           if (response.redirectExternal) {
             cm.router.route(response.redirectExternal);
             return;
@@ -34,21 +37,16 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
             window.location.replace(response.url);
             return;
           }
-          layout._$pagePlaceholder.replaceWith(view.$el);
-          layout._$pagePlaceholder = null;
-          var fragment = response.url.substr(cm.getUrl().length);
-          if (path === fragment + window.location.hash) {
-            fragment = path;
-          }
-          window.history.replaceState(null, null, fragment);
+          layout._removePagePlaceholder(view.$el);
+          layout._updateHistory(path, response.url);
           layout._onPageSetup(view, response.title, response.url, response.menuEntryHashList, response.jsTracking);
           view._ready();
           return view;
         })
         .catch(function(error) {
-          window.clearTimeout(layout._timeoutLoading);
+          layout._clearSpinnerTimeout();
           if (!(error instanceof Promise.CancellationError)) {
-            layout._$pagePlaceholder.addClass('error').html('<pre>' + error.message + '</pre>');
+            layout._errorPagePlaceholder(error);
             layout._onPageError();
             throw error;
           }
@@ -80,17 +78,6 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
    */
   loadPage: function(path) {
     cm.event.trigger('navigate', path);
-
-    if (!this._$pagePlaceholder) {
-      this._$pagePlaceholder = $('<div class="router-placeholder" />');
-      this.getPage().replaceWithHtml(this._$pagePlaceholder);
-      this._onPageTeardown();
-    } else {
-      this._$pagePlaceholder.removeClass('error').html('');
-    }
-    this._timeoutLoading = this.setTimeout(function() {
-      this._$pagePlaceholder.html('<div class="spinner spinner-expanded" />');
-    }, 750);
     return this._loadPageThrottled(path);
   },
 
@@ -139,5 +126,54 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
 
   _onPageError: function() {
     $('[data-menu-entry-hash]').removeClass('active');
+  },
+
+  _createPagePlaceholder: function() {
+    if (!this._$pagePlaceholder) {
+      this._$pagePlaceholder = $('<div class="router-placeholder" />');
+      this.getPage().replaceWithHtml(this._$pagePlaceholder);
+      this._onPageTeardown();
+    } else {
+      this._$pagePlaceholder.removeClass('error').html('');
+    }
+  },
+
+  /**
+   * @param {Element|String|jQuery} el
+   */
+  _removePagePlaceholder: function(el) {
+    this._$pagePlaceholder.replaceWith(el);
+    this._$pagePlaceholder = null;
+  },
+
+  /**
+   * @param {Error} error
+   */
+  _errorPagePlaceholder: function(error) {
+    this._$pagePlaceholder.addClass('error').html('<pre>' + error.message + '</pre>');
+  },
+
+  _chargeSpinnerTimeout: function() {
+    this._clearSpinnerTimeout();
+    this._timeoutLoading = this.setTimeout(function() {
+      this._$pagePlaceholder.html('<div class="spinner spinner-expanded" />');
+    }, 750);
+  },
+
+  _clearSpinnerTimeout: function() {
+    clearTimeout(this._timeoutLoading);
+  },
+
+  /**
+   * @param {String} path
+   * @param {String} url
+   */
+  _updateHistory: function(path, url) {
+    var fragment = url.substr(cm.getUrl().length);
+    if (path === fragment + window.location.hash) {
+      fragment = path;
+    }
+    window.history.replaceState(null, null, fragment);
   }
+
 });

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -21,7 +21,6 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
 
     var layout = this;
     this._loadPageThrottled = promiseThrottler(function(path) {
-      layout._createPagePlaceholder();
       layout._chargeSpinnerTimeout();
 
       return layout.ajaxModal('loadPage', {path: path})
@@ -39,7 +38,7 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
           }
           layout._removePagePlaceholder(view.$el);
           layout._updateHistory(path, response.url);
-          layout._onPageSetup(view, response.title, response.url, response.menuEntryHashList, response.jsTracking);
+          layout._onPageSetup(response.title, response.menuEntryHashList, response.jsTracking);
           view._ready();
           return view;
         })
@@ -99,13 +98,11 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
   },
 
   /**
-   * @param {CM_Page_Abstract} page
    * @param {String} title
-   * @param {String} url
    * @param {String[]} menuEntryHashList
    * @param {String} [jsTracking]
    */
-  _onPageSetup: function(page, title, url, menuEntryHashList, jsTracking) {
+  _onPageSetup: function(title, menuEntryHashList, jsTracking) {
     cm.window.title.setText(title);
     $('[data-menu-entry-hash]').removeClass('active');
     var menuEntrySelectors = _.map(menuEntryHashList, function(menuEntryHash) {
@@ -175,15 +172,15 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
   },
 
   /**
-   * @param {String} path
-   * @param {String} url
+   * @param {String} requestPath
+   * @param {String} responseUrl
    */
-  _updateHistory: function(path, url) {
-    var fragment = url.substr(cm.getUrl().length);
-    if (path === fragment + window.location.hash) {
-      fragment = path;
+  _updateHistory: function(requestPath, responseUrl) {
+    var responseFragment = responseUrl.substr(cm.getUrl().length);
+    if (requestPath === responseFragment + window.location.hash) {
+      responseFragment = requestPath;
     }
-    window.history.replaceState(null, null, fragment);
+    window.history.replaceState(null, null, responseFragment);
   }
 
 });

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -150,6 +150,10 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
    * @param {Error} error
    */
   _errorPagePlaceholder: function(error) {
+    if (null == this._$pagePlaceholder) {
+      // in case when error happened at the late stage when page replaced placeholder.
+      this._createPagePlaceholder();
+    }
     this._$pagePlaceholder.addClass('error').html('<pre>' + error.message + '</pre>');
   },
 

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -139,10 +139,20 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
   },
 
   /**
+   * @returns {jQuery}
+   */
+  _getPagePlaceholder: function() {
+    if (!this._$pagePlaceholder) {
+      this._createPagePlaceholder();
+    }
+    return this._$pagePlaceholder;
+  },
+
+  /**
    * @param {Element|String|jQuery} el
    */
   _removePagePlaceholder: function(el) {
-    this._$pagePlaceholder.replaceWith(el);
+    this._getPagePlaceholder().replaceWith(el);
     this._$pagePlaceholder = null;
   },
 
@@ -150,13 +160,13 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
    * @param {Error} error
    */
   _errorPagePlaceholder: function(error) {
-    this._$pagePlaceholder.addClass('error').html('<pre>' + error.message + '</pre>');
+    this._getPagePlaceholder().addClass('error').html('<pre>' + error.message + '</pre>');
   },
 
   _chargeSpinnerTimeout: function() {
     this._clearSpinnerTimeout();
     this._timeoutLoading = this.setTimeout(function() {
-      this._$pagePlaceholder.html('<div class="spinner spinner-expanded" />');
+      this._getPagePlaceholder().html('<div class="spinner spinner-expanded" />');
     }, 750);
   },
 

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -150,10 +150,6 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
    * @param {Error} error
    */
   _errorPagePlaceholder: function(error) {
-    if (null == this._$pagePlaceholder) {
-      // in case when error happened at the late stage when page replaced placeholder.
-      this._createPagePlaceholder();
-    }
     this._$pagePlaceholder.addClass('error').html('<pre>' + error.message + '</pre>');
   },
 


### PR DESCRIPTION
In the error handling of `CM_Layout_Abstract`'s `loadPage()` we modify `_$pagePlaceholder`:
```js
        .catch(function(error) {
          window.clearTimeout(layout._timeoutLoading);
          if (!(error instanceof Promise.CancellationError)) {
            layout._$pagePlaceholder.addClass('error').html('<pre>' + error.message + '</pre>');
            layout._onPageError();
            throw error;
          }
        });
```

The problem is that `_$pagePlaceholder` might have been set to `null` in the `then()` block above, so this will fail.

@vogdb could you look into this when you have some spare time? I have the feeling this code in general could use some love, it's quite difficult to read (e.g. logic spread between `loadPage` and `_loadPageThrottled`).