### PR TITLE
Allow "target" param in link, button_link smarty functions?

### DIFF
--- a/library/CM/SmartyPlugins/function.button_link.php
+++ b/library/CM/SmartyPlugins/function.button_link.php
@@ -35,6 +35,12 @@ function smarty_function_button_link(array $params, Smarty_Internal_Template $te
     }
     unset($params['title']);
 
+    $target = null;
+    if (isset($params['target'])) {
+        $target = (string) $params['target'];
+    }
+    unset($params['target']);
+
     if (isset($params['id'])) {
         $attrs .= ' id="' . $params['id'] . '"';
     }
@@ -86,6 +92,10 @@ function smarty_function_button_link(array $params, Smarty_Internal_Template $te
 
     if ($href) {
         $html .= '<a href="' . CM_Util::htmlspecialchars($href) . '"';
+
+        if ($target) {
+            $html .= ' target="' . CM_Util::htmlspecialchars($target) . '"';
+        }
     } else {
         $html .= '<button type="button" value="' . $label . '"';
     }

--- a/library/CM/SmartyPlugins/function.link.php
+++ b/library/CM/SmartyPlugins/function.link.php
@@ -50,6 +50,13 @@ function smarty_function_link(array $params, Smarty_Internal_Template $template)
         $href = (string) $params['href'];
     }
     unset($params['href']);
+
+    $target = null;
+    if (isset($params['target'])) {
+        $target = (string) $params['target'];
+    }
+    unset($params['target']);
+
     if (isset($params['page'])) {
         $href = smarty_function_linkUrl($params, $template);
     }
@@ -85,6 +92,7 @@ function smarty_function_link(array $params, Smarty_Internal_Template $template)
         'class'   => $class,
         'title'   => $title,
         'onclick' => $onclick,
+        'target'  => $target,
     ];
 
     foreach ($data as $name => $value) {


### PR DESCRIPTION
- to be able to use `target='_blank' - maybe we can have an "external" flag that would also add an icon to the link?!
- only if `href` is used I guess

@njam wdyt?