### PR TITLE
CM_Janus_RpcEndpoints: Call to a member function getStreamSubscribes() on a non-object in 

### DIFF
--- a/library/CM/Janus/RpcEndpoints.php
+++ b/library/CM/Janus/RpcEndpoints.php
@@ -83,6 +83,10 @@ class CM_Janus_RpcEndpoints {
         $streamRepository = $janus->getStreamRepository();
         $streamChannel = $streamRepository->findStreamChannelByKey($streamChannelKey);
 
+        if (null === $streamChannel) {
+            return;
+        }
+
         $streamSubscribe = $streamChannel->getStreamSubscribes()->findKey($streamKey);
         if ($streamSubscribe) {
             $streamRepository->removeStream($streamSubscribe);

--- a/library/CM/Janus/RpcEndpoints.php
+++ b/library/CM/Janus/RpcEndpoints.php
@@ -82,11 +82,9 @@ class CM_Janus_RpcEndpoints {
 
         $streamRepository = $janus->getStreamRepository();
         $streamChannel = $streamRepository->findStreamChannelByKey($streamChannelKey);
-
         if (null === $streamChannel) {
             return;
         }
-
         $streamSubscribe = $streamChannel->getStreamSubscribes()->findKey($streamKey);
         if ($streamSubscribe) {
             $streamRepository->removeStream($streamSubscribe);


### PR DESCRIPTION
```
ErrorException: E_ERROR: Call to a member function getStreamSubscribes() on a non-object in /home/fuckbook/releases/20151216140930/vendor/cargomedia/cm/library/CM/Janus/RpcEndpoints.php on line 86
    0. {main} /home/fuckbook/serve/public/index.php:0
    1. [internal function] 
```

@fvovan @tomaszdurka can you look into this?