### PR TITLE
Add SetupScript to write class types to table

### DIFF
--- a/library/CM/Class/TypeDumper.php
+++ b/library/CM/Class/TypeDumper.php
@@ -1,0 +1,46 @@
+<?php
+
+class CM_Class_TypeDumper extends CM_Provision_Script_Abstract implements CM_Provision_Script_UnloadableInterface {
+
+    public function load(CM_OutputStream_Interface $output) {
+        $dbClient = $this->getServiceManager()->getDatabases()->getMaster();
+        $values = Functional\map($this->_getAllTypes(), function ($className, $type) {
+            return [$type, $className];
+        });
+        $query = new CM_Db_Query_Insert($dbClient, 'cm_tmp_classType', ['type', 'className'], $values, null, 'REPLACE');
+        $query->execute();
+    }
+
+    public function unload(CM_OutputStream_Interface $output) {
+        $dbClient = $this->getServiceManager()->getDatabases()->getMaster();
+        $query = new CM_Db_Query_Delete($dbClient, 'cm_tmp_classType');
+        $query->execute();
+    }
+
+    public function shouldBeLoaded() {
+        return true;
+    }
+
+    public function shouldBeUnloaded() {
+        return true;
+    }
+
+    public function getRunLevel() {
+        return 1;
+    }
+
+    /**
+     * @return array
+     */
+    protected function _getAllTypes() {
+        $config = CM_Config::get();
+        $typeList = [];
+        foreach (get_object_vars($config) as $key => $value) {
+            if (isset($value->types)) {
+                $typeList += $value->types;
+            }
+        }
+        return $typeList;
+    }
+
+}

--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -3,6 +3,7 @@
 return function (CM_Config_Node $config) {
     $config->CM_App->setupScriptClasses = array();
     $config->CM_App->setupScriptClasses[] = 'CM_File_Filesystem_SetupScript';
+    $config->CM_App->setupScriptClasses[] = 'CM_Class_TypeDumper';
     $config->CM_App->setupScriptClasses[] = 'CM_Db_SetupScript';
     $config->CM_App->setupScriptClasses[] = 'CM_MongoDb_SetupScript';
     $config->CM_App->setupScriptClasses[] = 'CM_Elasticsearch_SetupScript';

--- a/resources/db/structure.sql
+++ b/resources/db/structure.sql
@@ -464,6 +464,15 @@ CREATE TABLE `cm_tmp_location` (
   UNIQUE KEY `levelId` (`level`,`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
+DROP TABLE IF EXISTS `cm_tmp_classType`;
+
+
+CREATE TABLE `cm_tmp_classType` (
+  `type` int(10) unsigned NOT NULL,
+  `className` varchar(255) NOT NULL,
+  PRIMARY KEY (`type`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
 DROP TABLE IF EXISTS `cm_tmp_location_coordinates`;
 
 

--- a/resources/db/update/58.php
+++ b/resources/db/update/58.php
@@ -1,0 +1,11 @@
+<?php
+
+if (!CM_Db_Db::existsTable('cm_tmp_classType')) {
+    CM_Db_Db::exec("
+        CREATE TABLE `cm_tmp_classType` (
+          `type` int(10) unsigned NOT NULL,
+          `className` varchar(255) NOT NULL,
+          PRIMARY KEY (`type`)
+        ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+    ");
+}

--- a/tests/library/CM/Class/TypeDumperTest.php
+++ b/tests/library/CM/Class/TypeDumperTest.php
@@ -1,0 +1,60 @@
+<?php
+
+class CM_Class_TypeDumperTest extends CMTest_TestCase {
+
+    protected function tearDown() {
+        CMTest_TH::clearEnv();
+    }
+
+    public function testLoad() {
+        CM_Config::get()->Foo = new stdClass();
+        CM_Config::get()->Foo->types = [
+            1111 => 'Foo1',
+            2222 => 'Foo2',
+        ];
+        CM_Config::get()->Bar = new stdClass();
+        CM_Config::get()->Bar->types = [
+            3333 => 'Bar1',
+            4444 => 'Bar2',
+        ];
+
+        $dumper = new CM_Class_TypeDumper($this->getServiceManager());
+        $dumper->load(new CM_OutputStream_Null());
+
+        $rowList = [
+            ['type' => 1111, 'className' => 'Foo1'],
+            ['type' => 2222, 'className' => 'Foo2'],
+            ['type' => 3333, 'className' => 'Bar1'],
+            ['type' => 4444, 'className' => 'Bar2'],
+        ];
+        $dbClient = $this->getServiceManager()->getDatabases()->getMaster();
+        foreach ($rowList as $row) {
+            $queryCount = new CM_Db_Query_Count($dbClient, 'cm_tmp_classType', $row);
+            $this->assertSame('1', $queryCount->execute()->fetchColumn());
+        }
+    }
+
+    public function testLoadTwice() {
+        CM_Config::get()->Foo = new stdClass();
+        CM_Config::get()->Foo->types = [
+            1111 => 'Foo1',
+            2222 => 'Foo2',
+        ];
+
+        $dumper = new CM_Class_TypeDumper($this->getServiceManager());
+        $dumper->load(new CM_OutputStream_Null());
+        $dumper->load(new CM_OutputStream_Null());
+    }
+
+    public function testUnload() {
+        $dumper = new CM_Class_TypeDumper($this->getServiceManager());
+        $dumper->load(new CM_OutputStream_Null());
+
+        $dbClient = $this->getServiceManager()->getDatabases()->getMaster();
+        $queryCount = new CM_Db_Query_Count($dbClient, 'cm_tmp_classType');
+        $this->assertNotSame('0', $queryCount->execute()->fetchColumn());
+
+        $dumper->unload(new CM_OutputStream_Null());
+        $this->assertSame('0', $queryCount->execute()->fetchColumn());
+    }
+}


### PR DESCRIPTION
Table like `tmp_classType` which wouldn't be used by application.
Can be used for data warehouse.

Manual migration needed:
```sql
CREATE TABLE `cm_tmp_classType` (
  `type` int(10) unsigned NOT NULL,
  `className` varchar(255) NOT NULL,
  PRIMARY KEY (`type`)
) ENGINE=MyISAM DEFAULT CHARSET=utf8;
```