### PR TITLE
Add cm-janus service

### DIFF
--- a/library/CM/Janus/Configuration.php
+++ b/library/CM/Janus/Configuration.php
@@ -32,7 +32,7 @@ class CM_Janus_Configuration {
      * @param string $token
      * @return CM_Janus_Server|null
      */
-    public function findServerByToken($token) {
+    public function findServerByKey($token) {
         foreach ($this->_servers as $server) {
             if ($server->getKey() === $token) {
                 return $server;

--- a/library/CM/Janus/Configuration.php
+++ b/library/CM/Janus/Configuration.php
@@ -34,7 +34,7 @@ class CM_Janus_Configuration {
      */
     public function findServerByToken($token) {
         foreach ($this->_servers as $server) {
-            if ($server->getToken() === $token) {
+            if ($server->getKey() === $token) {
                 return $server;
             }
         }

--- a/library/CM/Janus/Configuration.php
+++ b/library/CM/Janus/Configuration.php
@@ -29,12 +29,12 @@ class CM_Janus_Configuration {
     }
 
     /**
-     * @param string $token
+     * @param string $key
      * @return CM_Janus_Server|null
      */
-    public function findServerByKey($token) {
+    public function findServerByKey($key) {
         foreach ($this->_servers as $server) {
-            if ($server->getKey() === $token) {
+            if ($server->getKey() === $key) {
                 return $server;
             }
         }

--- a/library/CM/Janus/Configuration.php
+++ b/library/CM/Janus/Configuration.php
@@ -1,0 +1,57 @@
+<?php
+
+class CM_Janus_Configuration {
+
+    /** @var CM_Janus_Server[] */
+    protected $_servers;
+
+    /**
+     * @param array|null $servers
+     */
+    public function __construct(array $servers = null) {
+        foreach ((array) $servers as $server) {
+            $this->addServer($server);
+        }
+    }
+
+    /**
+     * @param CM_Janus_Server $server
+     */
+    public function addServer(CM_Janus_Server $server) {
+        $this->_servers[] = $server;
+    }
+
+    /**
+     * @return CM_Janus_Server[]
+     */
+    public function getServers() {
+        return $this->_servers;
+    }
+
+    /**
+     * @param string $token
+     * @return CM_Janus_Server|null
+     */
+    public function findServerByToken($token) {
+        foreach ($this->_servers as $server) {
+            if ($server->getToken() == $token) {
+                return $server;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param int $id
+     * @return CM_Janus_Server
+     * @throws CM_Exception_Invalid
+     */
+    public function getServer($id) {
+        foreach ($this->_servers as $server) {
+            if ($server->getId() == $id) {
+                return $server;
+            }
+        }
+        throw new CM_Exception_Invalid('Cannot find server with id `' . $id . '`');
+    }
+}

--- a/library/CM/Janus/Configuration.php
+++ b/library/CM/Janus/Configuration.php
@@ -34,7 +34,7 @@ class CM_Janus_Configuration {
      */
     public function findServerByToken($token) {
         foreach ($this->_servers as $server) {
-            if ($server->getToken() == $token) {
+            if ($server->getToken() === $token) {
                 return $server;
             }
         }
@@ -48,7 +48,7 @@ class CM_Janus_Configuration {
      */
     public function getServer($id) {
         foreach ($this->_servers as $server) {
-            if ($server->getId() == $id) {
+            if ($server->getId() === $id) {
                 return $server;
             }
         }

--- a/library/CM/Janus/Factory.php
+++ b/library/CM/Janus/Factory.php
@@ -11,7 +11,7 @@ class CM_Janus_Factory {
         foreach ($servers as $serverId => $serverConfig) {
             $configuration->addServer(new CM_Janus_Server(
                 $serverId,
-                $serverConfig['token'],
+                $serverConfig['key'],
                 $serverConfig['httpAddress'],
                 $serverConfig['webSocketAddress']
             ));

--- a/library/CM/Janus/Factory.php
+++ b/library/CM/Janus/Factory.php
@@ -1,0 +1,25 @@
+<?php
+
+class CM_Janus_Factory {
+
+    /**
+     * @param array $servers
+     * @return CM_Janus_Service
+     */
+    public function createService(array $servers) {
+        $configuration = new CM_Janus_Configuration();
+        foreach ($servers as $serverId => $serverConfig) {
+            $configuration->addServer(new CM_Janus_Server(
+                $serverId,
+                $serverConfig['token'],
+                $serverConfig['httpAddress'],
+                $serverConfig['webSocketAddress']
+            ));
+        }
+
+        $httpClient = new GuzzleHttp\Client();
+        $httpApiClient = new CM_Janus_HttpApiClient($httpClient);
+        $wowza = new CM_Janus_Service($configuration, $httpApiClient);
+        return $wowza;
+    }
+}

--- a/library/CM/Janus/Factory.php
+++ b/library/CM/Janus/Factory.php
@@ -19,7 +19,7 @@ class CM_Janus_Factory {
 
         $httpClient = new GuzzleHttp\Client();
         $httpApiClient = new CM_Janus_HttpApiClient($httpClient);
-        $wowza = new CM_Janus_Service($configuration, $httpApiClient);
-        return $wowza;
+        $janus = new CM_Janus_Service($configuration, $httpApiClient);
+        return $janus;
     }
 }

--- a/library/CM/Janus/HttpApiClient.php
+++ b/library/CM/Janus/HttpApiClient.php
@@ -14,7 +14,7 @@ class CM_Janus_HttpApiClient {
 
     /**
      * @param CM_Janus_Server $server
-     * @param string $clientKey
+     * @param string          $clientKey
      * @return string
      * @throws CM_Exception_Invalid
      */
@@ -37,18 +37,20 @@ class CM_Janus_HttpApiClient {
     }
 
     /**
-     * @param string $method
+     * @param string          $method
      * @param CM_Janus_Server $server
-     * @param string $path
-     * @param array|null $body
+     * @param string          $path
+     * @param array|null      $body
      * @return string
      * @throws CM_Exception_Invalid
      */
     protected function _request($method, CM_Janus_Server $server, $path, array $body = null) {
         $url = $server->getHttpAddress() . $path;
         $body = (array) $body;
-        $body['token'] = $server->getToken();
-        $options = ['body' => $body];
+        $options = [
+            'body'    => $body,
+            'headers' => ['Api-Key' => $server->getToken()],
+        ];
         $request = $this->_httpClient->createRequest($method, $url, $options);
         try {
             $response = $this->_httpClient->send($request);

--- a/library/CM/Janus/HttpApiClient.php
+++ b/library/CM/Janus/HttpApiClient.php
@@ -29,11 +29,7 @@ class CM_Janus_HttpApiClient {
      */
     public function fetchStatus(CM_Janus_Server $server) {
         $encodedStatus = $this->_request('GET', $server, '/status');
-        $status = CM_Params::decode($encodedStatus, true);
-        if (false == $status) {
-            throw new CM_Exception_Invalid('Cannot decode server status');
-        }
-        return $status;
+        return CM_Params::jsonDecode($encodedStatus);
     }
 
     /**

--- a/library/CM/Janus/HttpApiClient.php
+++ b/library/CM/Janus/HttpApiClient.php
@@ -1,0 +1,58 @@
+<?php
+
+class CM_Janus_HttpApiClient {
+
+    /** @var \GuzzleHttp\Client */
+    protected $_httpClient;
+
+    /**
+     * @param \GuzzleHttp\Client $httpClient
+     */
+    public function __construct(GuzzleHttp\Client $httpClient) {
+        $this->_httpClient = $httpClient;
+    }
+
+    /**
+     * @param CM_Janus_Server $server
+     * @param string $clientKey
+     * @return string
+     * @throws CM_Exception_Invalid
+     */
+    public function stopStream(CM_Janus_Server $server, $clientKey) {
+        return $this->_request('POST', $server, '/stop', ['clientId' => (string) $clientKey]);
+    }
+
+    /**
+     * @param CM_Janus_Server $server
+     * @return array
+     * @throws CM_Exception_Invalid
+     */
+    public function fetchStatus(CM_Janus_Server $server) {
+        $encodedStatus = $this->_request('GET', $server, '/status');
+        $status = CM_Params::decode($encodedStatus, true);
+        if (false == $status) {
+            throw new CM_Exception_Invalid('Cannot decode server status');
+        }
+        return $status;
+    }
+
+    /**
+     * @param string $method
+     * @param CM_Janus_Server $server
+     * @param string $path
+     * @param array|null $body
+     * @return string
+     * @throws CM_Exception_Invalid
+     */
+    protected function _request($method, CM_Janus_Server $server, $path, array $body = null) {
+        $url = 'http://' . $server->getHttpAddress() . $path;
+        $options = ['body' => $body];
+        $request = $this->_httpClient->createRequest($method, $url, $options);
+        try {
+            $response = $this->_httpClient->send($request);
+        } catch (GuzzleHttp\Exception\TransferException $e) {
+            throw new CM_Exception_Invalid('Fetching contents from `' . $url . '` failed: `' . $e->getMessage());
+        }
+        return $response->getBody();
+    }
+}

--- a/library/CM/Janus/HttpApiClient.php
+++ b/library/CM/Janus/HttpApiClient.php
@@ -19,7 +19,7 @@ class CM_Janus_HttpApiClient {
      * @throws CM_Exception_Invalid
      */
     public function stopStream(CM_Janus_Server $server, $clientKey) {
-        return $this->_request('POST', $server, '/stop', ['clientId' => (string) $clientKey]);
+        return $this->_request('POST', $server, '/stopStream', ['streamId' => (string) $clientKey]);
     }
 
     /**
@@ -45,7 +45,7 @@ class CM_Janus_HttpApiClient {
      * @throws CM_Exception_Invalid
      */
     protected function _request($method, CM_Janus_Server $server, $path, array $body = null) {
-        $url = 'http://' . $server->getHttpAddress() . $path;
+        $url = $server->getHttpAddress() . $path;
         $body = (array) $body;
         $body['token'] = $server->getToken();
         $options = ['body' => $body];

--- a/library/CM/Janus/HttpApiClient.php
+++ b/library/CM/Janus/HttpApiClient.php
@@ -45,7 +45,7 @@ class CM_Janus_HttpApiClient {
         $body = (array) $body;
         $options = [
             'body'    => $body,
-            'headers' => ['Api-Key' => $server->getToken()],
+            'headers' => ['Server-Key' => $server->getKey()],
         ];
         $request = $this->_httpClient->createRequest($method, $url, $options);
         try {

--- a/library/CM/Janus/HttpApiClient.php
+++ b/library/CM/Janus/HttpApiClient.php
@@ -46,6 +46,8 @@ class CM_Janus_HttpApiClient {
      */
     protected function _request($method, CM_Janus_Server $server, $path, array $body = null) {
         $url = 'http://' . $server->getHttpAddress() . $path;
+        $body = (array) $body;
+        $body['token'] = $server->getToken();
         $options = ['body' => $body];
         $request = $this->_httpClient->createRequest($method, $url, $options);
         try {

--- a/library/CM/Janus/RpcEndpoints.php
+++ b/library/CM/Janus/RpcEndpoints.php
@@ -1,0 +1,110 @@
+<?php
+
+class CM_Janus_RpcEndpoints {
+
+    /**
+     * @param string $token
+     * @param string $streamChannelKey
+     * @param string $streamKey
+     * @param int $start
+     * @param string $data
+     * @return array
+     * @throws CM_Exception_AuthFailed
+     * @throws CM_Exception_AuthRequired
+     * @throws CM_Exception_Invalid
+     * @throws CM_Exception_NotAllowed
+     * @throws Exception
+     */
+    public static function rpc_publish($token, $streamChannelKey, $streamKey, $start, $data) {
+        $janus = CM_Service_Manager::getInstance()->getJanus('janus');
+        self::_authenticate($janus, $token);
+
+        $params = CM_Params::factory(CM_Params::jsonDecode($data), true);
+        $server = $janus->getConfiguration()->findServerByToken($token);
+        $streamChannelType = $params->getInt('streamChannelType');
+        $session = new CM_Session($params->getString('sessionId'));
+        $user = $session->getUser(true);
+
+        $streamRepository = $janus->getStreamRepository();
+        $streamChannel = $streamRepository->createStreamChannel($streamChannelKey, $streamChannelType, $server->getId(), 0);
+        try {
+            $streamRepository->createStreamPublish($streamChannel, $user, $streamKey, $start);
+        } catch (CM_Exception_NotAllowed $ex) {
+            $streamChannel->delete();
+            throw $ex;
+        }
+        return ['streamChannelId' => $streamChannel->getId()];
+    }
+
+    /**
+     * @param string $token
+     * @param string $streamChannelKey
+     * @param string $streamKey
+     * @param string $start
+     * @param string $data
+     * @return bool
+     * @throws CM_Exception_AuthFailed
+     * @throws CM_Exception_AuthRequired
+     * @throws CM_Exception_Invalid
+     * @throws CM_Exception_Nonexistent
+     * @throws CM_Exception_NotAllowed
+     */
+    public static function rpc_subscribe($token, $streamChannelKey, $streamKey, $start, $data) {
+
+        $janus = CM_Service_Manager::getInstance()->getJanus('janus');
+        self::_authenticate($janus, $token);
+
+        $params = CM_Params::factory(CM_Params::jsonDecode($data), true);
+        $session = new CM_Session($params->getString('sessionId'));
+        $user = $session->getUser(true);
+
+        $streamRepository = $janus->getStreamRepository();
+        $streamChannel = $streamRepository->findStreamChannelByKey($streamChannelKey);
+        if (!$streamChannel) {
+            throw new CM_Exception_Nonexistent("Stream channel `{$streamChannelKey}` does not exists");
+        }
+        try {
+            $streamRepository->createStreamSubscribe($streamChannel, $user, $streamKey, $start);
+        } catch (CM_Exception_NotAllowed $exception) {
+            throw new CM_Exception_NotAllowed('Cannot subscribe: ' . $exception->getMessage());
+        }
+        return true;
+    }
+
+    /**
+     * @param string $token
+     * @param string $streamChannelKey
+     * @param string $streamKey
+     * @return bool
+     * @throws CM_Exception_AuthFailed
+     * @throws CM_Exception_Invalid
+     */
+    public static function rpc_removeStream($token, $streamChannelKey, $streamKey) {
+        $janus = CM_Service_Manager::getInstance()->getJanus('janus');
+        self::_authenticate($janus, $token);
+
+        $streamRepository = $janus->getStreamRepository();
+        $streamChannel = $streamRepository->findStreamChannelByKey($streamChannelKey);
+
+        $streamSubscribe = $streamChannel->getStreamSubscribes()->findKey($streamKey);
+        if ($streamSubscribe) {
+            $streamRepository->removeStream($streamSubscribe);
+        }
+        $streamPublish = $streamChannel->getStreamPublishs()->findKey($streamKey);
+        if ($streamPublish) {
+            $streamRepository->removeStream($streamSubscribe);
+        }
+        return true;
+    }
+
+    /**
+     * @param CM_Janus_Service $janus
+     * @param string $token
+     * @throws CM_Exception_AuthFailed
+     */
+    protected static function _authenticate(CM_Janus_Service $janus, $token) {
+        if (!$janus->getConfiguration()->findServerByToken($token)) {
+            throw new CM_Exception_AuthFailed('Invalid token');
+        }
+    }
+}

--- a/library/CM/Janus/RpcEndpoints.php
+++ b/library/CM/Janus/RpcEndpoints.php
@@ -3,7 +3,7 @@
 class CM_Janus_RpcEndpoints {
 
     /**
-     * @param string $token
+     * @param string $serverKey
      * @param string $streamChannelKey
      * @param string $streamKey
      * @param int    $start
@@ -15,15 +15,15 @@ class CM_Janus_RpcEndpoints {
      * @throws CM_Exception_NotAllowed
      * @throws Exception
      */
-    public static function rpc_publish($token, $streamChannelKey, $streamKey, $start, $data) {
+    public static function rpc_publish($serverKey, $streamChannelKey, $streamKey, $start, $data) {
         $janus = CM_Service_Manager::getInstance()->getJanus('janus');
-        self::_authenticate($janus, $token);
+        self::_authenticate($janus, $serverKey);
 
         $params = CM_Params::factory(CM_Params::jsonDecode($data), true);
-        $server = $janus->getConfiguration()->findServerByToken($token);
+        $server = $janus->getConfiguration()->findServerByserverKey($serverKey);
 
         if (!$server) {
-            throw new CM_Exception_Invalid('Server `' . $token . '` not found');
+            throw new CM_Exception_Invalid('Server `' . $serverKey . '` not found');
         }
 
         $streamChannelType = $params->getInt('streamChannelType');
@@ -42,7 +42,7 @@ class CM_Janus_RpcEndpoints {
     }
 
     /**
-     * @param string $token
+     * @param string $serverKey
      * @param string $streamChannelKey
      * @param string $streamKey
      * @param string $start
@@ -54,10 +54,10 @@ class CM_Janus_RpcEndpoints {
      * @throws CM_Exception_Nonexistent
      * @throws CM_Exception_NotAllowed
      */
-    public static function rpc_subscribe($token, $streamChannelKey, $streamKey, $start, $data) {
+    public static function rpc_subscribe($serverKey, $streamChannelKey, $streamKey, $start, $data) {
 
         $janus = CM_Service_Manager::getInstance()->getJanus('janus');
-        self::_authenticate($janus, $token);
+        self::_authenticate($janus, $serverKey);
 
         $params = CM_Params::factory(CM_Params::jsonDecode($data), true);
         $session = new CM_Session($params->getString('sessionId'));
@@ -77,16 +77,16 @@ class CM_Janus_RpcEndpoints {
     }
 
     /**
-     * @param string $token
+     * @param string $serverKey
      * @param string $streamChannelKey
      * @param string $streamKey
      * @return bool
      * @throws CM_Exception_AuthFailed
      * @throws CM_Exception_Invalid
      */
-    public static function rpc_removeStream($token, $streamChannelKey, $streamKey) {
+    public static function rpc_removeStream($serverKey, $streamChannelKey, $streamKey) {
         $janus = CM_Service_Manager::getInstance()->getJanus('janus');
-        self::_authenticate($janus, $token);
+        self::_authenticate($janus, $serverKey);
 
         $streamRepository = $janus->getStreamRepository();
         $streamChannel = $streamRepository->findStreamChannelByKey($streamChannelKey);
@@ -104,12 +104,12 @@ class CM_Janus_RpcEndpoints {
 
     /**
      * @param CM_Janus_Service $janus
-     * @param string           $token
+     * @param string           $serverKey
      * @throws CM_Exception_AuthFailed
      */
-    protected static function _authenticate(CM_Janus_Service $janus, $token) {
-        if (!$janus->getConfiguration()->findServerByToken($token)) {
-            throw new CM_Exception_AuthFailed('Invalid token');
+    protected static function _authenticate(CM_Janus_Service $janus, $serverKey) {
+        if (!$janus->getConfiguration()->findServerByKey($serverKey)) {
+            throw new CM_Exception_AuthFailed('Invalid serverKey');
         }
     }
 }

--- a/library/CM/Janus/RpcEndpoints.php
+++ b/library/CM/Janus/RpcEndpoints.php
@@ -6,7 +6,7 @@ class CM_Janus_RpcEndpoints {
      * @param string $token
      * @param string $streamChannelKey
      * @param string $streamKey
-     * @param int $start
+     * @param int    $start
      * @param string $data
      * @return array
      * @throws CM_Exception_AuthFailed
@@ -21,6 +21,11 @@ class CM_Janus_RpcEndpoints {
 
         $params = CM_Params::factory(CM_Params::jsonDecode($data), true);
         $server = $janus->getConfiguration()->findServerByToken($token);
+
+        if (!$server) {
+            throw new CM_Exception_Invalid('Server `' . $token . '` not found');
+        }
+
         $streamChannelType = $params->getInt('streamChannelType');
         $session = new CM_Session($params->getString('sessionId'));
         $user = $session->getUser(true);
@@ -99,7 +104,7 @@ class CM_Janus_RpcEndpoints {
 
     /**
      * @param CM_Janus_Service $janus
-     * @param string $token
+     * @param string           $token
      * @throws CM_Exception_AuthFailed
      */
     protected static function _authenticate(CM_Janus_Service $janus, $token) {

--- a/library/CM/Janus/RpcEndpoints.php
+++ b/library/CM/Janus/RpcEndpoints.php
@@ -20,7 +20,7 @@ class CM_Janus_RpcEndpoints {
         self::_authenticate($janus, $serverKey);
 
         $params = CM_Params::factory(CM_Params::jsonDecode($data), true);
-        $server = $janus->getConfiguration()->findServerByserverKey($serverKey);
+        $server = $janus->getConfiguration()->findServerByKey($serverKey);
 
         if (!$server) {
             throw new CM_Exception_Invalid('Server `' . $serverKey . '` not found');

--- a/library/CM/Janus/Server.php
+++ b/library/CM/Janus/Server.php
@@ -12,17 +12,17 @@ class CM_Janus_Server {
     protected $_webSocketAddress;
 
     /** @var string */
-    protected $_token;
+    protected $_key;
 
     /**
      * @param int $serverId
-     * @param string $token
+     * @param string $key
      * @param string $httpAddress
      * @param string $webSocketAddress
      */
-    public function __construct($serverId, $token, $httpAddress, $webSocketAddress) {
+    public function __construct($serverId, $key, $httpAddress, $webSocketAddress) {
         $this->_id = (int) $serverId;
-        $this->_token = (string) $token;
+        $this->_key = (string) $key;
         $this->_httpAddress = (string) $httpAddress;
         $this->_webSocketAddress = (string) $webSocketAddress;
     }
@@ -37,8 +37,8 @@ class CM_Janus_Server {
     /**
      * @return string
      */
-    public function getToken() {
-        return $this->_token;
+    public function getKey() {
+        return $this->_key;
     }
 
     /**

--- a/library/CM/Janus/Server.php
+++ b/library/CM/Janus/Server.php
@@ -1,0 +1,57 @@
+<?php
+
+class CM_Janus_Server {
+
+    /** @var int */
+    protected $_id;
+
+    /** @var string */
+    protected $_httpAddress;
+
+    /** @var string */
+    protected $_webSocketAddress;
+
+    /** @var string */
+    protected $_token;
+
+    /**
+     * @param int $serverId
+     * @param string $token
+     * @param string $httpAddress
+     * @param string $webSocketAddress
+     */
+    public function __construct($serverId, $token, $httpAddress, $webSocketAddress) {
+        $this->_id = (int) $serverId;
+        $this->_token = (string) $token;
+        $this->_httpAddress = (string) $httpAddress;
+        $this->_webSocketAddress = (int) $webSocketAddress;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId() {
+        return $this->_id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getToken() {
+        return $this->_token;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHttpAddress() {
+        return $this->_httpAddress;
+    }
+
+    /**
+     * @return string
+     */
+    public function getWebSocketAddress() {
+        return $this->_webSocketAddress;
+    }
+}

--- a/library/CM/Janus/Server.php
+++ b/library/CM/Janus/Server.php
@@ -24,7 +24,7 @@ class CM_Janus_Server {
         $this->_id = (int) $serverId;
         $this->_token = (string) $token;
         $this->_httpAddress = (string) $httpAddress;
-        $this->_webSocketAddress = (int) $webSocketAddress;
+        $this->_webSocketAddress = (string) $webSocketAddress;
     }
 
     /**

--- a/library/CM/Janus/Service.php
+++ b/library/CM/Janus/Service.php
@@ -1,0 +1,56 @@
+<?php
+
+class CM_Janus_Service extends CM_MediaStreams_Service {
+
+    /** @var CM_Janus_Configuration */
+    protected $_configuration;
+
+    /** @var CM_Janus_HttpApiClient */
+    protected $_httpApiClient;
+
+    /**
+     * @param CM_Janus_Configuration $configuration
+     * @param CM_Janus_HttpApiClient $httpClient
+     * @param CM_MediaStreams_StreamRepository|null $streamRepository
+     */
+    public function __construct(CM_Janus_Configuration $configuration, CM_Janus_HttpApiClient $httpClient, CM_MediaStreams_StreamRepository $streamRepository = null) {
+        $this->_configuration = $configuration;
+        $this->_httpApiClient = $httpClient;
+        parent::__construct($streamRepository);
+    }
+
+    public function synchronize() {
+        throw new CM_Exception_NotImplemented();
+    }
+
+    /**
+     * @return CM_Janus_Configuration
+     */
+    public function getConfiguration() {
+        return $this->_configuration;
+    }
+
+    /**
+     * @return CM_Janus_Stream[]
+     * @throws CM_Exception_Invalid
+     */
+    protected function _fetchStatus() {
+        $status = [];
+        foreach ($this->_configuration->getServers() as $server) {
+            foreach ($this->_httpApiClient->fetchStatus($server) as $streamInfo) {
+                $status[] = new CM_Janus_Stream($streamInfo['streamKey'], $streamInfo['streamChannelKey'], $server);
+            }
+        }
+        return $status;
+    }
+
+    /**
+     * @param CM_Model_Stream_Abstract $stream
+     */
+    protected function _stopStream(CM_Model_Stream_Abstract $stream) {
+        /** @var $streamChannel CM_Model_StreamChannel_Media */
+        $streamChannel = $stream->getStreamChannel();
+        $server = $this->_configuration->getServer($streamChannel->getServerId());
+        $this->_httpApiClient->stopStream($server, $stream->getKey());
+    }
+}

--- a/library/CM/Janus/Service.php
+++ b/library/CM/Janus/Service.php
@@ -46,11 +46,16 @@ class CM_Janus_Service extends CM_MediaStreams_Service {
 
     /**
      * @param CM_Model_Stream_Abstract $stream
+     * @throws CM_Exception_Invalid
+     * @throws CM_Janus_StopStreamError
      */
     protected function _stopStream(CM_Model_Stream_Abstract $stream) {
         /** @var $streamChannel CM_Model_StreamChannel_Media */
         $streamChannel = $stream->getStreamChannel();
         $server = $this->_configuration->getServer($streamChannel->getServerId());
-        $this->_httpApiClient->stopStream($server, $stream->getKey());
+        $result = $this->_httpApiClient->stopStream($server, $stream->getKey());
+        if (array_key_exists('error', $result)) {
+            throw new CM_Janus_StopStreamError($result['error']);
+        }
     }
 }

--- a/library/CM/Janus/StopStreamError.php
+++ b/library/CM/Janus/StopStreamError.php
@@ -1,0 +1,5 @@
+<?php
+
+class CM_Janus_StopStreamError extends CM_Exception {
+
+}

--- a/library/CM/Janus/Stream.php
+++ b/library/CM/Janus/Stream.php
@@ -1,0 +1,45 @@
+<?php
+
+class CM_Janus_Stream {
+
+    /** @var string */
+    protected $_streamKey;
+
+    /** @var string */
+    protected $_streamChannelKey;
+
+    /** @var CM_Janus_Server */
+    protected $_server;
+
+    /**
+     * @param string $streamKey
+     * @param string $streamChannelKey
+     * @param CM_Janus_Server $server
+     */
+    public function __construct($streamKey, $streamChannelKey, CM_Janus_Server $server) {
+        $this->_streamKey = $streamKey;
+        $this->_streamChannelKey = $streamChannelKey;
+        $this->_server = $server;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStreamKey() {
+        return $this->_streamKey;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStreamChannelKey() {
+        return $this->_streamChannelKey;
+    }
+
+    /**
+     * @return CM_Janus_Server
+     */
+    public function getServer() {
+        return $this->_server;
+    }
+}

--- a/library/CM/Service/Manager.php
+++ b/library/CM/Service/Manager.php
@@ -199,6 +199,15 @@ class CM_Service_Manager extends CM_Class_Abstract {
     }
 
     /**
+     * @param string $serviceName
+     * @return CM_Janus_Service
+     * @throws CM_Exception_Invalid
+     */
+    public function getJanus($serviceName) {
+        return $this->get($serviceName, 'CM_Janus_Service');
+    }
+
+    /**
      * @return CM_Memcache_Client
      */
     public function getMemcache() {

--- a/tests/library/CM/Janus/ConfigurationTest.php
+++ b/tests/library/CM/Janus/ConfigurationTest.php
@@ -10,9 +10,9 @@ class CM_Janus_ConfigurationTest extends CMTest_TestCase {
 
         $configuration = new CM_Janus_Configuration([$server1, $server2]);
 
-        $this->assertSame($server1, $configuration->findServerByToken('foo'));
-        $this->assertSame($server2, $configuration->findServerByToken('bar'));
-        $this->assertSame(null, $configuration->findServerByToken('zoo'));
+        $this->assertSame($server1, $configuration->findServerByKey('foo'));
+        $this->assertSame($server2, $configuration->findServerByKey('bar'));
+        $this->assertSame(null, $configuration->findServerByKey('zoo'));
     }
 
     public function testGetServer() {

--- a/tests/library/CM/Janus/ConfigurationTest.php
+++ b/tests/library/CM/Janus/ConfigurationTest.php
@@ -4,9 +4,9 @@ class CM_Janus_ConfigurationTest extends CMTest_TestCase {
 
     public function testFindServerByToken() {
         $server1 = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();
-        $server1->mockMethod('getToken')->set('foo');
+        $server1->mockMethod('getKey')->set('foo');
         $server2 = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();
-        $server2->mockMethod('getToken')->set('bar');
+        $server2->mockMethod('getKey')->set('bar');
 
         $configuration = new CM_Janus_Configuration([$server1, $server2]);
 

--- a/tests/library/CM/Janus/ConfigurationTest.php
+++ b/tests/library/CM/Janus/ConfigurationTest.php
@@ -2,7 +2,7 @@
 
 class CM_Janus_ConfigurationTest extends CMTest_TestCase {
 
-    public function testFindServerByToken() {
+    public function testFindServerByKey() {
         $server1 = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();
         $server1->mockMethod('getKey')->set('foo');
         $server2 = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();

--- a/tests/library/CM/Janus/ConfigurationTest.php
+++ b/tests/library/CM/Janus/ConfigurationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+class CM_Janus_ConfigurationTest extends CMTest_TestCase {
+
+    public function testFindServerByToken() {
+        $server1 = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();
+        $server1->mockMethod('getToken')->set('foo');
+        $server2 = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();
+        $server2->mockMethod('getToken')->set('bar');
+
+        $configuration = new CM_Janus_Configuration([$server1, $server2]);
+
+        $this->assertSame($server1, $configuration->findServerByToken('foo'));
+        $this->assertSame($server2, $configuration->findServerByToken('bar'));
+        $this->assertSame(null, $configuration->findServerByToken('zoo'));
+    }
+
+    public function testGetServer() {
+        $server = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();
+        $server->mockMethod('getId')->set(1);
+        $configuration = new CM_Janus_Configuration([$server]);
+
+        $this->assertSame($server, $configuration->getServer(1));
+
+        $exception = $this->catchException(function () use ($configuration) {
+            $configuration->getServer(2);
+        });
+        $this->assertTrue($exception instanceof CM_Exception_Invalid);
+        $this->assertSame('Cannot find server with id `2`', $exception->getMessage());
+    }
+}

--- a/tests/library/CM/Janus/FactorytTest.php
+++ b/tests/library/CM/Janus/FactorytTest.php
@@ -15,7 +15,7 @@ class CM_Janus_FactoryTest extends CMTest_TestCase {
         $servers = $janus->getConfiguration()->getServers();
         $this->assertCount(1, $servers);
         $this->assertSame(5, $servers[0]->getId());
-        $this->assertSame('foo-bar', $servers[0]->getToken());
+        $this->assertSame('foo-bar', $servers[0]->getKey());
         $this->assertSame('http://cm-janus.dev:8080', $servers[0]->getHttpAddress());
         $this->assertSame('ws://cm-janus.dev:8188', $servers[0]->getWebSocketAddress());
     }

--- a/tests/library/CM/Janus/FactorytTest.php
+++ b/tests/library/CM/Janus/FactorytTest.php
@@ -1,0 +1,22 @@
+<?php
+
+class CM_Janus_FactoryTest extends CMTest_TestCase {
+
+    public function testCreateService() {
+        $serversConfig = [
+            5 => [
+                'token'            => 'foo-bar',
+                'httpAddress'      => 'http://cm-janus.dev:8080',
+                'webSocketAddress' => 'ws://cm-janus.dev:8188',
+            ],
+        ];
+        $factory = new CM_Janus_Factory();
+        $janus = $factory->createService($serversConfig);
+        $servers = $janus->getConfiguration()->getServers();
+        $this->assertCount(1, $servers);
+        $this->assertSame(5, $servers[0]->getId());
+        $this->assertSame('foo-bar', $servers[0]->getToken());
+        $this->assertSame('http://cm-janus.dev:8080', $servers[0]->getHttpAddress());
+        $this->assertSame('ws://cm-janus.dev:8188', $servers[0]->getWebSocketAddress());
+    }
+}

--- a/tests/library/CM/Janus/FactorytTest.php
+++ b/tests/library/CM/Janus/FactorytTest.php
@@ -5,7 +5,7 @@ class CM_Janus_FactoryTest extends CMTest_TestCase {
     public function testCreateService() {
         $serversConfig = [
             5 => [
-                'token'            => 'foo-bar',
+                'key'            => 'foo-bar',
                 'httpAddress'      => 'http://cm-janus.dev:8080',
                 'webSocketAddress' => 'ws://cm-janus.dev:8188',
             ],

--- a/tests/library/CM/Janus/HttpApiClientTest.php
+++ b/tests/library/CM/Janus/HttpApiClientTest.php
@@ -1,0 +1,42 @@
+<?php
+
+class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
+
+    public function testStopStream() {
+        $httpClient = $this->mockObject('GuzzleHttp\Client');
+        $sendRequestMethod = $httpClient->mockMethod('send')->set(function (\GuzzleHttp\Message\RequestInterface $request) {
+            $this->assertSame('http://cm-janus.dev:8080/stopStream', $request->getUrl());
+            $this->assertSame('POST', $request->getMethod());
+            $this->assertSame('streamId=foo&token=bar', $request->getBody()->getContents());
+
+            $response = $this->mockClass('\GuzzleHttp\Message\Response')->newInstanceWithoutConstructor();
+            $response->mockMethod('getBody')->set(null);
+            return $response;
+        });
+        /** @var GuzzleHttp\Client $httpClient */
+
+        $server = new CM_Janus_Server(0, 'bar', 'http://cm-janus.dev:8080', 'ws://cm-janus.dev:8188');
+        $api = new CM_Janus_HttpApiClient($httpClient);
+        $api->stopStream($server, 'foo');
+        $this->assertSame(1, $sendRequestMethod->getCallCount());
+    }
+
+    public function testFetchStatus() {
+        $httpClient = $this->mockObject('GuzzleHttp\Client');
+        $sendRequestMethod = $httpClient->mockMethod('send')->set(function (\GuzzleHttp\Message\RequestInterface $request) {
+            $this->assertSame('http://cm-janus.dev:8080/status', $request->getUrl());
+            $this->assertSame('GET', $request->getMethod());
+
+            $response = $this->mockClass('\GuzzleHttp\Message\Response')->newInstanceWithoutConstructor();
+            $response->mockMethod('getBody')->set('{"foo":"bar"}');
+            return $response;
+        });
+        /** @var GuzzleHttp\Client $httpClient */
+
+        $server = new CM_Janus_Server(0, 'bar', 'http://cm-janus.dev:8080', 'ws://cm-janus.dev:8188');
+        $api = new CM_Janus_HttpApiClient($httpClient);
+        $result = $api->fetchStatus($server);
+        $this->assertSame(['foo' => 'bar'], $result);
+        $this->assertSame(1, $sendRequestMethod->getCallCount());
+    }
+}

--- a/tests/library/CM/Janus/HttpApiClientTest.php
+++ b/tests/library/CM/Janus/HttpApiClientTest.php
@@ -7,7 +7,8 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
         $sendRequestMethod = $httpClient->mockMethod('send')->set(function (\GuzzleHttp\Message\RequestInterface $request) {
             $this->assertSame('http://cm-janus.dev:8080/stopStream', $request->getUrl());
             $this->assertSame('POST', $request->getMethod());
-            $this->assertSame('streamId=foo&token=bar', $request->getBody()->getContents());
+            $this->assertSame('streamId=foo', $request->getBody()->getContents());
+            $this->assertSame($request->getHeader('Api-Key'), 'bar');
 
             $response = $this->mockClass('\GuzzleHttp\Message\Response')->newInstanceWithoutConstructor();
             $response->mockMethod('getBody')->set(null);
@@ -26,6 +27,7 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
         $sendRequestMethod = $httpClient->mockMethod('send')->set(function (\GuzzleHttp\Message\RequestInterface $request) {
             $this->assertSame('http://cm-janus.dev:8080/status', $request->getUrl());
             $this->assertSame('GET', $request->getMethod());
+            $this->assertSame($request->getHeader('Api-Key'), 'bar');
 
             $response = $this->mockClass('\GuzzleHttp\Message\Response')->newInstanceWithoutConstructor();
             $response->mockMethod('getBody')->set('{"foo":"bar"}');

--- a/tests/library/CM/Janus/HttpApiClientTest.php
+++ b/tests/library/CM/Janus/HttpApiClientTest.php
@@ -8,7 +8,7 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
             $this->assertSame('http://cm-janus.dev:8080/stopStream', $request->getUrl());
             $this->assertSame('POST', $request->getMethod());
             $this->assertSame('streamId=foo', $request->getBody()->getContents());
-            $this->assertSame('bar', $request->getHeader('Api-Key'));
+            $this->assertSame('bar', $request->getHeader('Server-Key'));
 
             $response = $this->mockClass('\GuzzleHttp\Message\Response')->newInstanceWithoutConstructor();
             $response->mockMethod('getBody')->set(null);
@@ -27,7 +27,7 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
         $sendRequestMethod = $httpClient->mockMethod('send')->set(function (\GuzzleHttp\Message\RequestInterface $request) {
             $this->assertSame('http://cm-janus.dev:8080/status', $request->getUrl());
             $this->assertSame('GET', $request->getMethod());
-            $this->assertSame('bar', $request->getHeader('Api-Key'));
+            $this->assertSame('bar', $request->getHeader('Server-Key'));
 
             $response = $this->mockClass('\GuzzleHttp\Message\Response')->newInstanceWithoutConstructor();
             $response->mockMethod('getBody')->set('{"foo":"bar"}');

--- a/tests/library/CM/Janus/HttpApiClientTest.php
+++ b/tests/library/CM/Janus/HttpApiClientTest.php
@@ -8,7 +8,7 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
             $this->assertSame('http://cm-janus.dev:8080/stopStream', $request->getUrl());
             $this->assertSame('POST', $request->getMethod());
             $this->assertSame('streamId=foo', $request->getBody()->getContents());
-            $this->assertSame($request->getHeader('Api-Key'), 'bar');
+            $this->assertSame('bar', $request->getHeader('Api-Key'));
 
             $response = $this->mockClass('\GuzzleHttp\Message\Response')->newInstanceWithoutConstructor();
             $response->mockMethod('getBody')->set(null);
@@ -27,7 +27,7 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
         $sendRequestMethod = $httpClient->mockMethod('send')->set(function (\GuzzleHttp\Message\RequestInterface $request) {
             $this->assertSame('http://cm-janus.dev:8080/status', $request->getUrl());
             $this->assertSame('GET', $request->getMethod());
-            $this->assertSame($request->getHeader('Api-Key'), 'bar');
+            $this->assertSame('bar', $request->getHeader('Api-Key'));
 
             $response = $this->mockClass('\GuzzleHttp\Message\Response')->newInstanceWithoutConstructor();
             $response->mockMethod('getBody')->set('{"foo":"bar"}');

--- a/tests/library/CM/Janus/ServiceTest.php
+++ b/tests/library/CM/Janus/ServiceTest.php
@@ -1,0 +1,72 @@
+<?php
+
+class CM_Janus_ServiceTest extends CMTest_TestCase {
+
+    public function testFetchStatus() {
+        $configuration = new CM_Janus_Configuration();
+        foreach ([1, 5] as $serverId) {
+            $server = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();
+            $server->mockMethod('getId')->set($serverId);
+            /** @var CM_Janus_Server $server */
+            $configuration->addServer($server);
+        }
+        $httpApiClient = $this->mockClass('CM_Janus_HttpApiClient')->newInstanceWithoutConstructor();
+        $httpApiClient->mockMethod('fetchStatus')->set(function (CM_Janus_Server $server) {
+            switch ($server->getId()) {
+                case 1:
+                    return [
+                        ['streamKey' => 'stream-foo', 'streamChannelKey' => 'channel-foo'],
+                    ];
+                case 5:
+                    return [
+                        ['streamKey' => 'stream-bar', 'streamChannelKey' => 'channel-bar'],
+                        ['streamKey' => 'stream-zoo', 'streamChannelKey' => 'channel-zoo'],
+                    ];
+            }
+        });
+        /** @var CM_Janus_HttpApiClient $httpApiClient */
+
+        $janus = new CM_Janus_Service($configuration, $httpApiClient);
+        /** @var CM_Janus_Stream[] $streams */
+        $streams = $this->callProtectedMethod($janus, '_fetchStatus');
+        $this->assertContainsOnlyInstancesOf('CM_Janus_Stream', $streams);
+        $this->assertCount(3, $streams);
+
+        $this->assertSame($configuration->getServer(1), $streams[0]->getServer());
+        $this->assertSame('stream-foo', $streams[0]->getStreamKey());
+        $this->assertSame('channel-foo', $streams[0]->getStreamChannelKey());
+
+        $this->assertSame($configuration->getServer(5), $streams[1]->getServer());
+        $this->assertSame('stream-bar', $streams[1]->getStreamKey());
+        $this->assertSame('channel-bar', $streams[1]->getStreamChannelKey());
+
+        $this->assertSame($configuration->getServer(5), $streams[2]->getServer());
+        $this->assertSame('stream-zoo', $streams[2]->getStreamKey());
+        $this->assertSame('channel-zoo', $streams[2]->getStreamChannelKey());
+    }
+
+    public function testStopStream() {
+        $streamChannel = $this->mockClass('CM_Model_StreamChannel_Abstract')->newInstanceWithoutConstructor();
+        $streamChannel->mockMethod('getServerId')->set(1);
+
+        $stream = $this->mockClass('CM_Model_Stream_Abstract')->newInstanceWithoutConstructor();
+        $stream->mockMethod('getStreamChannel')->set($streamChannel);
+        $stream->mockMethod('getKey')->set('foo');
+
+        $server = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();
+        $server->mockMethod('getId')->set(1);
+
+        $configuration = new CM_Janus_Configuration([$server]);
+
+        $httpApiClient = $this->mockClass('CM_Janus_HttpApiClient')->newInstanceWithoutConstructor();
+        $stopStreamMethod = $httpApiClient->mockMethod('stopStream')->set(function (CM_Janus_Server $passedServer, $streamKey) use ($server) {
+            $this->assertSame($server, $passedServer);
+            $this->assertSame('foo', $streamKey);
+        });
+        /** @var CM_Janus_HttpApiClient $httpApiClient */
+
+        $janus = new CM_Janus_Service($configuration, $httpApiClient);
+        $this->callProtectedMethod($janus, '_stopStream', [$stream]);
+        $this->assertSame(1, $stopStreamMethod->getCallCount());
+    }
+}


### PR DESCRIPTION
- Can be dummy
- Separate service instances for video/audio?

Used for:
- Expose registered [`cm-janus`](https://github.com/cargomedia/cm-janus/issues/4) instances
- Disabling functionality in dev VMs (not register service?)
