### PR TITLE
Fix error handling of CM_Janus_Service::_stopStream()

### DIFF
--- a/library/CM/Janus/HttpApiClient.php
+++ b/library/CM/Janus/HttpApiClient.php
@@ -15,11 +15,12 @@ class CM_Janus_HttpApiClient {
     /**
      * @param CM_Janus_Server $server
      * @param string          $clientKey
-     * @return string
+     * @return array
      * @throws CM_Exception_Invalid
      */
     public function stopStream(CM_Janus_Server $server, $clientKey) {
-        return $this->_request('POST', $server, '/stopStream', ['streamId' => (string) $clientKey]);
+        $res = $this->_request('POST', $server, '/stopStream', ['streamId' => (string) $clientKey]);
+        return CM_Params::jsonDecode($res);
     }
 
     /**
@@ -53,6 +54,10 @@ class CM_Janus_HttpApiClient {
         } catch (GuzzleHttp\Exception\TransferException $e) {
             throw new CM_Exception_Invalid('Fetching contents from `' . $url . '` failed: `' . $e->getMessage());
         }
-        return $response->getBody();
+        $body = $response->getBody();
+        if (null === $body) {
+            throw new CM_Exception_Invalid('Empty response body');
+        }
+        return $body->getContents();
     }
 }

--- a/tests/library/CM/Janus/HttpApiClientTest.php
+++ b/tests/library/CM/Janus/HttpApiClientTest.php
@@ -10,8 +10,11 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
             $this->assertSame('streamId=foo', $request->getBody()->getContents());
             $this->assertSame('bar', $request->getHeader('Server-Key'));
 
+            $body = $this->mockClass('\GuzzleHttp\Post\PostBody')->newInstanceWithoutConstructor();
+            $body->mockMethod('getContents')->set('');
+
             $response = $this->mockClass('\GuzzleHttp\Message\Response')->newInstanceWithoutConstructor();
-            $response->mockMethod('getBody')->set(null);
+            $response->mockMethod('getBody')->set($body);
             return $response;
         });
         /** @var GuzzleHttp\Client $httpClient */
@@ -29,8 +32,11 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
             $this->assertSame('GET', $request->getMethod());
             $this->assertSame('bar', $request->getHeader('Server-Key'));
 
+            $body = $this->mockClass('\GuzzleHttp\Post\PostBody')->newInstanceWithoutConstructor();
+            $body->mockMethod('getContents')->set('{"foo":"bar"}');
+
             $response = $this->mockClass('\GuzzleHttp\Message\Response')->newInstanceWithoutConstructor();
-            $response->mockMethod('getBody')->set('{"foo":"bar"}');
+            $response->mockMethod('getBody')->set($body);
             return $response;
         });
         /** @var GuzzleHttp\Client $httpClient */
@@ -40,5 +46,37 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
         $result = $api->fetchStatus($server);
         $this->assertSame(['foo' => 'bar'], $result);
         $this->assertSame(1, $sendRequestMethod->getCallCount());
+    }
+
+    public function testFail() {
+        /** @var GuzzleHttp\Client|\Mocka\AbstractClassTrait $httpClient */
+        $httpClient = $this->mockObject('GuzzleHttp\Client');
+        /** @var \Mocka\FunctionMock $sendFailMethod */
+        $sendFailMethod = $httpClient->mockMethod('send')->set(function () {
+            throw new GuzzleHttp\Exception\TransferException();
+        });
+
+        $server = new CM_Janus_Server(0, 'bar', 'http://cm-janus.dev:8080', 'ws://cm-janus.dev:8188');
+        $api = new CM_Janus_HttpApiClient($httpClient);
+        $exception = $this->catchException(function () use ($api, $server) {
+            $api->fetchStatus($server);
+        });
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertStringStartsWith('Fetching contents from', $exception->getMessage());
+
+        $this->assertSame(1, $sendFailMethod->getCallCount());
+
+        $httpClient->mockMethod('send')->set(function () {
+            $response = $this->mockClass('\GuzzleHttp\Message\Response')->newInstanceWithoutConstructor();
+            $response->mockMethod('getBody')->set(null);
+            return $response;
+        });
+
+        $exception = $this->catchException(function () use ($api, $server) {
+            $api->fetchStatus($server);
+        });
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertSame('Empty response body', $exception->getMessage());
+        $this->assertSame(2, $sendFailMethod->getCallCount());
     }
 }

--- a/tests/library/CM/Janus/HttpApiClientTest.php
+++ b/tests/library/CM/Janus/HttpApiClientTest.php
@@ -11,7 +11,7 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
             $this->assertSame('bar', $request->getHeader('Server-Key'));
 
             $body = $this->mockClass('\GuzzleHttp\Post\PostBody')->newInstanceWithoutConstructor();
-            $body->mockMethod('getContents')->set('');
+            $body->mockMethod('getContents')->set('{"success":"Stream stopped"}');
 
             $response = $this->mockClass('\GuzzleHttp\Message\Response')->newInstanceWithoutConstructor();
             $response->mockMethod('getBody')->set($body);
@@ -33,7 +33,7 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
             $this->assertSame('bar', $request->getHeader('Server-Key'));
 
             $body = $this->mockClass('\GuzzleHttp\Post\PostBody')->newInstanceWithoutConstructor();
-            $body->mockMethod('getContents')->set('{"foo":"bar"}');
+            $body->mockMethod('getContents')->set('[{"id":"foo", "channelName":"bar"},{"id":"baz", "channelName":"quux"}]');
 
             $response = $this->mockClass('\GuzzleHttp\Message\Response')->newInstanceWithoutConstructor();
             $response->mockMethod('getBody')->set($body);
@@ -44,7 +44,7 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
         $server = new CM_Janus_Server(0, 'bar', 'http://cm-janus.dev:8080', 'ws://cm-janus.dev:8188');
         $api = new CM_Janus_HttpApiClient($httpClient);
         $result = $api->fetchStatus($server);
-        $this->assertSame(['foo' => 'bar'], $result);
+        $this->assertSame([['id' => 'foo', 'channelName' => 'bar'], ['id' => 'baz', 'channelName' => 'quux']], $result);
         $this->assertSame(1, $sendRequestMethod->getCallCount());
     }
 


### PR DESCRIPTION
The returned value is not an array, but expected to be one.
Also the docu for `CM_Janus_HttpApiClient::stopStream()` should be updated.