### PR TITLE
Fix CM_Elasticsearch_Client error handling

### DIFF
--- a/tests/library/CM/Elasticsearch/ClientTest.php
+++ b/tests/library/CM/Elasticsearch/ClientTest.php
@@ -169,6 +169,8 @@ class CM_Elasticsearch_ClientTest extends CMTest_TestCase {
         $typeName = 'typeName';
         $cmClient->deleteIndex($indexName);
         $cmClient->createIndex($indexName, $typeName, [], [], false);
+        $cmClient->awaitReady();
+
         $this->assertSame(0, $cmClient->count($indexName, $typeName));
 
         $cmClient->bulkAddDocuments([new CM_Elasticsearch_Document('3', ['11' => '22'])], $indexName, $typeName);


### PR DESCRIPTION
Currently we handle 503 ElasticSearch errors which are not errors by nature but only a consequence of delayed shard initialization (and this error occurs only during tests execution)
Author of elasticsearch-php library advised to insert awaiting block to tests
```
 $client->cluster()->health([
  'wait_for_status' => 'yellow'
]);
 ```
and then we will be able to remove mentioned error handling from CM_Elasticsearch_Client