### PR TITLE
Allow configuration of multiple janus services

### DIFF
--- a/library/CM/Janus/Configuration.php
+++ b/library/CM/Janus/Configuration.php
@@ -43,6 +43,20 @@ class CM_Janus_Configuration {
     }
 
     /**
+     * @param string $plugin
+     * @return CM_Janus_Server|null
+     */
+    public function findServerByPlugin($plugin) {
+        $plugin = (string) $plugin;
+        foreach ($this->_servers as $server) {
+            if (in_array($plugin, $server->getPluginList())) {
+                return $server;
+            }
+        }
+        return null;
+    }
+
+    /**
      * @param int $id
      * @return CM_Janus_Server
      * @throws CM_Exception_Invalid

--- a/library/CM/Janus/Configuration.php
+++ b/library/CM/Janus/Configuration.php
@@ -48,11 +48,11 @@ class CM_Janus_Configuration {
      */
     public function findServerByPlugin($plugin) {
         $plugin = (string) $plugin;
-        $pluginServerList = Functional\filter($this->_servers, function (CM_Janus_Server $server) use ($plugin) {
+        $pluginServerList = array_values(Functional\filter($this->_servers, function (CM_Janus_Server $server) use ($plugin) {
             return in_array($plugin, $server->getPluginList());
-        });
+        }));
         if (!empty($pluginServerList)) {
-            return $pluginServerList[array_rand($pluginServerList)];
+            return $pluginServerList[mt_rand(0, count($pluginServerList) - 1)];
         }
         return null;
     }

--- a/library/CM/Janus/Configuration.php
+++ b/library/CM/Janus/Configuration.php
@@ -48,10 +48,11 @@ class CM_Janus_Configuration {
      */
     public function findServerByPlugin($plugin) {
         $plugin = (string) $plugin;
-        foreach ($this->_servers as $server) {
-            if (in_array($plugin, $server->getPluginList())) {
-                return $server;
-            }
+        $pluginServerList = Functional\filter($this->_servers, function (CM_Janus_Server $server) use ($plugin) {
+            return in_array($plugin, $server->getPluginList());
+        });
+        if (!empty($pluginServerList)) {
+            return $pluginServerList[array_rand($pluginServerList)];
         }
         return null;
     }

--- a/library/CM/Janus/Factory.php
+++ b/library/CM/Janus/Factory.php
@@ -9,7 +9,6 @@ class CM_Janus_Factory {
      */
     public function createService(array $servers) {
         $configuration = new CM_Janus_Configuration();
-        $allPluginList = [];
 
         foreach ($servers as $serverId => $serverConfig) {
             $iceServerList = isset($serverConfig['iceServerList']) ? $serverConfig['iceServerList'] : null;
@@ -18,11 +17,6 @@ class CM_Janus_Factory {
                 throw new CM_Exception_Invalid('Server pluginList is empty');
             }
             $serverPluginList = $serverConfig['pluginList'];
-            $pluginsIntersection = array_intersect($allPluginList, $serverPluginList);
-            if (!empty($pluginsIntersection)) {
-                throw new CM_Exception_Invalid('Each janus server plugin should point to exactly one server');
-            }
-
             $configuration->addServer(new CM_Janus_Server(
                 $serverId,
                 $serverConfig['key'],
@@ -31,7 +25,6 @@ class CM_Janus_Factory {
                 $serverPluginList,
                 $iceServerList
             ));
-            $allPluginList = array_merge($allPluginList, $serverPluginList);
         }
 
         $httpClient = new GuzzleHttp\Client();

--- a/library/CM/Janus/Factory.php
+++ b/library/CM/Janus/Factory.php
@@ -5,18 +5,33 @@ class CM_Janus_Factory {
     /**
      * @param array $servers
      * @return CM_Janus_Service
+     * @throws CM_Exception_Invalid
      */
     public function createService(array $servers) {
         $configuration = new CM_Janus_Configuration();
+        $allPluginList = [];
+
         foreach ($servers as $serverId => $serverConfig) {
             $iceServerList = isset($serverConfig['iceServerList']) ? $serverConfig['iceServerList'] : null;
+
+            if (empty($serverConfig['pluginList'])) {
+                throw new CM_Exception_Invalid('Server pluginList is empty');
+            }
+            $serverPluginList = $serverConfig['pluginList'];
+            $pluginsIntersection = array_intersect($allPluginList, $serverPluginList);
+            if (!empty($pluginsIntersection)) {
+                throw new CM_Exception_Invalid('Each janus server plugin should point to exactly one server');
+            }
+
             $configuration->addServer(new CM_Janus_Server(
                 $serverId,
                 $serverConfig['key'],
                 $serverConfig['httpAddress'],
                 $serverConfig['webSocketAddress'],
+                $serverPluginList,
                 $iceServerList
             ));
+            $allPluginList = array_merge($allPluginList, $serverPluginList);
         }
 
         $httpClient = new GuzzleHttp\Client();

--- a/library/CM/Janus/Factory.php
+++ b/library/CM/Janus/Factory.php
@@ -16,13 +16,12 @@ class CM_Janus_Factory {
             if (empty($serverConfig['pluginList'])) {
                 throw new CM_Exception_Invalid('Server pluginList is empty');
             }
-            $serverPluginList = $serverConfig['pluginList'];
             $configuration->addServer(new CM_Janus_Server(
                 $serverId,
                 $serverConfig['key'],
                 $serverConfig['httpAddress'],
                 $serverConfig['webSocketAddress'],
-                $serverPluginList,
+                $serverConfig['pluginList'],
                 $iceServerList
             ));
         }

--- a/library/CM/Janus/Server.php
+++ b/library/CM/Janus/Server.php
@@ -14,6 +14,9 @@ class CM_Janus_Server {
     /** @var string */
     protected $_key;
 
+    /** @var string[] */
+    protected $_pluginList;
+
     /** @var  array */
     protected $_iceServerList;
 
@@ -22,9 +25,10 @@ class CM_Janus_Server {
      * @param string     $key
      * @param string     $httpAddress
      * @param string     $webSocketAddress
+     * @param string[]   $pluginList
      * @param array|null $iceServerList
      */
-    public function __construct($serverId, $key, $httpAddress, $webSocketAddress, array $iceServerList = null) {
+    public function __construct($serverId, $key, $httpAddress, $webSocketAddress, array $pluginList, array $iceServerList = null) {
         if (null === $iceServerList) {
             $iceServerList = [];
         }
@@ -32,6 +36,9 @@ class CM_Janus_Server {
         $this->_key = (string) $key;
         $this->_httpAddress = (string) $httpAddress;
         $this->_webSocketAddress = (string) $webSocketAddress;
+        $this->_pluginList = array_map(function ($el) {
+            return (string) $el;
+        }, $pluginList);
         $this->_iceServerList = $iceServerList;
     }
 
@@ -61,6 +68,13 @@ class CM_Janus_Server {
      */
     public function getWebSocketAddress() {
         return $this->_webSocketAddress;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPluginList() {
+        return $this->_pluginList;
     }
 
     /**

--- a/library/CM/Janus/Server.php
+++ b/library/CM/Janus/Server.php
@@ -36,8 +36,8 @@ class CM_Janus_Server {
         $this->_key = (string) $key;
         $this->_httpAddress = (string) $httpAddress;
         $this->_webSocketAddress = (string) $webSocketAddress;
-        $this->_pluginList = array_map(function ($el) {
-            return (string) $el;
+        $this->_pluginList = array_map(function ($plugin) {
+            return (string) $plugin;
         }, $pluginList);
         $this->_iceServerList = $iceServerList;
     }

--- a/tests/library/CM/Janus/ConfigurationTest.php
+++ b/tests/library/CM/Janus/ConfigurationTest.php
@@ -15,6 +15,21 @@ class CM_Janus_ConfigurationTest extends CMTest_TestCase {
         $this->assertSame(null, $configuration->findServerByKey('zoo'));
     }
 
+    public function testFindServerByPlugin() {
+        $server1 = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();
+        $server1->mockMethod('getPluginList')->set(['audio', 'audioHD']);
+        $server2 = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();
+        $server2->mockMethod('getPluginList')->set(['video', 'videoHD']);
+
+        $configuration = new CM_Janus_Configuration([$server1, $server2]);
+
+        $this->assertSame($server1, $configuration->findServerByPlugin('audio'));
+        $this->assertSame($server1, $configuration->findServerByPlugin('audioHD'));
+        $this->assertSame($server2, $configuration->findServerByPlugin('videoHD'));
+        $this->assertSame(null, $configuration->findServerByKey('bar'));
+    }
+
+
     public function testGetServer() {
         $server = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();
         $server->mockMethod('getId')->set(1);

--- a/tests/library/CM/Janus/ConfigurationTest.php
+++ b/tests/library/CM/Janus/ConfigurationTest.php
@@ -17,7 +17,7 @@ class CM_Janus_ConfigurationTest extends CMTest_TestCase {
 
     public function testFindServerByPlugin() {
         $server1 = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();
-        $server1->mockMethod('getPluginList')->set(['audio', 'audioHD']);
+        $server1->mockMethod('getPluginList')->set(['audio', 'audioHD', 'video']);
         $server2 = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();
         $server2->mockMethod('getPluginList')->set(['video', 'videoHD']);
 
@@ -26,6 +26,12 @@ class CM_Janus_ConfigurationTest extends CMTest_TestCase {
         $this->assertSame($server1, $configuration->findServerByPlugin('audio'));
         $this->assertSame($server1, $configuration->findServerByPlugin('audioHD'));
         $this->assertSame($server2, $configuration->findServerByPlugin('videoHD'));
+        mt_srand(2);
+        srand(2);
+        $this->assertSame($server2, $configuration->findServerByPlugin('video'));
+        mt_srand(5);
+        srand(5);
+        $this->assertSame($server1, $configuration->findServerByPlugin('video'));
         $this->assertSame(null, $configuration->findServerByKey('bar'));
     }
 

--- a/tests/library/CM/Janus/ConfigurationTest.php
+++ b/tests/library/CM/Janus/ConfigurationTest.php
@@ -26,11 +26,9 @@ class CM_Janus_ConfigurationTest extends CMTest_TestCase {
         $this->assertSame($server1, $configuration->findServerByPlugin('audio'));
         $this->assertSame($server1, $configuration->findServerByPlugin('audioHD'));
         $this->assertSame($server2, $configuration->findServerByPlugin('videoHD'));
-        mt_srand(2);
-        srand(2);
+        mt_srand(1);
         $this->assertSame($server2, $configuration->findServerByPlugin('video'));
-        mt_srand(5);
-        srand(5);
+        mt_srand(3);
         $this->assertSame($server1, $configuration->findServerByPlugin('video'));
         $this->assertSame(null, $configuration->findServerByKey('bar'));
     }

--- a/tests/library/CM/Janus/FactorytTest.php
+++ b/tests/library/CM/Janus/FactorytTest.php
@@ -29,30 +29,7 @@ class CM_Janus_FactoryTest extends CMTest_TestCase {
             $factory->createService($serversConfig);
         });
         $this->assertInstanceOf('CM_Exception_Invalid', $exception);
-        $this->assertSame('Server pluginList is empty' , $exception->getMessage());
-
-        $serversConfig = [
-            1 => [
-                'key'              => 'foo-bar',
-                'httpAddress'      => 'http://cm-janus.dev:8080',
-                'webSocketAddress' => 'ws://cm-janus.dev:8188',
-                'pluginList'       => ['audio', 'audioHD'],
-                'iceServerList'    => $iceServerList,
-            ],
-            6 => [
-                'key'              => 'foo-bar-baz',
-                'httpAddress'      => 'http://cm-janus.dev:8081',
-                'webSocketAddress' => 'ws://cm-janus.dev:8189',
-                'pluginList'       => ['audio', 'video'],
-                'iceServerList'    => $iceServerList,
-            ],
-        ];
-
-        $exception = $this->catchException(function () use ($factory, $serversConfig) {
-            $factory->createService($serversConfig);
-        });
-        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
-        $this->assertSame('Each janus server plugin should point to exactly one server' , $exception->getMessage());
+        $this->assertSame('Server pluginList is empty', $exception->getMessage());
     }
 
     public function testCreateServiceSuccess() {
@@ -73,7 +50,7 @@ class CM_Janus_FactoryTest extends CMTest_TestCase {
                 'key'              => 'foo-bar-baz',
                 'httpAddress'      => 'http://cm-janus.dev:8081',
                 'webSocketAddress' => 'ws://cm-janus.dev:8189',
-                'pluginList'       => ['video'],
+                'pluginList'       => ['video', 'audio', 'videoHD'],
                 'iceServerList'    => $iceServerList,
             ],
         ];
@@ -86,11 +63,13 @@ class CM_Janus_FactoryTest extends CMTest_TestCase {
         $this->assertSame('http://cm-janus.dev:8080', $servers[0]->getHttpAddress());
         $this->assertSame('ws://cm-janus.dev:8188', $servers[0]->getWebSocketAddress());
         $this->assertSame($iceServerList, $servers[0]->getIceServerList());
+        $this->assertSame($serversConfig[5]['pluginList'], $servers[0]->getPluginList());
 
         $this->assertSame(6, $servers[1]->getId());
         $this->assertSame('foo-bar-baz', $servers[1]->getKey());
         $this->assertSame('http://cm-janus.dev:8081', $servers[1]->getHttpAddress());
         $this->assertSame('ws://cm-janus.dev:8189', $servers[1]->getWebSocketAddress());
         $this->assertSame($iceServerList, $servers[1]->getIceServerList());
+        $this->assertSame($serversConfig[6]['pluginList'], $servers[1]->getPluginList());
     }
 }

--- a/tests/library/CM/Janus/FactorytTest.php
+++ b/tests/library/CM/Janus/FactorytTest.php
@@ -2,8 +2,7 @@
 
 class CM_Janus_FactoryTest extends CMTest_TestCase {
 
-    public function testCreateService() {
-
+    public function testCreateServiceFail() {
         $iceServerList = [
             ['url' => 'turn:example.com:3478', 'username' => 'foo', 'credential' => 'bar'],
             ['url' => 'turn:test.com:3478', 'username' => 'baz', 'credential' => 'quux'],
@@ -14,17 +13,84 @@ class CM_Janus_FactoryTest extends CMTest_TestCase {
                 'key'              => 'foo-bar',
                 'httpAddress'      => 'http://cm-janus.dev:8080',
                 'webSocketAddress' => 'ws://cm-janus.dev:8188',
+                'pluginList'       => ['audio', 'audioHD'],
+                'iceServerList'    => $iceServerList,
+            ],
+            6 => [
+                'key'              => 'foo-bar-baz',
+                'httpAddress'      => 'http://cm-janus.dev:8081',
+                'webSocketAddress' => 'ws://cm-janus.dev:8189',
+                'pluginList'       => [],
+                'iceServerList'    => $iceServerList,
+            ],
+        ];
+        $factory = new CM_Janus_Factory();
+        $exception = $this->catchException(function () use ($factory, $serversConfig) {
+            $factory->createService($serversConfig);
+        });
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertSame('Server pluginList is empty' , $exception->getMessage());
+
+        $serversConfig = [
+            1 => [
+                'key'              => 'foo-bar',
+                'httpAddress'      => 'http://cm-janus.dev:8080',
+                'webSocketAddress' => 'ws://cm-janus.dev:8188',
+                'pluginList'       => ['audio', 'audioHD'],
+                'iceServerList'    => $iceServerList,
+            ],
+            6 => [
+                'key'              => 'foo-bar-baz',
+                'httpAddress'      => 'http://cm-janus.dev:8081',
+                'webSocketAddress' => 'ws://cm-janus.dev:8189',
+                'pluginList'       => ['audio', 'video'],
+                'iceServerList'    => $iceServerList,
+            ],
+        ];
+
+        $exception = $this->catchException(function () use ($factory, $serversConfig) {
+            $factory->createService($serversConfig);
+        });
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertSame('Each janus server plugin should point to exactly one server' , $exception->getMessage());
+    }
+
+    public function testCreateServiceSuccess() {
+        $iceServerList = [
+            ['url' => 'turn:example.com:3478', 'username' => 'foo', 'credential' => 'bar'],
+            ['url' => 'turn:test.com:3478', 'username' => 'baz', 'credential' => 'quux'],
+        ];
+
+        $serversConfig = [
+            5 => [
+                'key'              => 'foo-bar',
+                'httpAddress'      => 'http://cm-janus.dev:8080',
+                'webSocketAddress' => 'ws://cm-janus.dev:8188',
+                'pluginList'       => ['audio', 'audioHD'],
+                'iceServerList'    => $iceServerList,
+            ],
+            6 => [
+                'key'              => 'foo-bar-baz',
+                'httpAddress'      => 'http://cm-janus.dev:8081',
+                'webSocketAddress' => 'ws://cm-janus.dev:8189',
+                'pluginList'       => ['video'],
                 'iceServerList'    => $iceServerList,
             ],
         ];
         $factory = new CM_Janus_Factory();
         $janus = $factory->createService($serversConfig);
         $servers = $janus->getConfiguration()->getServers();
-        $this->assertCount(1, $servers);
+        $this->assertCount(2, $servers);
         $this->assertSame(5, $servers[0]->getId());
         $this->assertSame('foo-bar', $servers[0]->getKey());
         $this->assertSame('http://cm-janus.dev:8080', $servers[0]->getHttpAddress());
         $this->assertSame('ws://cm-janus.dev:8188', $servers[0]->getWebSocketAddress());
         $this->assertSame($iceServerList, $servers[0]->getIceServerList());
+
+        $this->assertSame(6, $servers[1]->getId());
+        $this->assertSame('foo-bar-baz', $servers[1]->getKey());
+        $this->assertSame('http://cm-janus.dev:8081', $servers[1]->getHttpAddress());
+        $this->assertSame('ws://cm-janus.dev:8189', $servers[1]->getWebSocketAddress());
+        $this->assertSame($iceServerList, $servers[1]->getIceServerList());
     }
 }

--- a/tests/library/CM/Janus/HttpApiClientTest.php
+++ b/tests/library/CM/Janus/HttpApiClientTest.php
@@ -19,7 +19,7 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
         });
         /** @var GuzzleHttp\Client $httpClient */
 
-        $server = new CM_Janus_Server(0, 'bar', 'http://cm-janus.dev:8080', 'ws://cm-janus.dev:8188');
+        $server = new CM_Janus_Server(0, 'bar', 'http://cm-janus.dev:8080', 'ws://cm-janus.dev:8188', []);
         $api = new CM_Janus_HttpApiClient($httpClient);
         $api->stopStream($server, 'foo');
         $this->assertSame(1, $sendRequestMethod->getCallCount());
@@ -41,7 +41,7 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
         });
         /** @var GuzzleHttp\Client $httpClient */
 
-        $server = new CM_Janus_Server(0, 'bar', 'http://cm-janus.dev:8080', 'ws://cm-janus.dev:8188');
+        $server = new CM_Janus_Server(0, 'bar', 'http://cm-janus.dev:8080', 'ws://cm-janus.dev:8188', []);
         $api = new CM_Janus_HttpApiClient($httpClient);
         $result = $api->fetchStatus($server);
         $this->assertSame([['id' => 'foo', 'channelName' => 'bar'], ['id' => 'baz', 'channelName' => 'quux']], $result);
@@ -56,7 +56,7 @@ class CM_Janus_HttpApiClientTest extends CMTest_TestCase {
             throw new GuzzleHttp\Exception\TransferException();
         });
 
-        $server = new CM_Janus_Server(0, 'bar', 'http://cm-janus.dev:8080', 'ws://cm-janus.dev:8188');
+        $server = new CM_Janus_Server(0, 'bar', 'http://cm-janus.dev:8080', 'ws://cm-janus.dev:8188', []);
         $api = new CM_Janus_HttpApiClient($httpClient);
         $exception = $this->catchException(function () use ($api, $server) {
             $api->fetchStatus($server);

--- a/tests/library/CM/Janus/ServiceTest.php
+++ b/tests/library/CM/Janus/ServiceTest.php
@@ -92,7 +92,7 @@ class CM_Janus_ServiceTest extends CMTest_TestCase {
 
         $emptyStreamChannel = CMTest_TH::createStreamChannel(null, CM_Janus_Service::getTypeStatic());
 
-        $server1 = $this->mockClass('CM_Janus_Server')->newInstance([1, 'key', 'http://mock', 'ws://mock']);
+        $server1 = $this->mockClass('CM_Janus_Server')->newInstance([1, 'key', 'http://mock', 'ws://mock', []]);
         /** @var CM_Janus_Configuration|\Mocka\AbstractClassTrait $configuration */
         $configuration = $this->mockObject('CM_Janus_Configuration');
         $configuration->mockMethod('getServers')->set([$server1]);
@@ -149,7 +149,7 @@ class CM_Janus_ServiceTest extends CMTest_TestCase {
         $streamChannelKey2 = $streamChannel2->getKey();
         CMTest_TH::createStreamPublish(null, $streamChannel2); //to make channel non empty
 
-        $server1 = $this->mockClass('CM_Janus_Server')->newInstance([1, 'key', 'http://mock', 'ws://mock']);
+        $server1 = $this->mockClass('CM_Janus_Server')->newInstance([1, 'key', 'http://mock', 'ws://mock', []]);
         /** @var CM_Janus_Configuration|\Mocka\AbstractClassTrait $configuration */
         $configuration = $this->mockObject('CM_Janus_Configuration');
         $configuration->mockMethod('getServers')->set([$server1]);


### PR DESCRIPTION
As a preparation for scaling the janus infrastructure we'd like to separate the *audio* and the *video* streams to separate janus servers.

My initial thought is that we could configure two independent janus services in the service manager (`janus-audio` and `janus-video`). When connecting to a stream we would then read the configuration from the right service.

@fvovan what do you think, does it make sense?
We also need to make sure that synchronization with multiple januses works on the streamchannel level. Could you check this as well?

cc @tomaszdurka 