### PR TITLE
Remove unneeded variables from CSS cache key

### DIFF
--- a/library/CM/App.php
+++ b/library/CM/App.php
@@ -38,18 +38,16 @@ class CM_App implements CM_Service_ManagerAwareInterface {
 
         /** @var CM_Asset_Javascript_Abstract[] $assetList */
         $assetList = array();
-        $languageList = new CM_Paging_Language_Enabled();
         foreach (CM_Site_Abstract::getAll() as $site) {
+            $render = new CM_Frontend_Render(new CM_Frontend_Environment($site));
             $assetList[] = new CM_Asset_Javascript_Internal($site);
             $assetList[] = new CM_Asset_Javascript_Library($site);
             $assetList[] = new CM_Asset_Javascript_Vendor_BeforeBody($site);
             $assetList[] = new CM_Asset_Javascript_Vendor_AfterBody($site);
-            foreach ($languageList as $language) {
-                $render = new CM_Frontend_Render(new CM_Frontend_Environment($site, null, $language));
-                $assetList[] = new CM_Asset_Css_Vendor($render);
-                $assetList[] = new CM_Asset_Css_Library($render);
-            }
+            $assetList[] = new CM_Asset_Css_Vendor($render);
+            $assetList[] = new CM_Asset_Css_Library($render);
         }
+        $languageList = new CM_Paging_Language_Enabled();
         foreach ($languageList as $language) {
             $assetList[] = new CM_Asset_Javascript_Translations($language);
         }

--- a/library/CM/Asset/Css.php
+++ b/library/CM/Asset/Css.php
@@ -89,10 +89,6 @@ class CM_Asset_Css extends CM_Asset_Abstract {
 
         $cacheKey = CM_CacheConst::App_Resource . '_md5:' . md5($content);
         $cacheKey .= '_compress:' . (int) $compress;
-        $cacheKey .= '_siteId:' . $render->getSite()->getId();
-        if ($render->getLanguage()) {
-            $cacheKey .= '_languageId:' . $render->getLanguage()->getId();
-        }
         $cache = new CM_Cache_Storage_File();
         if (false === ($contentTransformed = $cache->get($cacheKey))) {
             $contentTransformed = $content;

--- a/library/CM/CacheConst.php
+++ b/library/CM/CacheConst.php
@@ -49,8 +49,6 @@ class CM_CacheConst {
 
     //_md5:X
     //_md5:X_compress:X
-    //_md5:X_compress:X_siteId:X
-    //_md5:X_compress:X_siteId:X_languageId:X
     const App_Resource = 'App_Resource';
 
     //_lock:X


### PR DESCRIPTION
siteId and languageId are *not* used to compile the CSS, so they can't affect it.