### PR TITLE
Add a method to retrieve the default Janus Server

### DIFF
--- a/library/CM/Janus/Configuration.php
+++ b/library/CM/Janus/Configuration.php
@@ -56,4 +56,16 @@ class CM_Janus_Configuration {
         }
         throw new CM_Exception_Invalid('Cannot find server with id `' . $id . '`');
     }
+
+    /**
+     * @return CM_Janus_Server
+     * @throws CM_Exception_Invalid
+     */
+    public function getServerRandom() {
+        $servers = $this->_servers;
+        if (empty($servers)) {
+            throw new CM_Exception_Invalid('No servers configured');
+        }
+        return $servers[array_rand($servers)];
+    }
 }

--- a/library/CM/Janus/Service.php
+++ b/library/CM/Janus/Service.php
@@ -77,18 +77,6 @@ class CM_Janus_Service extends CM_MediaStreams_Service {
     }
 
     /**
-     * @return CM_Janus_Server
-     * @throws CM_Exception_Invalid
-     */
-    public function getRandomServer() {
-        $servers = $this->_configuration->getServers();
-        if (empty($servers)) {
-            throw new CM_Exception_Invalid('No Janus servers configured');
-        }
-        return $servers[array_rand($servers)];
-    }
-
-    /**
      * @return CM_Janus_Stream[]
      * @throws CM_Exception_Invalid
      */

--- a/library/CM/Janus/Service.php
+++ b/library/CM/Janus/Service.php
@@ -77,6 +77,18 @@ class CM_Janus_Service extends CM_MediaStreams_Service {
     }
 
     /**
+     * @return CM_Janus_Server
+     * @throws CM_Exception_Invalid
+     */
+    public function getRandomServer() {
+        $servers = $this->_configuration->getServers();
+        if (empty($servers)) {
+            throw new CM_Exception_Invalid('No Janus servers configured');
+        }
+        return $servers[array_rand($servers)];
+    }
+
+    /**
      * @return CM_Janus_Stream[]
      * @throws CM_Exception_Invalid
      */


### PR DESCRIPTION
It's not very convient to know which Janus server should be used, I need to get janus config to connect the CamShow.

I'm currently doing something like this:
```
$serviceManager = CM_Service_Manager::getInstance();
$janus = $serviceManager->getJanus('janus');
$janusServer = $janus->getConfiguration()->getServer(0));        
```

- why i have to pass the `serviceName` to `getJanus()`?
- how can i know which server i should use? this is not about load balancing? should it be transparent at my level?