### PR TITLE
Don't catch InvalidParam in RPC endpoint

### DIFF
--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -61,9 +61,9 @@ return function (CM_Config_Node $config) {
     $config->CM_Http_Response_View_Abstract->catchPublicExceptions = true;
 
     $config->CM_Http_Response_RPC->exceptionsToCatch = array(
-        'CM_Exception_InvalidParam' => [],
-        'CM_Exception_AuthRequired' => [],
-        'CM_Exception_NotAllowed'   => [],
+        'CM_Exception_InvalidParam' => ['log' => 'CM_Paging_Log_NotFound'],
+        'CM_Exception_AuthRequired' => ['log' => 'CM_Paging_Log_NotFound'],
+        'CM_Exception_NotAllowed'   => ['log' => 'CM_Paging_Log_NotFound'],
     );
     $config->CM_Http_Response_RPC->catchPublicExceptions = true;
 


### PR DESCRIPTION
We experienced some "blindness" because of this catching. I suggest to *not* catch InvalidParam, so that it gets logged and is more visible.

@alexispeter @zazabe please review