### PR TITLE
Implement copy from "local" to "s3" filesystem without reading content into memory

### DIFF
--- a/library/CM/File.php
+++ b/library/CM/File.php
@@ -184,9 +184,18 @@ class CM_File extends CM_Class_Abstract implements CM_Comparable {
      * @param CM_File $file
      */
     public function copyToFile(CM_File $file) {
-        $sameFilesystemAdapter = $this->_filesystem->equals($file->_filesystem);
-        if ($sameFilesystemAdapter) {
+        $filesystemSource = $this->_filesystem;
+        $filesystemDestination = $file->_filesystem;
+        $adapterSource = $filesystemSource->getAdapter();
+        $adapterDestination = $filesystemDestination->getAdapter();
+        if ($filesystemSource->equals($filesystemDestination)) {
             $this->copy($file->getPath());
+        } elseif ($adapterSource instanceof CM_File_Filesystem_Adapter_StreamInterface &&
+            $adapterDestination instanceof CM_File_Filesystem_Adapter_StreamInterface
+        ) {
+            $streamSource = $adapterSource->getStreamRead($this->getPath());
+            $streamDestination = $adapterDestination->getStreamWrite($file->getPath());
+            stream_copy_to_stream($streamSource, $streamDestination);
         } else {
             $file->write($this->read());
         }

--- a/library/CM/File.php
+++ b/library/CM/File.php
@@ -196,6 +196,8 @@ class CM_File extends CM_Class_Abstract implements CM_Comparable {
             $streamSource = $adapterSource->getStreamRead($this->getPath());
             $streamDestination = $adapterDestination->getStreamWrite($file->getPath());
             stream_copy_to_stream($streamSource, $streamDestination);
+            @fclose($streamDestination);
+            @fclose($streamSource);
         } else {
             $file->write($this->read());
         }

--- a/library/CM/File/Filesystem/Adapter/AwsS3.php
+++ b/library/CM/File/Filesystem/Adapter/AwsS3.php
@@ -19,8 +19,12 @@ class CM_File_Filesystem_Adapter_AwsS3 extends CM_File_Filesystem_Adapter implem
      * @param string          $bucket
      * @param string|null     $acl
      * @param string|null     $pathPrefix
+     * @throws CM_Exception
      */
     public function __construct(Aws\S3\S3Client $client, $bucket, $acl = null, $pathPrefix = null) {
+        if (!in_array('s3', stream_get_wrappers(), true)) {
+            throw new CM_Exception('Stream wrapper not enabled');
+        }
         parent::__construct($pathPrefix);
         if (null === $acl) {
             $acl = 'private';

--- a/library/CM/File/Filesystem/Adapter/AwsS3.php
+++ b/library/CM/File/Filesystem/Adapter/AwsS3.php
@@ -22,9 +22,6 @@ class CM_File_Filesystem_Adapter_AwsS3 extends CM_File_Filesystem_Adapter implem
      * @throws CM_Exception
      */
     public function __construct(Aws\S3\S3Client $client, $bucket, $acl = null, $pathPrefix = null) {
-        if (!in_array('s3', stream_get_wrappers(), true)) {
-            throw new CM_Exception('Stream wrapper not enabled');
-        }
         parent::__construct($pathPrefix);
         if (null === $acl) {
             $acl = 'private';
@@ -36,6 +33,9 @@ class CM_File_Filesystem_Adapter_AwsS3 extends CM_File_Filesystem_Adapter implem
 
     public function getStreamRead($path) {
         $streamUrl = $this->_getStreamUrl($path);
+        if (!in_array('s3', stream_get_wrappers(), true)) {
+            throw new CM_Exception('Stream wrapper not enabled');
+        }
         $stream = @fopen($streamUrl, 'r');
         if (false === $stream) {
             throw new CM_Exception('Cannot open read stream for `' . $streamUrl . '`.');
@@ -45,6 +45,9 @@ class CM_File_Filesystem_Adapter_AwsS3 extends CM_File_Filesystem_Adapter implem
 
     public function getStreamWrite($path) {
         $streamUrl = $this->_getStreamUrl($path);
+        if (!in_array('s3', stream_get_wrappers(), true)) {
+            throw new CM_Exception('Stream wrapper not enabled');
+        }
         $stream = @fopen($streamUrl, 'w');
         if (false === $stream) {
             throw new CM_Exception('Cannot open write stream for `' . $streamUrl . '`.');

--- a/library/CM/File/Filesystem/Adapter/Local.php
+++ b/library/CM/File/Filesystem/Adapter/Local.php
@@ -3,7 +3,8 @@
 class CM_File_Filesystem_Adapter_Local extends CM_File_Filesystem_Adapter implements
     CM_File_Filesystem_Adapter_ChecksumCalculatorInterface,
     CM_File_Filesystem_Adapter_SizeCalculatorInterface,
-    CM_File_Filesystem_Adapter_AppendInterface {
+    CM_File_Filesystem_Adapter_AppendInterface,
+    CM_File_Filesystem_Adapter_StreamInterface {
 
     /** @var int */
     private $_mode;
@@ -18,6 +19,24 @@ class CM_File_Filesystem_Adapter_Local extends CM_File_Filesystem_Adapter implem
             $mode = 0777;
         }
         $this->_mode = (int) $mode;
+    }
+
+    public function getStreamRead($path) {
+        $pathAbsolute = $this->_getAbsolutePath($path);
+        $stream = @fopen($pathAbsolute, 'r');
+        if (false === $stream) {
+            throw new CM_Exception('Cannot open read stream for `' . $pathAbsolute . '`.');
+        }
+        return $stream;
+    }
+
+    public function getStreamWrite($path) {
+        $pathAbsolute = $this->_getAbsolutePath($path);
+        $stream = @fopen($pathAbsolute, 'w');
+        if (false === $stream) {
+            throw new CM_Exception('Cannot open write stream for `' . $pathAbsolute . '`.');
+        }
+        return $stream;
     }
 
     public function read($path) {

--- a/library/CM/File/Filesystem/Adapter/StreamInterface.php
+++ b/library/CM/File/Filesystem/Adapter/StreamInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+interface CM_File_Filesystem_Adapter_StreamInterface {
+
+    /**
+     * @param string $path
+     * @return resource
+     * @throws CM_Exception
+     */
+    public function getStreamRead($path);
+
+    /**
+     * @param string $path
+     * @return resource
+     * @throws CM_Exception
+     */
+    public function getStreamWrite($path);
+}

--- a/library/CM/File/Filesystem/Factory.php
+++ b/library/CM/File/Filesystem/Factory.php
@@ -27,6 +27,7 @@ class CM_File_Filesystem_Factory {
                     $clientParams['region'] = $options['region'];
                 }
                 $client = \Aws\S3\S3Client::factory($clientParams);
+                $client->registerStreamWrapper();
                 return new CM_File_Filesystem_Adapter_AwsS3($client, $options['bucket'], $acl, $pathPrefix);
                 break;
             default:


### PR DESCRIPTION
As discovered with @tomaszdurka 
Currently `CM_File::copyToFile(CM_File $file)` will read the complete file contents into memory to write them to the new location, if the two filesystems of the operation are different.

If we copy a big file from *local* to *s3* filesystem this can easily lead to memory exhaustion of PHP.

Should we introduce a special `copyFromLocal()` which could be optionally implemented by some file systems (defined with an interface, similar like we do it for `CM_File_Filesystem_Adapter_AppendInterface`).

@fauvel could you look into this?