### PR TITLE
Reduce error messages amount for CM_Elasticsearch_Client

### DIFF
--- a/library/CM/Elasticsearch/Client.php
+++ b/library/CM/Elasticsearch/Client.php
@@ -286,12 +286,16 @@ class CM_Elasticsearch_Client {
                 throw new CM_Exception_Invalid('Unknown error in one or more bulk request actions');
             }
             $message = '';
+            $i = 0;
             foreach ($response['items'] as $item) {
                 list($operation, $description) = each($item);
                 $message .= 'Operator `' . $operation . '` ' . $description['error'] . PHP_EOL;
+                if (++$i > 2) {
+                    break;
+                }
             }
 
-            throw new CM_Exception_Invalid('Error in one or more bulk request actions' . PHP_EOL . $message);
+            throw new CM_Exception_Invalid('Error(s) in ' . count($response['items']) . ' bulk request action(s)' . PHP_EOL . $message);
         }
     }
 


### PR DESCRIPTION
Currently it add every error message for bulk API requests, and as each bulk request consists of many elements it pollutes our logs.
So need to change it to something like "bulk request contains 34 errors" and display few of them