### PR TITLE
Janus' checkStreams not working

### DIFF
--- a/library/CM/Maintenance/Cli.php
+++ b/library/CM/Maintenance/Cli.php
@@ -79,8 +79,11 @@ class CM_Maintenance_Cli extends CM_Cli_Runnable_Abstract {
 
         if ($this->getServiceManager()->has('janus')) {
             $this->_registerClockworkCallbacks('1 minute', array(
-                'CM_Janus_Service::synchronize' => function () {
+                'CM_Janus_Service::synchronize'  => function () {
                     $this->getServiceManager()->getJanus('janus')->synchronize();
+                },
+                'CM_Janus_Service::checkStreams' => function () {
+                    $this->getServiceManager()->getJanus('janus')->checkStreams();
                 },
             ));
         }


### PR DESCRIPTION
Reproduce:
- Create a video stream
- Set "allowedUntil" to the past (e.g. no more money)
- -> The stream is not stopped.

It looks to me like `checkStreams()` is not called from maintenance.

@tomaszdurka @fvovan can you check? And maybe test the whole thing to make sure the whole mechanism works ?