### PR TITLE
Breaking: Enable MaxMind through the service manager

### DIFF
--- a/library/CM/Location/Cli.php
+++ b/library/CM/Location/Cli.php
@@ -8,7 +8,7 @@ class CM_Location_Cli extends CM_Cli_Runnable_Abstract {
      */
     public function outdated($verbose = null) {
         /** @var CMService_MaxMind $maxMind */
-        $maxMind = CM_Service_Manager::getInstance()->get('maxmind', 'CMService_MaxMind');
+        $maxMind = $this->getServiceManager()->get('maxmind', 'CMService_MaxMind');
         $maxMind->setStreamOutput($this->_getStreamOutput());
         $maxMind->setStreamError($this->_getStreamError());
         $maxMind->setVerbose($verbose);
@@ -22,7 +22,7 @@ class CM_Location_Cli extends CM_Cli_Runnable_Abstract {
      */
     public function upgrade($withoutIpBlocks = null, $verbose = null) {
         /** @var CMService_MaxMind $maxMind */
-        $maxMind = CM_Service_Manager::getInstance()->get('maxmind', 'CMService_MaxMind');
+        $maxMind = $this->getServiceManager()->get('maxmind', 'CMService_MaxMind');
         $maxMind->setStreamOutput($this->_getStreamOutput());
         $maxMind->setStreamError($this->_getStreamError());
         $maxMind->setWithoutIpBlocks($withoutIpBlocks);

--- a/library/CM/Location/Cli.php
+++ b/library/CM/Location/Cli.php
@@ -7,7 +7,10 @@ class CM_Location_Cli extends CM_Cli_Runnable_Abstract {
      * @synchronized
      */
     public function outdated($verbose = null) {
-        $maxMind = new CMService_MaxMind($this->_getStreamOutput(), $this->_getStreamError(), null, $verbose);
+        $maxMind = new CMService_MaxMind();
+        $maxMind->setStreamOutput($this->_getStreamOutput());
+        $maxMind->setStreamError($this->_getStreamError());
+        $maxMind->setVerbose($verbose);
         $maxMind->outdated();
     }
 
@@ -17,7 +20,11 @@ class CM_Location_Cli extends CM_Cli_Runnable_Abstract {
      * @synchronized
      */
     public function upgrade($withoutIpBlocks = null, $verbose = null) {
-        $maxMind = new CMService_MaxMind($this->_getStreamOutput(), $this->_getStreamError(), $withoutIpBlocks, $verbose);
+        $maxMind = new CMService_MaxMind();
+        $maxMind->setStreamOutput($this->_getStreamOutput());
+        $maxMind->setStreamError($this->_getStreamError());
+        $maxMind->setWithoutIpBlocks($withoutIpBlocks);
+        $maxMind->setVerbose($verbose);
         $maxMind->upgrade();
     }
 

--- a/library/CM/Location/Cli.php
+++ b/library/CM/Location/Cli.php
@@ -7,7 +7,8 @@ class CM_Location_Cli extends CM_Cli_Runnable_Abstract {
      * @synchronized
      */
     public function outdated($verbose = null) {
-        $maxMind = new CMService_MaxMind();
+        /** @var CMService_MaxMind $maxMind */
+        $maxMind = CM_Service_Manager::getInstance()->get('maxmind', 'CMService_MaxMind');
         $maxMind->setStreamOutput($this->_getStreamOutput());
         $maxMind->setStreamError($this->_getStreamError());
         $maxMind->setVerbose($verbose);
@@ -20,7 +21,8 @@ class CM_Location_Cli extends CM_Cli_Runnable_Abstract {
      * @synchronized
      */
     public function upgrade($withoutIpBlocks = null, $verbose = null) {
-        $maxMind = new CMService_MaxMind();
+        /** @var CMService_MaxMind $maxMind */
+        $maxMind = CM_Service_Manager::getInstance()->get('maxmind', 'CMService_MaxMind');
         $maxMind->setStreamOutput($this->_getStreamOutput());
         $maxMind->setStreamError($this->_getStreamError());
         $maxMind->setWithoutIpBlocks($withoutIpBlocks);

--- a/library/CM/Maintenance/Cli.php
+++ b/library/CM/Maintenance/Cli.php
@@ -89,12 +89,12 @@ class CM_Maintenance_Cli extends CM_Cli_Runnable_Abstract {
                 }
             }
         ));
-        if (CM_Service_Manager::getInstance()->has('maxmind')) {
+        if ($this->getServiceManager()->has('maxmind')) {
             $this->_registerClockworkCallbacks('8 days', array(
                 'CMService_MaxMind::upgrade' => function () {
                     try {
                         /** @var CMService_MaxMind $maxMind */
-                        $maxMind = CM_Service_Manager::getInstance()->get('maxmind', 'CMService_MaxMind');
+                        $maxMind = $this->getServiceManager()->get('maxmind', 'CMService_MaxMind');
                         $maxMind->upgrade();
                     } catch (Exception $exception) {
                         if (!is_a($exception, 'CM_Exception')) {

--- a/library/CM/Maintenance/Cli.php
+++ b/library/CM/Maintenance/Cli.php
@@ -89,24 +89,27 @@ class CM_Maintenance_Cli extends CM_Cli_Runnable_Abstract {
                 }
             }
         ));
-        $this->_registerClockworkCallbacks('8 days', array(
-            'CMService_MaxMind::upgrade' => function () {
-                try {
-                    $maxMind = new CMService_MaxMind();
-                    $maxMind->upgrade();
-                } catch (Exception $exception) {
-                    if (!is_a($exception, 'CM_Exception')) {
-                        $exception = new CM_Exception($exception->getMessage(), null, [
-                            'file'  => $exception->getFile(),
-                            'line'  => $exception->getLine(),
-                            'trace' => $exception->getTraceAsString(),
-                        ]);
+        if (CM_Service_Manager::getInstance()->has('maxmind')) {
+            $this->_registerClockworkCallbacks('8 days', array(
+                'CMService_MaxMind::upgrade' => function () {
+                    try {
+                        /** @var CMService_MaxMind $maxMind */
+                        $maxMind = CM_Service_Manager::getInstance()->get('maxmind', 'CMService_MaxMind');
+                        $maxMind->upgrade();
+                    } catch (Exception $exception) {
+                        if (!is_a($exception, 'CM_Exception')) {
+                            $exception = new CM_Exception($exception->getMessage(), null, [
+                                'file'  => $exception->getFile(),
+                                'line'  => $exception->getLine(),
+                                'trace' => $exception->getTraceAsString(),
+                            ]);
+                        }
+                        $exception->setSeverity(CM_Exception::FATAL);
+                        throw $exception;
                     }
-                    $exception->setSeverity(CM_Exception::FATAL);
-                    throw $exception;
                 }
-            }
-        ));
+            ));
+        }
     }
 
     protected function _registerCallbacksLocal() {

--- a/library/CMService/MaxMind.php
+++ b/library/CMService/MaxMind.php
@@ -871,14 +871,12 @@ class CMService_MaxMind extends CM_Class_Abstract {
 				`country`.`name` AS `countryName`
 			FROM `cm_model_location_city` `city`
 			LEFT JOIN `cm_model_location_state` `state` ON `state`.`id` = `city`.`stateId`
-			LEFT JOIN `cm_model_location_country` `country` ON `country`.`id` = `city`.`countryId`');
+			LEFT JOIN `cm_model_location_country` `country` ON `country`.`id` = `city`.`countryId`
+			WHERE `city`.`_maxmind` IS NOT NULL');
         $count = $result->getAffectedRows();
         $item = 0;
         while (false !== ($row = $result->fetch())) {
             list($cityId, $cityCode, $cityName, $regionId, $maxMindRegion, $regionAbbreviation, $regionName, $countryCode, $countryName) = array_values($row);
-            if (null === $cityCode) {
-                throw new CM_Exception('City `' . $cityName . '` (' . $cityId . ') has no MaxMind code');
-            }
             if (null === $regionId) {
                 $regionCode = null;
             } else {
@@ -911,7 +909,8 @@ class CMService_MaxMind extends CM_Class_Abstract {
 			FROM `cm_model_location_zip` `zip`
 			LEFT JOIN `cm_model_location_city` `city` ON `city`.`id` = `zip`.`cityId`
 			LEFT JOIN `cm_model_location_state` `state` ON `state`.`id` = `city`.`stateId`
-			LEFT JOIN `cm_model_location_country` `country` ON `country`.`id` = `city`.`countryId`');
+			LEFT JOIN `cm_model_location_country` `country` ON `country`.`id` = `city`.`countryId`
+			WHERE `city`.`_maxmind` IS NOT NULL');
         $count = $result->getAffectedRows();
         $item = 0;
         while (false !== ($row = $result->fetch())) {

--- a/library/CMService/MaxMind.php
+++ b/library/CMService/MaxMind.php
@@ -30,23 +30,33 @@ class CMService_MaxMind extends CM_Class_Abstract {
         $_zipCodeListByCityAdded, $_zipCodeListByCityRemoved, $_zipCodeIdListByMaxMind,
         $_ipBlockListByLocation;
 
-    /**
-     * @param CM_OutputStream_Interface|null $streamOutput
-     * @param CM_OutputStream_Interface|null $streamError
-     * @param bool|null                      $withoutIpBlocks
-     * @param bool|null                      $verbose
-     */
-    public function __construct(CM_OutputStream_Interface $streamOutput = null, CM_OutputStream_Interface $streamError = null, $withoutIpBlocks = null, $verbose = null) {
-        if (null === $streamOutput) {
-            $streamOutput = new CM_OutputStream_Null();
-        }
-        if (null === $streamError) {
-            $streamError = new CM_OutputStream_Null();
-        }
-        $this->_streamOutput = $streamOutput;
+    public function __construct() {
+        $this->_streamOutput = new CM_OutputStream_Null();
+        $this->_streamError = new CM_OutputStream_Null();
+        $this->_withoutIpBlocks = false;
+        $this->_verbose = false;
+    }
+
+    public function setStreamError(CM_OutputStream_Interface $streamError) {
         $this->_streamError = $streamError;
-        $this->_withoutIpBlocks = (bool) $withoutIpBlocks;
+    }
+
+    public function setStreamOutput(CM_OutputStream_Interface $streamOutput) {
+        $this->_streamOutput = $streamOutput;
+    }
+
+    /**
+     * @param bool $verbose
+     */
+    public function setVerbose($verbose) {
         $this->_verbose = (bool) $verbose;
+    }
+
+    /**
+     * @param bool $withoutIpBlocks
+     */
+    public function setWithoutIpBlocks($withoutIpBlocks) {
+        $this->_withoutIpBlocks = (bool) $withoutIpBlocks;
     }
 
     public function outdated() {

--- a/tests/library/CMService/MaxMindTest.php
+++ b/tests/library/CMService/MaxMindTest.php
@@ -3354,8 +3354,7 @@ class CMService_MaxMindTest extends CMTest_TestCase {
         $ipBlocksReaderMock = $this->_getReaderMock($ipDataMock, "Copyright (c) 2011 MaxMind Inc.  All Rights Reserved.\nstartIpNum,endIpNum,locId\n");
         $locationReaderMock = $this->_getReaderMock($locationDataMock, "Copyright (c) 2012 MaxMind LLC.  All Rights Reserved.\nlocId,country,region,city,postalCode,latitude,longitude,metroCode,areaCode\n");
         $maxMind = $this->getMock('CMService_MaxMind',
-            ['_getCountryData', '_getRegionData', '_getLocationReader', '_getIpBlocksReader', '_getRegionListLegacy', '_updateSearchIndex'],
-            [$this->_outputStream, $this->_errorStream, null, true]);
+            ['_getCountryData', '_getRegionData', '_getLocationReader', '_getIpBlocksReader', '_getRegionListLegacy', '_updateSearchIndex']);
         $maxMind->expects($this->any())->method('_getCountryData')->will($this->returnValue($countryDataMock));
         $maxMind->expects($this->any())->method('_getRegionData')->will($this->returnValue($regionDataMock));
         $maxMind->expects($this->any())->method('_getLocationReader')->will($this->returnValue($locationReaderMock));
@@ -3363,6 +3362,9 @@ class CMService_MaxMindTest extends CMTest_TestCase {
         $maxMind->expects($this->any())->method('_getRegionListLegacy')->will($this->returnValue($regionListLegacyMock));
         $maxMind->expects($this->any())->method('_updateSearchIndex')->will($this->returnValue(null));
         /** @var CMService_MaxMind $maxMind */
+        $maxMind->setStreamOutput($this->_outputStream);
+        $maxMind->setStreamError($this->_errorStream);
+        $maxMind->setVerbose(true);
         $maxMind->upgrade();
     }
 


### PR DESCRIPTION
Reason:
```
CM_Exception: City `London` (1) has no MaxMind code in /home/vagrant/sk/vendor/cargomedia/cm/library/CMService/MaxMind.php on line 880
```

In the clockwork this code is registered like this:
```php
        $this->_registerClockworkCallbacks('8 days', array(
            'CMService_MaxMind::upgrade' => function () {
                try {
                    $maxMind = new CMService_MaxMind();
                    $maxMind->upgrade();
```

Probably for dev machines this shouldn't even run?
How about registering "MaxMind" as a service in the serviceManager, and in the clockwork first checking if it has been registered?
For a blueprint see https://github.com/njam/sk/commit/88e22b7cdd23a59fa4354398756a186af133a3c6