### PR TITLE
Prevent browser from caching page loads, even in history

### DIFF
--- a/library/CM/Http/Response/Abstract.php
+++ b/library/CM/Http/Response/Abstract.php
@@ -162,6 +162,11 @@ abstract class CM_Http_Response_Abstract extends CM_Class_Abstract implements CM
         $this->addHeaderRaw('HTTP/1.0 404 Not Found');
     }
 
+    public function setHeaderDisableCache() {
+        # Via http://stackoverflow.com/questions/49547/making-sure-a-web-page-is-not-cached-across-all-browsers/5493543#5493543
+        $this->setHeader('Cache-Control', 'no-store, must-revalidate');
+    }
+
     /**
      * @param string $key
      * @param string $value
@@ -260,7 +265,7 @@ abstract class CM_Http_Response_Abstract extends CM_Class_Abstract implements CM
             $exceptionsToCatch = $config->exceptionsToCatch;
             $catchPublicExceptions = !empty($config->catchPublicExceptions);
             $errorOptions = \Functional\first($exceptionsToCatch, function ($options, $exceptionClass) use ($ex) {
-                return is_a($ex, $exceptionClass) ;
+                return is_a($ex, $exceptionClass);
             });
             $catchException = null !== $errorOptions;
             if ($catchException) {

--- a/library/CM/Http/Response/Page.php
+++ b/library/CM/Http/Response/Page.php
@@ -67,6 +67,7 @@ class CM_Http_Response_Page extends CM_Http_Response_Abstract {
     }
 
     protected function _process() {
+        $this->setHeaderDisableCache();
         $this->_site->preprocessPageResponse($this);
         $this->_processContentOrRedirect();
         if ($redirectUrl = $this->getRedirectUrl()) {

--- a/tests/library/CM/Http/Response/PageTest.php
+++ b/tests/library/CM/Http/Response/PageTest.php
@@ -56,7 +56,9 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
 
         $response = CMTest_TH::createResponsePage('/mock5', array('host' => $site->getHost()));
         $response->process();
-        $this->assertEmpty($response->getHeaders());
+        $this->assertFalse(Functional\some($response->getHeaders(), function($header) {
+            return preg_match('/^Location:/', $header);
+        }));
 
         $response = CMTest_TH::createResponsePage('/mock5', array('host' => 'incorrect-host.org'));
         $response->process();


### PR DESCRIPTION
Usually our pages load via an AJAX POST request, so they're never cached.
But if the next page has a different layout than the current one, the whole page will be refreshed.
In this case we want to also avoid that the browser caches the page load.

@zazabe @fauvel please review