### PR TITLE
Add ICE config for Janus

### DIFF
--- a/library/CM/Janus/Factory.php
+++ b/library/CM/Janus/Factory.php
@@ -13,7 +13,8 @@ class CM_Janus_Factory {
                 $serverId,
                 $serverConfig['key'],
                 $serverConfig['httpAddress'],
-                $serverConfig['webSocketAddress']
+                $serverConfig['webSocketAddress'],
+                $serverConfig['iceServerList']
             ));
         }
 

--- a/library/CM/Janus/Server.php
+++ b/library/CM/Janus/Server.php
@@ -14,17 +14,25 @@ class CM_Janus_Server {
     /** @var string */
     protected $_key;
 
+    /** @var  array */
+    protected $_iceServerList;
+
     /**
-     * @param int $serverId
-     * @param string $key
-     * @param string $httpAddress
-     * @param string $webSocketAddress
+     * @param int        $serverId
+     * @param string     $key
+     * @param string     $httpAddress
+     * @param string     $webSocketAddress
+     * @param array|null $iceServerList
      */
-    public function __construct($serverId, $key, $httpAddress, $webSocketAddress) {
+    public function __construct($serverId, $key, $httpAddress, $webSocketAddress, array $iceServerList = null) {
+        if (null === $iceServerList) {
+            $iceServerList = [];
+        }
         $this->_id = (int) $serverId;
         $this->_key = (string) $key;
         $this->_httpAddress = (string) $httpAddress;
         $this->_webSocketAddress = (string) $webSocketAddress;
+        $this->_iceServerList = $iceServerList;
     }
 
     /**
@@ -53,5 +61,12 @@ class CM_Janus_Server {
      */
     public function getWebSocketAddress() {
         return $this->_webSocketAddress;
+    }
+
+    /**
+     * @return array
+     */
+    public function getIceServerList() {
+        return $this->_iceServerList;
     }
 }

--- a/tests/library/CM/Janus/FactorytTest.php
+++ b/tests/library/CM/Janus/FactorytTest.php
@@ -3,11 +3,18 @@
 class CM_Janus_FactoryTest extends CMTest_TestCase {
 
     public function testCreateService() {
+
+        $iceServerList = [
+            ['url' => 'turn:example.com:3478', 'username' => 'foo', 'credential' => 'bar'],
+            ['url' => 'turn:test.com:3478', 'username' => 'baz', 'credential' => 'quux'],
+        ];
+
         $serversConfig = [
             5 => [
-                'key'            => 'foo-bar',
+                'key'              => 'foo-bar',
                 'httpAddress'      => 'http://cm-janus.dev:8080',
                 'webSocketAddress' => 'ws://cm-janus.dev:8188',
+                'iceServerList'    => $iceServerList,
             ],
         ];
         $factory = new CM_Janus_Factory();
@@ -18,5 +25,6 @@ class CM_Janus_FactoryTest extends CMTest_TestCase {
         $this->assertSame('foo-bar', $servers[0]->getKey());
         $this->assertSame('http://cm-janus.dev:8080', $servers[0]->getHttpAddress());
         $this->assertSame('ws://cm-janus.dev:8188', $servers[0]->getWebSocketAddress());
+        $this->assertSame($iceServerList, $servers[0]->getIceServerList());
     }
 }


### PR DESCRIPTION
Basically we need an array of ICE servers:
```
iceServers: [{url: "turn:yourturnserver.com:3478", username: "janususer", credential: "januspwd"}]
```

Initially username/credential will probably be hardcoded application-wide. In the future we might want to generate them on the server side (or client side with an ajax call).

I think they could be configured *per* janus server. E.g. in case we have geographically distributed janus instances, then it makes sense to use a *close* ICE server.

cc @tomaszdurka @zazabe @kris-lab 