### PR TITLE
StreamChannel creation: Check for existing archives with same mediaId

### DIFF
--- a/library/CM/MediaStreams/StreamRepository.php
+++ b/library/CM/MediaStreams/StreamRepository.php
@@ -43,7 +43,7 @@ class CM_MediaStreams_StreamRepository {
         if (null !== $mediaId) {
             $mediaId = (string) $mediaId;
             if (null !== CM_Model_StreamChannelArchive_Media::findByMediaId($mediaId)) {
-                throw new CM_Exception_Invalid('Channel archive with given mediaId already exists');
+                throw new CM_Exception_Invalid('Channel archive with mediaId `'.$mediaId.'` already exists');
             }
         }
 

--- a/library/CM/MediaStreams/StreamRepository.php
+++ b/library/CM/MediaStreams/StreamRepository.php
@@ -34,6 +34,7 @@ class CM_MediaStreams_StreamRepository {
      * @param int|null    $thumbnailCount
      * @param string|null $mediaId
      * @return CM_Model_StreamChannel_Abstract
+     * @throws CM_Exception_Invalid
      */
     public function createStreamChannel($streamName, $streamChannelType, $serverId, $thumbnailCount = null, $mediaId = null) {
         if (null !== $thumbnailCount) {
@@ -41,7 +42,11 @@ class CM_MediaStreams_StreamRepository {
         }
         if (null !== $mediaId) {
             $mediaId = (string) $mediaId;
+            if (null !== CM_Model_StreamChannelArchive_Media::findByMediaId($mediaId)) {
+                throw new CM_Exception_Invalid('Channel archive with given mediaId already exists');
+            }
         }
+
         return CM_Model_StreamChannel_Abstract::createType($streamChannelType, [
             'key'            => $streamName,
             'adapterType'    => $this->_adapterType,

--- a/tests/library/CM/MediaStreams/StreamRepository.php
+++ b/tests/library/CM/MediaStreams/StreamRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+class CM_MediaStreams_StreamRepositoryTest extends CMTest_TestCase {
+
+    public function tearDown() {
+        CMTest_TH::clearEnv();
+    }
+
+    public function testConstructor() {
+        $repository = new CM_MediaStreams_StreamRepository(1);
+        $this->assertInstanceOf('CM_MediaStreams_StreamRepository', $repository);
+    }
+
+    public function testCreateStreamChannel() {
+        $repository = new CM_MediaStreams_StreamRepository(1);
+        $channel = $repository->createStreamChannel('foo', CM_Model_StreamChannel_Media::getTypeStatic(), 2, 3, '444-bar');
+        $this->assertInstanceOf('CM_Model_StreamChannel_Media', $channel);
+
+        CM_Model_StreamChannelArchive_Media::createStatic(['streamChannel' => $channel]);
+
+        $exception = $this->catchException(function () use ($repository) {
+            $repository->createStreamChannel('bar', CM_Model_StreamChannel_Media::getTypeStatic(), 2, 5, '444-bar');
+        });
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertSame('Channel archive with given mediaId already exists', $exception->getMessage());
+    }
+}

--- a/tests/library/CM/MediaStreams/StreamRepository.php
+++ b/tests/library/CM/MediaStreams/StreamRepository.php
@@ -13,15 +13,16 @@ class CM_MediaStreams_StreamRepositoryTest extends CMTest_TestCase {
 
     public function testCreateStreamChannel() {
         $repository = new CM_MediaStreams_StreamRepository(1);
-        $channel = $repository->createStreamChannel('foo', CM_Model_StreamChannel_Media::getTypeStatic(), 2, 3, '444-bar');
+        $mediaId = '444-bar';
+        $channel = $repository->createStreamChannel('foo', CM_Model_StreamChannel_Media::getTypeStatic(), 2, 3, $mediaId);
         $this->assertInstanceOf('CM_Model_StreamChannel_Media', $channel);
 
         CM_Model_StreamChannelArchive_Media::createStatic(['streamChannel' => $channel]);
 
-        $exception = $this->catchException(function () use ($repository) {
-            $repository->createStreamChannel('bar', CM_Model_StreamChannel_Media::getTypeStatic(), 2, 5, '444-bar');
+        $exception = $this->catchException(function () use ($repository, $mediaId) {
+            $repository->createStreamChannel('bar', CM_Model_StreamChannel_Media::getTypeStatic(), 2, 5, $mediaId);
         });
         $this->assertInstanceOf('CM_Exception_Invalid', $exception);
-        $this->assertSame('Channel archive with given mediaId already exists', $exception->getMessage());
+        $this->assertSame('Channel archive with mediaId `' . $mediaId . '` already exists', $exception->getMessage());
     }
 }


### PR DESCRIPTION
Use `findByMediaId()` and throw.

Similar to https://github.com/fvovan/CM/commit/a9b14c154748ac1fea20db258f3946e3e368d63f

cc @tomaszdurka @alexispeter 