### PR TITLE
Remove publish dependency from media archive

### DIFF
--- a/library/CM/Model/StreamChannel/Media.php
+++ b/library/CM/Model/StreamChannel/Media.php
@@ -9,9 +9,6 @@ class CM_Model_StreamChannel_Media extends CM_Model_StreamChannel_Abstract {
     }
 
     public function onUnpublish(CM_Model_Stream_Publish $streamPublish) {
-        if (!CM_Model_StreamChannelArchive_Media::findById($this->getId())) {
-            CM_Model_StreamChannelArchive_Media::createStatic(array('streamChannel' => $this));
-        }
     }
 
     public function onUnsubscribe(CM_Model_Stream_Subscribe $streamSubscribe) {
@@ -32,9 +29,6 @@ class CM_Model_StreamChannel_Media extends CM_Model_StreamChannel_Abstract {
      * @return string
      */
     public function getHash() {
-        if ($this->hasStreamPublish()) {
-            return md5($this->getStreamPublish()->getKey());
-        }
         return md5($this->getKey());
     }
 

--- a/library/CM/Model/StreamChannelArchive/Media.php
+++ b/library/CM/Model/StreamChannelArchive/Media.php
@@ -182,11 +182,6 @@ class CM_Model_StreamChannelArchive_Media extends CM_Model_StreamChannelArchive_
         $streamChannel = $data['streamChannel'];
         $createStamp = $streamChannel->getCreateStamp();
         $userId = null;
-        if ($streamChannel->hasStreamPublish()) {
-            $streamPublish = $streamChannel->getStreamPublish();
-            $createStamp = $streamPublish->getStart();
-            $userId = $streamPublish->getUserId();
-        }
         $thumbnailCount = $streamChannel->getThumbnailCount();
         $file = isset($data['file']) ? $data['file'] : null;
         $end = time();


### PR DESCRIPTION
Hash content depends on publish existence.
```
    /**
     * @return string
     */
    public function getHash() {
        if ($this->hasStreamPublish()) {
            return md5($this->getStreamPublish()->getKey());
        }
        return md5($this->getKey());
    }
``