### PR TITLE
Handle concurrent streamchannel *archive* creations?

### DIFF
--- a/library/CM/MediaStreams/StreamRepository.php
+++ b/library/CM/MediaStreams/StreamRepository.php
@@ -34,7 +34,6 @@ class CM_MediaStreams_StreamRepository {
      * @param int|null    $thumbnailCount
      * @param string|null $mediaId
      * @return CM_Model_StreamChannel_Abstract
-     * @throws CM_Exception_Invalid
      */
     public function createStreamChannel($streamName, $streamChannelType, $serverId, $thumbnailCount = null, $mediaId = null) {
         if (null !== $thumbnailCount) {
@@ -42,13 +41,7 @@ class CM_MediaStreams_StreamRepository {
         }
         if (null !== $mediaId) {
             $mediaId = (string) $mediaId;
-            $existsMediaArchive = CM_Db_Db::exec('SELECT EXISTS( SELECT 1 FROM `cm_streamChannelArchive_media` WHERE mediaId = ? )', [$mediaId])->fetchColumn();
-
-            if (1 === $existsMediaArchive) {
-                throw new CM_Exception_Invalid('Archive with given mediaId already exists');
-            }
         }
-
         return CM_Model_StreamChannel_Abstract::createType($streamChannelType, [
             'key'            => $streamName,
             'adapterType'    => $this->_adapterType,

--- a/library/CM/MediaStreams/StreamRepository.php
+++ b/library/CM/MediaStreams/StreamRepository.php
@@ -34,6 +34,7 @@ class CM_MediaStreams_StreamRepository {
      * @param int|null    $thumbnailCount
      * @param string|null $mediaId
      * @return CM_Model_StreamChannel_Abstract
+     * @throws CM_Exception_Invalid
      */
     public function createStreamChannel($streamName, $streamChannelType, $serverId, $thumbnailCount = null, $mediaId = null) {
         if (null !== $thumbnailCount) {
@@ -41,7 +42,13 @@ class CM_MediaStreams_StreamRepository {
         }
         if (null !== $mediaId) {
             $mediaId = (string) $mediaId;
+            $existsMediaArchive = CM_Db_Db::exec('SELECT EXISTS( SELECT 1 FROM `cm_streamChannelArchive_media` WHERE mediaId = ? )', [$mediaId])->fetchColumn();
+
+            if (1 === $existsMediaArchive) {
+                throw new CM_Exception_Invalid('Archive with given mediaId already exists');
+            }
         }
+
         return CM_Model_StreamChannel_Abstract::createType($streamChannelType, [
             'key'            => $streamName,
             'adapterType'    => $this->_adapterType,

--- a/library/CM/Model/StreamChannelArchive/Media.php
+++ b/library/CM/Model/StreamChannelArchive/Media.php
@@ -202,7 +202,7 @@ class CM_Model_StreamChannelArchive_Media extends CM_Model_StreamChannelArchive_
             'data'              => CM_Params::jsonEncode(['thumbnailCount' => $thumbnailCount]),
             'key'               => $streamChannel->getKey(),
             'mediaId'           => $streamChannel->getMediaId(),
-        ]);
+        ], null, ['id' => ['literal' => 'LAST_INSERT_ID(id)']]);
         return new self($streamChannel->getId());
     }
 

--- a/tests/library/CM/Model/StreamChannelArchive/MediaTest.php
+++ b/tests/library/CM/Model/StreamChannelArchive/MediaTest.php
@@ -36,6 +36,22 @@ class CM_Model_StreamChannelArchive_MediaTest extends CMTest_TestCase {
         $this->assertSame($streamChannel->getHash(), $archive->getHash());
     }
 
+    public function testCreateDuplicated() {
+        $channel = CM_Model_StreamChannel_Media::createStatic(array(
+            'key'            => 'foo',
+            'serverId'       => 1,
+            'thumbnailCount' => 2,
+            'adapterType'    => 1,
+            'mediaId'        => 'foo',
+        ));
+        $archive1 = CM_Model_StreamChannelArchive_Media::createStatic(['streamChannel' => $channel]);
+        $archive2 = CM_Model_StreamChannelArchive_Media::createStatic(['streamChannel' => $channel]);
+        $this->assertInstanceOf('CM_Model_StreamChannelArchive_Media', $archive2);
+
+        $this->assertSame($archive1->getId(), $archive2->getId());
+        $this->assertSame($archive1->getCreated(), $archive2->getCreated());
+    }
+
     public function testNoUser() {
         /** @var CM_Model_StreamChannel_Media $streamChannel */
         $streamChannel = CMTest_TH::createStreamChannel();


### PR DESCRIPTION
Could we something similar like in https://github.com/cargomedia/cm/pull/2054, but for streamchannel *archives*

ON DUPLICATE KEY UPDATE