### PR TITLE
StreamRepository: Argument #1 is not an array

### DIFF
--- a/library/CM/MediaStreams/StreamRepository.php
+++ b/library/CM/MediaStreams/StreamRepository.php
@@ -44,10 +44,10 @@ class CM_MediaStreams_StreamRepository {
         }
 
         return CM_Model_StreamChannel_Abstract::createType($streamChannelType, [
-            'key'            => $streamName,
-            'adapterType'    => $this->_adapterType,
-            'serverId'       => (int) $serverId,
-            'mediaId'        => $mediaId,
+            'key'         => $streamName,
+            'adapterType' => $this->_adapterType,
+            'serverId'    => (int) $serverId,
+            'mediaId'     => $mediaId,
         ]);
     }
 
@@ -102,10 +102,11 @@ class CM_MediaStreams_StreamRepository {
      * @param CM_Model_StreamChannel_Abstract $streamChannel
      */
     public function removeStreamChannel(CM_Model_StreamChannel_Abstract $streamChannel) {
-        /** @var CM_Model_Stream_Abstract[] $streams */
-        $streams = array_merge($streamChannel->getStreamSubscribes(), $streamChannel->getStreamPublishs());
-        foreach ($streams as $stream) {
-            $stream->delete();
+        foreach ($streamChannel->getStreamSubscribes() as $streamSubscribe) {
+            $streamSubscribe->delete();
+        }
+        foreach ($streamChannel->getStreamPublishs() as $streamPublish) {
+            $streamPublish->delete();
         }
         $streamChannel->delete();
     }

--- a/tests/library/CM/MediaStreams/StreamRepositoryTest.php
+++ b/tests/library/CM/MediaStreams/StreamRepositoryTest.php
@@ -32,10 +32,16 @@ class CM_MediaStreams_StreamRepositoryTest extends CMTest_TestCase {
         $streamPublish = $this->mockObject();
         $streamPublish->mockMethod('delete');
 
+        $pagingSubscribes = $this->mockClass('CM_Paging_StreamSubscribe_StreamChannel')->newInstanceWithoutConstructor();
+        $pagingSubscribes->mockMethod('getItems')->set([$streamSubscribe]);
+        $pagingPublishs = $this->mockClass('CM_Paging_StreamPublish_StreamChannel')->newInstanceWithoutConstructor();
+        $pagingPublishs->mockMethod('getItems')->set([$streamPublish]);
+
+        /** @var CM_Model_StreamChannel_Abstract|\Mocka\AbstractClassTrait $streamChannel */
         $streamChannel = $this->mockClass('CM_Model_StreamChannel_Abstract')->newInstanceWithoutConstructor();
         $streamChannel->mockMethod('delete');
-        $streamChannel->mockMethod('getStreamSubscribes')->set([$streamSubscribe]);
-        $streamChannel->mockMethod('getStreamPublishs')->set([$streamPublish]);
+        $streamChannel->mockMethod('getStreamSubscribes')->set($pagingSubscribes);
+        $streamChannel->mockMethod('getStreamPublishs')->set($pagingPublishs);
 
         $streamRepository = new CM_MediaStreams_StreamRepository(1);
         $streamRepository->removeStreamChannel($streamChannel);


### PR DESCRIPTION
```
ErrorException: E_WARNING: array_merge(): Argument #1 is not an array in /home/example/releases/20160229164533/vendor/cargomedia/cm/library/CM/MediaStreams/StreamRepository.php on line 106
     0. {main} /home/example/serve/public/index.php:0
     1. CM_Http_Handler->processRequest(CM_Http_Request_Post) /home/example/releases/20160229164533/public/index.php:8
     2. CM_Http_Response_Abstract->process() /home/example/releases/20160229164533/vendor/cargomedia/cm/library/CM/Http/Handler.php:26
     3. CM_Http_Response_RPC->_process() /home/example/releases/20160229164533/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php:47
     4. CM_Http_Response_Abstract->_runWithCatching(Closure, Closure) /home/example/releases/20160229164533/vendor/cargomedia/cm/library/CM/Http/Response/RPC.php:21
     5. CM_Http_Response_RPC->{closure}() /home/example/releases/20160229164533/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php:262
     6. call_user_func_array([], []) /home/example/releases/20160229164533/vendor/cargomedia/cm/library/CM/Http/Response/RPC.php:18
     7. [internal function] 
     8. CM_MediaStreams_StreamRepository->removeStreamChannel(SK_Cam_VideoStreamChannel(188572306)) /home/example/releases/20160229164533/vendor/cargomedia/cm/library/CM/Janus/RpcEndpoints.php:195
     9. array_merge(CM_Paging_StreamSubscribe_StreamChannel, CM_Paging_StreamPublish_StreamChannel) /home/example/releases/20160229164533/vendor/cargomedia/cm/library/CM/MediaStreams/StreamRepository.php:106
    10. [internal function] 
```