### PR TITLE
Create streamchannel when subscribing in Janus

### DIFF
--- a/library/CM/Janus/RpcEndpoints.php
+++ b/library/CM/Janus/RpcEndpoints.php
@@ -25,11 +25,13 @@ class CM_Janus_RpcEndpoints {
         $paramsChannel = CM_Params::factory(CM_Params::jsonDecode($channelData), true);
         $streamChannelType = $paramsChannel->getInt('streamChannelType');
 
-        $server = $janus->getConfiguration()->findServerByKey($serverKey);
         $streamRepository = $janus->getStreamRepository();
         $streamChannel = $streamRepository->findStreamChannelByKey($streamChannelKey);
-        if (!$streamChannel) {
+        if (null !== $streamChannel) {
+            $server = $janus->getConfiguration()->findServerByKey($serverKey);
             $streamChannel = $streamRepository->createStreamChannel($streamChannelKey, $streamChannelType, $server->getId(), 0);
+        } elseif ($streamChannel->getType() !== $streamChannelType) {
+            throw new CM_Exception_Invalid('Passed stream channel type does not match existing');
         }
         try {
             $streamRepository->createStreamPublish($streamChannel, $user, $streamKey, $start);
@@ -65,7 +67,7 @@ class CM_Janus_RpcEndpoints {
 
         $streamRepository = $janus->getStreamRepository();
         $streamChannel = $streamRepository->findStreamChannelByKey($streamChannelKey);
-        if (!$streamChannel) {
+        if (null !== $streamChannel) {
             $server = $janus->getConfiguration()->findServerByKey($serverKey);
             $streamChannel = $streamRepository->createStreamChannel($streamChannelKey, $streamChannelType, $server->getId(), 0);
         } elseif ($streamChannel->getType() !== $streamChannelType) {

--- a/library/CM/Janus/RpcEndpoints.php
+++ b/library/CM/Janus/RpcEndpoints.php
@@ -66,7 +66,7 @@ class CM_Janus_RpcEndpoints {
             $server = $janus->getConfiguration()->findServerByKey($serverKey);
             $streamChannel = $streamRepository->createStreamChannel($streamChannelKey, $streamChannelType, $server->getId(), 0);
         } elseif ($streamChannel->getType() !== $streamChannelType) {
-            throw new CM_Exception_Invalid('Passed stream channel type is does not match with existing');
+            throw new CM_Exception_Invalid('Passed stream channel type does not match existing');
         }
         try {
             $streamRepository->createStreamSubscribe($streamChannel, $user, $streamKey, $start);

--- a/library/CM/Janus/RpcEndpoints.php
+++ b/library/CM/Janus/RpcEndpoints.php
@@ -27,7 +27,10 @@ class CM_Janus_RpcEndpoints {
 
         $server = $janus->getConfiguration()->findServerByKey($serverKey);
         $streamRepository = $janus->getStreamRepository();
-        $streamChannel = $streamRepository->createStreamChannel($streamChannelKey, $streamChannelType, $server->getId(), 0);
+        $streamChannel = $streamRepository->findStreamChannelByKey($streamChannelKey);
+        if (!$streamChannel) {
+            $streamChannel = $streamRepository->createStreamChannel($streamChannelKey, $streamChannelType, $server->getId(), 0);
+        }
         try {
             $streamRepository->createStreamPublish($streamChannel, $user, $streamKey, $start);
         } catch (CM_Exception_NotAllowed $exception) {

--- a/library/CM/Janus/RpcEndpoints.php
+++ b/library/CM/Janus/RpcEndpoints.php
@@ -27,7 +27,7 @@ class CM_Janus_RpcEndpoints {
 
         $streamRepository = $janus->getStreamRepository();
         $streamChannel = $streamRepository->findStreamChannelByKey($streamChannelKey);
-        if (null !== $streamChannel) {
+        if (null === $streamChannel) {
             $server = $janus->getConfiguration()->findServerByKey($serverKey);
             $streamChannel = $streamRepository->createStreamChannel($streamChannelKey, $streamChannelType, $server->getId(), 0);
         } elseif ($streamChannel->getType() !== $streamChannelType) {
@@ -67,7 +67,7 @@ class CM_Janus_RpcEndpoints {
 
         $streamRepository = $janus->getStreamRepository();
         $streamChannel = $streamRepository->findStreamChannelByKey($streamChannelKey);
-        if (null !== $streamChannel) {
+        if (null === $streamChannel) {
             $server = $janus->getConfiguration()->findServerByKey($serverKey);
             $streamChannel = $streamRepository->createStreamChannel($streamChannelKey, $streamChannelType, $server->getId(), 0);
         } elseif ($streamChannel->getType() !== $streamChannelType) {


### PR DESCRIPTION
Do not throw, but rather crete stream-channel:
https://github.com/cargomedia/cm/blob/master/library/CM/Janus/RpcEndpoints.php#L61

Should we create stream-channel here only if it doesn't exist then?
https://github.com/cargomedia/cm/blob/master/library/CM/Janus/RpcEndpoints.php#L30