### PR TITLE
remove hasClientId() check

### DIFF
--- a/library/CM/Log/Handler/MongoDb.php
+++ b/library/CM/Log/Handler/MongoDb.php
@@ -85,9 +85,7 @@ class CM_Log_Handler_MongoDb extends CM_Log_Handler_Abstract {
                 'headers' => $request->getHeaders(),
             ];
 
-            if ($request->hasClientId()) {
-                $formattedContext['httpRequest']['clientId'] = $request->getClientId();
-            }
+            $formattedContext['httpRequest']['clientId'] = $request->getClientId();
         }
 
         return [


### PR DESCRIPTION
to always have clientId in mongo event logs