### PR TITLE
StreamRepository::createStreamChannel(): handle concurrent calls

### DIFF
--- a/library/CM/Db/Query/Insert.php
+++ b/library/CM/Db/Query/Insert.php
@@ -78,6 +78,6 @@ class CM_Db_Query_Insert extends CM_Db_Query_Abstract {
      * @return bool
      */
     private function _isValidLiteral($literal) {
-        return (1 === preg_match('/LAST_INSERT_ID\((?:id)?\)/', $literal));
+        return (1 === preg_match('/^LAST_INSERT_ID\((?:id)?\)$/', $literal));
     }
 }

--- a/library/CM/Db/Query/Insert.php
+++ b/library/CM/Db/Query/Insert.php
@@ -58,6 +58,11 @@ class CM_Db_Query_Insert extends CM_Db_Query_Abstract {
             foreach ($onDuplicateKeyValues as $fields => $values) {
                 if ($values === null) {
                     $valuesList[] = $this->_getClient()->quoteIdentifier($fields) . ' = NULL';
+                } elseif (!empty($values['literal'])) {
+                    $literal = (string) $values['literal'];
+                    if ($this->_isValidLiteral($literal)) {
+                        $valuesList[] = $this->_getClient()->quoteIdentifier($fields) . ' = ' . $values['literal'];
+                    }
                 } else {
                     $valuesList[] = $this->_getClient()->quoteIdentifier($fields) . ' = ?';
                     $this->_addParameters($values);
@@ -66,5 +71,13 @@ class CM_Db_Query_Insert extends CM_Db_Query_Abstract {
 
             $this->_addSql('ON DUPLICATE KEY UPDATE ' . implode(',', $valuesList));
         }
+    }
+
+    /**
+     * @param string $literal
+     * @return bool
+     */
+    private function _isValidLiteral($literal) {
+        return (1 === preg_match('/LAST_INSERT_ID\((?:id)?\)/', $literal));
     }
 }

--- a/library/CM/Db/Query/Insert.php
+++ b/library/CM/Db/Query/Insert.php
@@ -62,6 +62,8 @@ class CM_Db_Query_Insert extends CM_Db_Query_Abstract {
                     $literal = (string) $values['literal'];
                     if ($this->_isValidLiteral($literal)) {
                         $valuesList[] = $this->_getClient()->quoteIdentifier($fields) . ' = ' . $values['literal'];
+                    } else {
+                        throw new CM_Exception('Unescaped Value is not whitelisted');
                     }
                 } else {
                     $valuesList[] = $this->_getClient()->quoteIdentifier($fields) . ' = ?';

--- a/library/CM/Model/StreamChannel/Abstract.php
+++ b/library/CM/Model/StreamChannel/Abstract.php
@@ -263,7 +263,7 @@ abstract class CM_Model_StreamChannel_Abstract extends CM_Model_Abstract {
             'createStamp' => time(),
             'type'        => static::getTypeStatic(),
             'adapterType' => $adapterType,
-        ));
+        ), null, ['id' => ['literal' => 'LAST_INSERT_ID(id)']]);
         $cacheKey = CM_CacheConst::StreamChannel_Id . '_key' . $key . '_adapterType:' . $adapterType;
         CM_Cache_Shared::getInstance()->delete($cacheKey);
         return new static($id);

--- a/library/CM/Model/StreamChannel/Media.php
+++ b/library/CM/Model/StreamChannel/Media.php
@@ -144,18 +144,15 @@ class CM_Model_StreamChannel_Media extends CM_Model_StreamChannel_Abstract {
             'createStamp' => time(),
             'type'        => static::getTypeStatic(),
             'adapterType' => $adapterType,
-        ]);
-        try {
-            CM_Db_Db::insert('cm_streamChannel_media', [
-                'id'       => $id,
-                'serverId' => $serverId,
-                'data'     => CM_Params::encode(['thumbnailCount' => $thumbnailCount], true),
-                'mediaId'  => $mediaId,
-            ]);
-        } catch (CM_Exception $ex) {
-            CM_Db_Db::delete('cm_streamChannel', ['id' => $id]);
-            throw $ex;
-        }
+        ], null, ['id' => ['literal' => 'LAST_INSERT_ID(id)']]);
+
+        CM_Db_Db::insert('cm_streamChannel_media', [
+            'id'       => $id,
+            'serverId' => $serverId,
+            'data'     => CM_Params::encode(['thumbnailCount' => $thumbnailCount], true),
+            'mediaId'  => $mediaId,
+        ], null, ['id' => ['literal' => 'LAST_INSERT_ID(id)']]);
+
         $cacheKey = CM_CacheConst::StreamChannel_Id . '_key' . $key . '_adapterType:' . $adapterType;
         CM_Cache_Shared::getInstance()->delete($cacheKey);
         return new static($id);

--- a/tests/library/CM/Db/Query/InsertTest.php
+++ b/tests/library/CM/Db/Query/InsertTest.php
@@ -88,6 +88,14 @@ class CM_Db_Query_InsertTest extends CMTest_TestCase {
             'id' => ['literal' => 'LAST_INSERT_ID(id)']
         ]);
         $this->assertSame('INSERT INTO `t``est` (`foo`,`bar`) VALUES (?,?) ON DUPLICATE KEY UPDATE `id` = LAST_INSERT_ID(id)', $query->getSqlTemplate());
+
+        $exception = $this->catchException(function () use ($query) {
+            new CM_Db_Query_Insert(self::$_client, 't`est', ['foo' => 'foo2', 'bar' => 'bar2'], null, [
+                'id' => ['literal' => 'COUNT(*)']
+            ]);
+        });
+        $this->assertInstanceOf('CM_Exception', $exception);
+        $this->assertSame('Unescaped Value is not whitelisted', $exception->getMessage());
     }
 
     public function testIsValidLiteral() {

--- a/tests/library/CM/Db/Query/InsertTest.php
+++ b/tests/library/CM/Db/Query/InsertTest.php
@@ -83,5 +83,17 @@ class CM_Db_Query_InsertTest extends CMTest_TestCase {
         // Statement
         $query = new CM_Db_Query_Insert(self::$_client, 't`est', array('foo' => 'foo2', 'bar' => 'bar2'), null, null, 'INSERT IGNORE');
         $this->assertSame('INSERT IGNORE INTO `t``est` (`foo`,`bar`) VALUES (?,?)', $query->getSqlTemplate());
+
+        $query = new CM_Db_Query_Insert(self::$_client, 't`est', ['foo' => 'foo2', 'bar' => 'bar2'], null, [
+            'id' => ['literal' => 'LAST_INSERT_ID(id)']
+        ]);
+        $this->assertSame('INSERT INTO `t``est` (`foo`,`bar`) VALUES (?,?) ON DUPLICATE KEY UPDATE `id` = LAST_INSERT_ID(id)', $query->getSqlTemplate());
+    }
+
+    public function testIsValidLiteral() {
+        $query = $this->mockClass('CM_Db_Query_Insert')->newInstanceWithoutConstructor();
+        $this->assertFalse($this->callProtectedMethod($query, '_isValidLiteral', ['COUNT']));
+        $this->assertTrue($this->callProtectedMethod($query, '_isValidLiteral', ['LAST_INSERT_ID()']));
+        $this->assertTrue($this->callProtectedMethod($query, '_isValidLiteral', ['LAST_INSERT_ID(id)']));
     }
 }

--- a/tests/library/CM/Model/StreamChannel/AbstractTest.php
+++ b/tests/library/CM/Model/StreamChannel/AbstractTest.php
@@ -46,20 +46,6 @@ class CM_Model_StreamChannel_AbstractTest extends CMTest_TestCase {
         CM_Model_StreamChannel_Media::factory($messageStreamChannel->getId());
     }
 
-    public function testCreateDuplicate() {
-        $channel1 = CM_Model_StreamChannel_Message::createStatic([
-            'key'         => 'foo',
-            'adapterType' => CM_MessageStream_Adapter_SocketRedis::getTypeStatic(),
-        ]);
-        $channel2 = CM_Model_StreamChannel_Message::createStatic([
-            'key'         => 'foo',
-            'adapterType' => CM_MessageStream_Adapter_SocketRedis::getTypeStatic(),
-        ]);
-        $this->assertInstanceOf('CM_Model_StreamChannel_Message', $channel1);
-        $this->assertInstanceOf('CM_Model_StreamChannel_Message', $channel2);
-        $this->assertSame($channel1->getId(), $channel2->getId());
-    }
-
     public function testFindByKeyAndAdapter() {
         $adapterType = 1;
         /** @var CM_Model_StreamChannel_Media $streamChannelOriginal */
@@ -185,15 +171,20 @@ class CM_Model_StreamChannel_AbstractTest extends CMTest_TestCase {
         $this->assertEquals(CM_MessageStream_Adapter_SocketRedis::getTypeStatic(), $streamChannel->getAdapterType());
         $this->assertSame(time(), $streamChannel->getCreateStamp());
 
-        try {
-            CM_Model_StreamChannel_Abstract::createType(CM_Model_StreamChannel_Message::getTypeStatic(), array('key'         => 'foo1',
-                                                                                                               'adapterType' => CM_MessageStream_Adapter_SocketRedis::getTypeStatic()));
-            $this->fail();
-        } catch (CM_Db_Exception $e) {
-            $this->assertContains('Duplicate entry', $e->getMessage());
-        }
-
-        CM_Model_StreamChannel_Abstract::createType(CM_Model_StreamChannel_Message::getTypeStatic(), array('key' => 'foo1', 'adapterType' => 2));
+        /** @var CM_Model_StreamChannel_Abstract $channel1 */
+        $channel1 = CM_Model_StreamChannel_Abstract::createType(CM_Model_StreamChannel_Message::getTypeStatic(), [
+            'key'         => 'foo',
+            'adapterType' => CM_MessageStream_Adapter_SocketRedis::getTypeStatic(),
+        ]);
+        /** @var CM_Model_StreamChannel_Abstract $channel2 */
+        $channel2 = CM_Model_StreamChannel_Abstract::createType(CM_Model_StreamChannel_Message::getTypeStatic(), [
+            'key'         => 'foo',
+            'adapterType' => CM_MessageStream_Adapter_SocketRedis::getTypeStatic(),
+        ]);
+        $this->assertInstanceOf('CM_Model_StreamChannel_Message', $channel1);
+        $this->assertInstanceOf('CM_Model_StreamChannel_Message', $channel2);
+        $this->assertSame($channel1->getId(), $channel2->getId());
+        $this->assertSame($channel1->getCreateStamp(), $channel2->getCreateStamp());
     }
 
     public function testEncryptAndDecryptKey() {

--- a/tests/library/CM/Model/StreamChannel/AbstractTest.php
+++ b/tests/library/CM/Model/StreamChannel/AbstractTest.php
@@ -46,6 +46,20 @@ class CM_Model_StreamChannel_AbstractTest extends CMTest_TestCase {
         CM_Model_StreamChannel_Media::factory($messageStreamChannel->getId());
     }
 
+    public function testCreateDuplicate() {
+        $channel1 = CM_Model_StreamChannel_Message::createStatic([
+            'key'         => 'foo',
+            'adapterType' => CM_MessageStream_Adapter_SocketRedis::getTypeStatic(),
+        ]);
+        $channel2 = CM_Model_StreamChannel_Message::createStatic([
+            'key'         => 'foo',
+            'adapterType' => CM_MessageStream_Adapter_SocketRedis::getTypeStatic(),
+        ]);
+        $this->assertInstanceOf('CM_Model_StreamChannel_Message', $channel1);
+        $this->assertInstanceOf('CM_Model_StreamChannel_Message', $channel2);
+        $this->assertSame($channel1->getId(), $channel2->getId());
+    }
+
     public function testFindByKeyAndAdapter() {
         $adapterType = 1;
         /** @var CM_Model_StreamChannel_Media $streamChannelOriginal */

--- a/tests/library/CM/Model/StreamChannel/MediaTest.php
+++ b/tests/library/CM/Model/StreamChannel/MediaTest.php
@@ -55,6 +55,29 @@ class CM_Model_StreamChannel_MediaTest extends CMTest_TestCase {
         }
     }
 
+    public function testCreateDuplicate() {
+        /** @var CM_Model_StreamChannel_Media $channel1 */
+        $channel1 = CM_Model_StreamChannel_Media::createStatic(array(
+            'key'            => 'foo',
+            'serverId'       => 1,
+            'thumbnailCount' => 2,
+            'adapterType'    => 1,
+        ));
+
+        /** @var CM_Model_StreamChannel_Media $channel2 */
+        $channel2 = CM_Model_StreamChannel_Media::createStatic(array(
+            'key'            => 'foo',
+            'serverId'       => 1,
+            'thumbnailCount' => 2,
+            'adapterType'    => 1,
+        ));
+
+        $this->assertInstanceOf('CM_Model_StreamChannel_Media', $channel1);
+        $this->assertInstanceOf('CM_Model_StreamChannel_Media', $channel2);
+        $this->assertSame($channel1->getId(), $channel2->getId());
+        $this->assertSame($channel1->getCreateStamp(), $channel2->getCreateStamp());
+    }
+
     public function testGetStreamPublish() {
         /** @var CM_Model_StreamChannel_Media $streamChannel */
         $streamChannel = CMTest_TH::createStreamChannel();


### PR DESCRIPTION
`StreamRepository::createStreamChannel()` is concurrently from multiple RPC calls in `CM_Janus_RpcEndpoints`.
With audio subscribe requests this is quite likely to happen.

What could we do to prevent errors, and ignore/merge subsequent requests and make them atomic?
Those tables are InnoDB…

@tomaszdurka @fvovan @alexispeter thoughts?