### PR TITLE
Install pecl/stats 1.0.3 (newest requires php7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - tests/travis/install-php-runkit.sh
   - tests/travis/install-php-svm.sh
   - yes '' | travis_retry pecl install imagick
-  - travis_retry pecl install stats
+  - travis_retry pecl install stats-1.0.3
   - travis_retry pecl install gearman-1.0.3
   - if [ `php-config --vernum` -ge 50500 ]; then yes '' | travis_retry pecl install apcu-4.0.10; fi
   - phpenv config-add tests/travis/php.ini


### PR DESCRIPTION
Reported by @zazabe (see https://travis-ci.org/cargomedia/cm/jobs/100095791):
```
The command "pecl install stats" failed. Retrying, 2 of 3.
WARNING: channel "pecl.php.net" has updated its protocols, use "pecl channel-update pecl.php.net" to update
pecl/stats requires PHP (version >= 7.0.0), installed version is 5.4.37
No valid packages found
install failed
```
@njam see also http://pecl.php.net/package/stats – please review!
