### PR TITLE
Disallow creating streamChannel with mediaId used by an existing archive

### DIFF
--- a/library/CM/MediaStreams/StreamRepository.php
+++ b/library/CM/MediaStreams/StreamRepository.php
@@ -34,7 +34,6 @@ class CM_MediaStreams_StreamRepository {
      * @param int|null    $thumbnailCount
      * @param string|null $mediaId
      * @return CM_Model_StreamChannel_Abstract
-     * @throws CM_Exception_Invalid
      */
     public function createStreamChannel($streamName, $streamChannelType, $serverId, $thumbnailCount = null, $mediaId = null) {
         if (null !== $thumbnailCount) {
@@ -42,13 +41,7 @@ class CM_MediaStreams_StreamRepository {
         }
         if (null !== $mediaId) {
             $mediaId = (string) $mediaId;
-            $existsMediaArchive = CM_Db_Db::exec('SELECT EXISTS( SELECT 1 FROM `cm_streamChannelArchive_media` WHERE mediaId = ? )', [$mediaId])->fetchColumn();
-
-            if (1 === $existsMediaArchive) {
-                throw new CM_Exception_Invalid('Archive with given mediaId already exists');
-            }
         }
-
         return CM_Model_StreamChannel_Abstract::createType($streamChannelType, [
             'key'            => $streamName,
             'adapterType'    => $this->_adapterType,

--- a/library/CM/MediaStreams/StreamRepository.php
+++ b/library/CM/MediaStreams/StreamRepository.php
@@ -34,6 +34,7 @@ class CM_MediaStreams_StreamRepository {
      * @param int|null    $thumbnailCount
      * @param string|null $mediaId
      * @return CM_Model_StreamChannel_Abstract
+     * @throws CM_Exception_Invalid
      */
     public function createStreamChannel($streamName, $streamChannelType, $serverId, $thumbnailCount = null, $mediaId = null) {
         if (null !== $thumbnailCount) {
@@ -41,7 +42,13 @@ class CM_MediaStreams_StreamRepository {
         }
         if (null !== $mediaId) {
             $mediaId = (string) $mediaId;
+            $existsMediaArchive = CM_Db_Db::exec('SELECT EXISTS( SELECT 1 FROM `cm_streamChannelArchive_media` WHERE mediaId = ? )', [$mediaId])->fetchColumn();
+
+            if (1 === $existsMediaArchive) {
+                throw new CM_Exception_Invalid('Archive with given mediaId already exists');
+            }
         }
+
         return CM_Model_StreamChannel_Abstract::createType($streamChannelType, [
             'key'            => $streamName,
             'adapterType'    => $this->_adapterType,

--- a/library/CM/Model/StreamChannel/Media.php
+++ b/library/CM/Model/StreamChannel/Media.php
@@ -150,14 +150,17 @@ class CM_Model_StreamChannel_Media extends CM_Model_StreamChannel_Abstract {
 
         $id = CM_Db_Db::exec("SELECT LAST_INSERT_ID()")->fetchColumn();
 
-        if ('0' !== $id) {
-            CM_Db_Db::insert('cm_streamChannel_media', [
-                'id'       => $id,
-                'serverId' => $serverId,
-                'data'     => CM_Params::encode(['thumbnailCount' => $thumbnailCount], true),
-                'mediaId'  => $mediaId,
-            ], null, ['id' => ['literal' => 'LAST_INSERT_ID(id)']]);
+        if ('0' === $id) {
+            throw new CM_Exception_Invalid('Channel archive with given mediaId already exists');
         }
+
+        $id = (int) $id;
+        CM_Db_Db::insert('cm_streamChannel_media', [
+            'id'       => $id,
+            'serverId' => $serverId,
+            'data'     => CM_Params::encode(['thumbnailCount' => $thumbnailCount], true),
+            'mediaId'  => $mediaId,
+        ], null, ['id' => ['literal' => 'LAST_INSERT_ID(id)']]);
 
         $cacheKey = CM_CacheConst::StreamChannel_Id . '_key' . $key . '_adapterType:' . $adapterType;
         CM_Cache_Shared::getInstance()->delete($cacheKey);

--- a/tests/library/CM/Model/StreamChannel/MediaTest.php
+++ b/tests/library/CM/Model/StreamChannel/MediaTest.php
@@ -41,6 +41,32 @@ class CM_Model_StreamChannel_MediaTest extends CMTest_TestCase {
         $this->assertSame(null, $channel3->getMediaId());
     }
 
+    public function testCreateWithExistingArchiveMedia() {
+        $channel1 = CM_Model_StreamChannel_Media::createStatic(array(
+            'key'            => 'foo',
+            'serverId'       => 1,
+            'thumbnailCount' => 2,
+            'adapterType'    => 1,
+            'mediaId'        => 'foo',
+        ));
+        $archive = CM_Model_StreamChannelArchive_Media::createStatic(['streamChannel' => $channel1]);
+        $this->assertInstanceOf('CM_Model_StreamChannelArchive_Media', $archive);
+        $this->assertSame($channel1->getMediaId(), $archive->getMediaId());
+
+        $exception = $this->catchException(function () {
+            CM_Model_StreamChannel_Media::createStatic(array(
+                'key'            => 'baz',
+                'serverId'       => 1,
+                'thumbnailCount' => 3,
+                'adapterType'    => 1,
+                'mediaId'        => 'foo',
+            ));
+        });
+
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertSame('Channel archive with given mediaId already exists', $exception->getMessage());
+    }
+
     public function testCreateWithoutServerId() {
         try {
             CM_Model_StreamChannel_Media::createStatic(array(


### PR DESCRIPTION
`createStreamChannel()` should check that there's no archive with the same mediaId.

Mysql:
- `WHERE NOT EXISTS` - http://dev.mysql.com/doc/refman/5.7/en/exists-and-not-exists-subqueries.html

PHP:
- Check twice: before, and after INSERT