### PR TITLE
Consider CDN URL in site matching

### DIFF
--- a/library/CM/Http/UrlParser.php
+++ b/library/CM/Http/UrlParser.php
@@ -1,0 +1,26 @@
+<?php
+
+class CM_Http_UrlParser {
+
+    /** @var string */
+    private $_url;
+
+    /**
+     * @param string $url
+     */
+    public function __construct($url) {
+        $this->_url = (string) $url;
+    }
+
+    /**
+     * @return string
+     * @throws CM_Exception
+     */
+    public function getHost() {
+        $host = parse_url($this->_url, PHP_URL_HOST);
+        if (false === $host || null === $host) {
+            throw new CM_Exception('Cannot detect host from `' . $this->_url . '`.');
+        }
+        return $host;
+    }
+}

--- a/tests/library/CM/Http/UrlParserTest.php
+++ b/tests/library/CM/Http/UrlParserTest.php
@@ -1,0 +1,19 @@
+<?php
+
+class CM_Http_UrlParserTest extends CMTest_TestCase {
+
+    public function testGetHost() {
+        $urlParser = new CM_Http_UrlParser('http://www.example.com');
+        $this->assertSame('www.example.com', $urlParser->getHost());
+    }
+
+    /**
+     * @expectedException CM_Exception
+     * @expectedExceptionMessage Cannot detect host
+     */
+    public function testGetHostInvalid() {
+        $urlParser = new CM_Http_UrlParser('jo');
+        $urlParser->getHost();
+    }
+
+}

--- a/tests/library/CM/Site/AbstractTest.php
+++ b/tests/library/CM/Site/AbstractTest.php
@@ -74,6 +74,19 @@ class CM_Site_AbstractTest extends CMTest_TestCase {
         $this->assertFalse($siteClassMatchXxx->match($requestNotPartial));
     }
 
+    public function testMatchCdn() {
+        $siteClass = $this->getMockBuilder('CM_Site_Abstract')
+            ->setMethods(array('getUrl'))
+            ->setMethods(array('getUrlCdn'))
+            ->getMockForAbstractClass();
+        $siteClass->expects($this->any())->method('getUrl')->will($this->returnValue('http://www.example.com'));
+        $siteClass->expects($this->any())->method('getUrlCdn')->will($this->returnValue('http://cdn.example.com'));
+        /** @var CM_Site_Abstract $siteClass */
+
+        $this->assertTrue($siteClass->match(new CM_Http_Request_Get('/', array('host' => 'cdn.example.com'))));
+        $this->assertFalse($siteClass->match(new CM_Http_Request_Get('/', array('host' => 'www.google.com'))));
+    }
+
     public function testFactory() {
         try {
             CM_Site_Abstract::factory(9999);


### PR DESCRIPTION
@alexispeter @tomaszdurka please review

This is not necessarily needed atm because we pass the site-id along with CDN requests.
Still I think it makes sense to make the site matching consider it, in case we need it in the future…