### PR TITLE
set user's currency as environment-currency

### DIFF
--- a/library/CM/Frontend/Environment.php
+++ b/library/CM/Frontend/Environment.php
@@ -175,9 +175,13 @@ class CM_Frontend_Environment extends CM_Class_Abstract {
     }
 
     /**
-     * @return CM_Model_Currency|null
+     * @return CM_Model_Currency
      */
     public function getCurrency() {
-        return $this->_currency;
+        $currency = $this->_currency;
+        if (null === $currency) {
+            $currency = CM_Model_Currency::getDefaultCurrency();
+        }
+        return $currency;
     }
 }

--- a/library/CM/Http/Response/Abstract.php
+++ b/library/CM/Http/Response/Abstract.php
@@ -115,8 +115,15 @@ abstract class CM_Http_Response_Abstract extends CM_Class_Abstract implements CM
      */
     public function getEnvironment() {
         $location = $this->getRequest()->getLocation();
-        $currency = (null !== $location) ? CM_Model_Currency::findByLocation($location) : null;
-        return new CM_Frontend_Environment($this->getSite(), $this->getRequest()->getViewer(), $this->getRequest()->getLanguage(), null, null, $location, $currency);
+        $viewer = $this->getRequest()->getViewer();
+        $currency = null;
+        if (null === $currency && null !== $viewer) {
+            $currency = $viewer->getCurrency();
+        }
+        if (null === $currency && null !== $location) {
+            $currency = CM_Model_Currency::findByLocation($location);
+        }
+        return new CM_Frontend_Environment($this->getSite(), $viewer, $this->getRequest()->getLanguage(), null, null, $location, $currency);
     }
 
     /**

--- a/tests/library/CM/Frontend/EnvironmentTest.php
+++ b/tests/library/CM/Frontend/EnvironmentTest.php
@@ -2,6 +2,10 @@
 
 class CM_Frontend_EnvironmentTest extends CMTest_TestCase {
 
+    public function tearDown() {
+        CMTest_TH::clearEnv();
+    }
+
     public function testGetters() {
         $site = CM_Site_Abstract::factory();
         $user = CM_Model_User::createStatic();
@@ -23,6 +27,7 @@ class CM_Frontend_EnvironmentTest extends CMTest_TestCase {
     }
 
     public function testSetNull() {
+        $defaultCurrency = CM_Model_Currency::create('840', 'USD');
         $environment = new CM_Frontend_Environment();
         $this->assertEquals(CM_Site_Abstract::factory(), $environment->getSite());
         $this->assertNull($environment->getViewer());
@@ -31,7 +36,7 @@ class CM_Frontend_EnvironmentTest extends CMTest_TestCase {
         $this->assertEquals(CM_Bootloader::getInstance()->getTimeZone(), $environment->getTimeZone());
         $this->assertSame(CM_Bootloader::getInstance()->isDebug(), $environment->isDebug());
         $this->assertNull($environment->getLocation());
-        $this->assertNull($environment->getCurrency());
+        $this->assertEquals($defaultCurrency, $environment->getCurrency());
     }
 
     /**

--- a/tests/library/CM/Http/Response/PageTest.php
+++ b/tests/library/CM/Http/Response/PageTest.php
@@ -147,10 +147,11 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
     }
 
     public function testProcessTrackingViewer() {
-        $viewer = $this->getMock('CM_Model_User', array('getIdRaw', 'getVisible', 'getLanguage'));
+        $viewer = $this->getMock('CM_Model_User', array('getIdRaw', 'getVisible', 'getLanguage', 'getCurrency'));
         $viewer->expects($this->any())->method('getIdRaw')->will($this->returnValue(array('id' => '1')));
         $viewer->expects($this->any())->method('getVisible')->will($this->returnValue(false));
         $viewer->expects($this->any())->method('getLanguage')->will($this->returnValue(null));
+        $viewer->expects($this->any())->method('getCurrency')->will($this->returnValue(null));
         /** @var CM_Model_User $viewer */
         $response = CMTest_TH::createResponsePage('/mock5', null, $viewer);
         $response->setServiceManager($this->_getServiceManager('ga123', 'km123'));


### PR DESCRIPTION
So environment-currency can be used throughout views. 
Simplifies things for views that need a currency but not necessarily a viewer.