### PR TITLE
CM_StreamChannel_Media invalidate key-cache on create

### DIFF
--- a/library/CM/Model/StreamChannel/Media.php
+++ b/library/CM/Model/StreamChannel/Media.php
@@ -128,6 +128,8 @@ class CM_Model_StreamChannel_Media extends CM_Model_StreamChannel_Abstract {
             CM_Db_Db::delete('cm_streamChannel', array('id' => $id));
             throw $ex;
         }
+        $cacheKey = CM_CacheConst::StreamChannel_Id . '_key' . $key . '_adapterType:' . $adapterType;
+        CM_Cache_Shared::getInstance()->delete($cacheKey);
         return new static($id);
     }
 }


### PR DESCRIPTION
Needs to invalidate cache on Create like parent class does. Probably was forgotten during refactoring.

please review @tomaszdurka 