### PR TITLE
fix CM_MediaStreams_Cli::importArchive()

### DIFF
--- a/library/CM/MediaStreams/Cli.php
+++ b/library/CM/MediaStreams/Cli.php
@@ -23,7 +23,7 @@ class CM_MediaStreams_Cli extends CM_Cli_Runnable_Abstract {
      */
     public function importArchive($streamChannelId, CM_File $archiveSource) {
         $streamChannelArchive = new CM_Model_StreamChannelArchive_Media($streamChannelId);
-        $filename = $streamChannelArchive->getId() . '-' . $streamChannelArchive->getHash() . '-original' . $archiveSource->getExtension();
+        $filename = $streamChannelArchive->getId() . '-' . $streamChannelArchive->getHash() . '-original.' . $archiveSource->getExtension();
         $archiveDestination = new CM_File_UserContent('streamChannels', $filename, $streamChannelArchive->getId());
         $archiveDestination->ensureParentDirectory();
         $archiveSource->copyToFile($archiveDestination);

--- a/library/CM/Model/StreamChannelArchive/Media.php
+++ b/library/CM/Model/StreamChannelArchive/Media.php
@@ -27,8 +27,8 @@ class CM_Model_StreamChannelArchive_Media extends CM_Model_StreamChannelArchive_
      * @param CM_File_UserContent|null $file
      */
     public function setFile(CM_File_UserContent $file = null) {
-        $path = null !== $file ? $file->getPath() : null;
-        CM_Db_Db::update('cm_streamChannelArchive_media', ['file' => $path], ['id' => $this->getId()]);
+        $filename = null !== $file ? $file->getFileName() : null;
+        CM_Db_Db::update('cm_streamChannelArchive_media', ['file' => $filename], ['id' => $this->getId()]);
         $this->_change();
     }
 


### PR DESCRIPTION
There are two problems.
- we save full file path in database.
- dot between filename and extension is lost