### PR TITLE
CMService_MaxMind::_getCountryData() has issues with some patterns

### DIFF
--- a/library/CMService/MaxMind.php
+++ b/library/CMService/MaxMind.php
@@ -2,7 +2,7 @@
 
 class CMService_MaxMind extends CM_Class_Abstract {
 
-    const COUNTRY_URL = 'https://raw.githubusercontent.com/lukes/ISO-3166-Countries-with-Regional-Codes/master/all/all.csv';
+    const COUNTRY_URL = 'https://raw.githubusercontent.com/lukes/ISO-3166-Countries-with-Regional-Codes/56efb650f927eda08c18c2a077226104d0e41744/all/all.csv';
     const REGION_URL = 'http://www.maxmind.com/download/geoip/misc/region_codes.csv';
     const GEO_LITE_CITY_URL = 'http://geolite.maxmind.com/download/geoip/database/GeoLiteCity_CSV/GeoLiteCity-latest.zip';
     const GEO_IP_URL = 'https://download.maxmind.com/app/geoip_download';


### PR DESCRIPTION
@fauvel something for you?

Looks like that cases like the following are not parsed correctly leading to a wrong final array for the country with an additional field after the name (which instead should be country code):

> "Saint Helena, Ascension and Tristan da Cunha",SH,SHN,654,ISO 3166-2:SH,Africa,Western Africa,002,011
```php
array(10) {
  [0] =>
  string(13) "Saint Helena""
  [1] =>
  string(32) " Ascension and Tristan da Cunha""
  [2] =>
  string(2) "SH"
  [3] =>
  string(3) "SHN"
  [4] =>
  string(3) "654"
  [5] =>
  string(13) "ISO 3166-2:SH"
  [6] =>
  string(6) "Africa"
  [7] =>
  string(14) "Western Africa"
  [8] =>
  string(3) "002"
  [9] =>
  string(3) "011"
}
```

>"Bonaire, Sint Eustatius and Saba",BQ,BES,535,ISO 3166-2:BQ,Americas,Caribbean,019,029
```php
array(10) {
  [0] =>
  string(8) "Bonaire""
  [1] =>
  string(25) " Sint Eustatius and Saba""
  [2] =>
  string(2) "BQ"
  [3] =>
  string(3) "BES"
  [4] =>
  string(3) "535"
  [5] =>
  string(13) "ISO 3166-2:BQ"
  [6] =>
  string(8) "Americas"
  [7] =>
  string(9) "Caribbean"
  [8] =>
  string(3) "019"
  [9] =>
  string(3) "029"
}
```

I guess it should always be like this one instead:

> Saint Barthélemy,BL,BLM,652,ISO 3166-2:BL,Americas,Caribbean,019,029
```php
array(9) {
  [0] =>
  string(17) "Saint Barthélemy"
  [1] =>
  string(2) "BL"
  [2] =>
  string(3) "BLM"
  [3] =>
  string(3) "652"
  [4] =>
  string(13) "ISO 3166-2:BL"
  [5] =>
  string(8) "Americas"
  [6] =>
  string(9) "Caribbean"
  [7] =>
  string(3) "019"
  [8] =>
  string(3) "029"
}
```