### PR TITLE
make encryption url-safe

### DIFF
--- a/library/CM/Util/Encryption.php
+++ b/library/CM/Util/Encryption.php
@@ -9,7 +9,8 @@ class CM_Util_Encryption {
      */
     public function encrypt($data, $secretKey) {
         $this->_validateKey($secretKey);
-        return strtr(base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $secretKey, $data, MCRYPT_MODE_ECB)), '+=/', '-_.');
+        $encrypted = base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $secretKey, $data, MCRYPT_MODE_ECB));
+        return strtr($encrypted, '+=/', '-_.'); // substitute URI reserved characters
     }
 
     /**

--- a/library/CM/Util/Encryption.php
+++ b/library/CM/Util/Encryption.php
@@ -9,7 +9,7 @@ class CM_Util_Encryption {
      */
     public function encrypt($data, $secretKey) {
         $this->_validateKey($secretKey);
-        return base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $secretKey, $data, MCRYPT_MODE_ECB));
+        return strtr(base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $secretKey, $data, MCRYPT_MODE_ECB)), '+=/', '-_.');
     }
 
     /**
@@ -19,7 +19,7 @@ class CM_Util_Encryption {
      */
     public function decrypt($data, $secretKey) {
         $this->_validateKey($secretKey);
-        return rtrim(mcrypt_decrypt(MCRYPT_RIJNDAEL_128, $secretKey, base64_decode($data), MCRYPT_MODE_ECB), "\0");
+        return rtrim(mcrypt_decrypt(MCRYPT_RIJNDAEL_128, $secretKey, base64_decode(strtr($data, '-_.', '+=/')), MCRYPT_MODE_ECB), "\0");
     }
 
     /**

--- a/tests/library/CM/Model/StreamChannel/AbstractTest.php
+++ b/tests/library/CM/Model/StreamChannel/AbstractTest.php
@@ -198,7 +198,6 @@ class CM_Model_StreamChannel_AbstractTest extends CMTest_TestCase {
         $encryptMethod = new ReflectionMethod('CM_Model_StreamChannel_Abstract', '_encryptKey');
         $encryptMethod->setAccessible(true);
         $encryptedData = $encryptMethod->invoke(null, $data, $encryptionKey);
-        $this->assertNotSame(false, base64_decode($encryptedData, true), 'Encrypted data is not valid base64 string');
 
         $streamChannel = $this->getMockBuilder('CM_Model_StreamChannel_Abstract')->setMethods(array('getKey'))->disableOriginalConstructor()->getMockForAbstractClass();
         $streamChannel->expects($this->any())->method('getKey')->will($this->returnValue($encryptedData));

--- a/tests/library/CM/Util/EncryptionTest.php
+++ b/tests/library/CM/Util/EncryptionTest.php
@@ -23,8 +23,15 @@ class CM_Util_EncryptionTest extends CMTest_TestCase {
         $plain = 'highlySecretData';
         $encryption = new CM_Util_Encryption();
         $encrypted = $encryption->encrypt($plain, $encryptionKey);
-        $this->assertNotSame(false, base64_decode($encrypted, true), 'Encrypted data is not valid base64 string');
         $this->assertNotEquals($plain, $encryption->decrypt($encrypted, str_replace('1', '2', $encryptionKey)));
         $this->assertSame($plain, $encryption->decrypt($encrypted, $encryptionKey));
+    }
+
+    public function testUrlSafeEncryption() {
+        $encryptionKey = 'aaaabaaaaaaaaaab';
+        $plain = '{"user":2,"expiration":1449847146}';
+        $encryption = new CM_Util_Encryption();
+        $encrypted = $encryption->encrypt($plain, $encryptionKey);
+        $this->assertTrue(!preg_match('!/|\+|=!', $encrypted), 'Not url-safe');
     }
 }


### PR DESCRIPTION
`+/=` are not url-safe, see http://stackoverflow.com/questions/1374753/passing-base64-encoded-strings-in-url/5835352#5835352