### PR TITLE
StreamChannel::findByKeyAndAdapter(): catch CM_Exception_Nonexistent?

### DIFF
--- a/library/CM/Model/StreamChannel/Abstract.php
+++ b/library/CM/Model/StreamChannel/Abstract.php
@@ -221,6 +221,7 @@ abstract class CM_Model_StreamChannel_Abstract extends CM_Model_Abstract {
         try {
             $streamChannel = self::factory($result['id'], $result['type']);
         } catch (CM_Exception_Nonexistent $ex) {
+            $cache->delete($cacheKey);
             return null;
         }
         return $streamChannel;

--- a/library/CM/Model/StreamChannel/Abstract.php
+++ b/library/CM/Model/StreamChannel/Abstract.php
@@ -218,7 +218,12 @@ abstract class CM_Model_StreamChannel_Abstract extends CM_Model_Abstract {
         if (!$result) {
             return null;
         }
-        return self::factory($result['id'], $result['type']);
+        try {
+            $streamChannel = self::factory($result['id'], $result['type']);
+        } catch (CM_Exception_Nonexistent $ex) {
+            return null;
+        }
+        return $streamChannel;
     }
 
     /**

--- a/tests/library/CM/Model/StreamChannel/AbstractTest.php
+++ b/tests/library/CM/Model/StreamChannel/AbstractTest.php
@@ -50,12 +50,19 @@ class CM_Model_StreamChannel_AbstractTest extends CMTest_TestCase {
         $adapterType = 1;
         /** @var CM_Model_StreamChannel_Media $streamChannelOriginal */
         $streamChannelOriginal = CMTest_TH::createStreamChannel(null, $adapterType);
+        $streamChannelId = $streamChannelOriginal->getId();
         $streamChannelKey = $streamChannelOriginal->getKey();
         $streamChannel = CM_Model_StreamChannel_Abstract::findByKeyAndAdapter($streamChannelKey, $adapterType);
         $this->assertInstanceOf('CM_Model_StreamChannel_Media', $streamChannel);
         $this->assertEquals($streamChannelOriginal->getId(), $streamChannel->getId());
 
         $streamChannelOriginal->delete();
+        $this->assertNull(CM_Model_StreamChannel_Abstract::findByKeyAndAdapter($streamChannelKey, $adapterType));
+
+        // invalid cache-entry
+        $cacheKey = CM_CacheConst::StreamChannel_Id . '_key' . $streamChannelKey . '_adapterType:' . $adapterType;
+        $cache = CM_Cache_Shared::getInstance();
+        $cache->set($cacheKey, ['id' => $streamChannelId, 'type' => $adapterType]);
         $this->assertNull(CM_Model_StreamChannel_Abstract::findByKeyAndAdapter($streamChannelKey, $adapterType));
     }
 

--- a/tests/library/CM/Model/StreamChannel/AbstractTest.php
+++ b/tests/library/CM/Model/StreamChannel/AbstractTest.php
@@ -64,6 +64,7 @@ class CM_Model_StreamChannel_AbstractTest extends CMTest_TestCase {
         $cache = CM_Cache_Shared::getInstance();
         $cache->set($cacheKey, ['id' => $streamChannelId, 'type' => $adapterType]);
         $this->assertNull(CM_Model_StreamChannel_Abstract::findByKeyAndAdapter($streamChannelKey, $adapterType));
+        $this->assertSame(false, $cache->get($cacheKey));
     }
 
     /**


### PR DESCRIPTION
I'm investigating a case where `findByKeyAndAdapter()` fails with `CM_Exception_Nonexistent`, probably because the cache entry says the channel still exists, but it's actually not in the database anymore:

```
CM_Exception_Nonexistent: SK_Cam_AudioStreamChannel `Array (     [id] => 198810904 )` has no data. in /home/example/releases/20160401130435/vendor/cargomedia/cm/library/CM/Model/Abstract.php on line 304
     0. {main} /home/example/serve/public/index.php:0
     1. CM_Http_Handler->processRequest(CM_Http_Request_Post) /home/example/releases/20160401130435/public/index.php:8
     2. CM_Http_Response_Abstract->process() /home/example/releases/20160401130435/vendor/cargomedia/cm/library/CM/Http/Handler.php:26
     3. CM_Http_Response_RPC->_process() /home/example/releases/20160401130435/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php:47
     4. CM_Http_Response_Abstract->_runWithCatching(Closure, Closure) /home/example/releases/20160401130435/vendor/cargomedia/cm/library/CM/Http/Response/RPC.php:21
     5. CM_Http_Response_RPC->{closure}() /home/example/releases/20160401130435/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php:262
     6. call_user_func_array([], []) /home/example/releases/20160401130435/vendor/cargomedia/cm/library/CM/Http/Response/RPC.php:18
     7. [internal function] 
     8. CM_MediaStreams_StreamRepository->findStreamChannelByKey('FxEAp5d4TEL4nHTsJnY0Ag__') /home/example/releases/20160401130435/vendor/cargomedia/cm/library/CM/Janus/RpcEndpoints.php:159
     9. CM_Model_StreamChannel_Abstract->findByKeyAndAdapter('FxEAp5d4TEL4nHTsJnY0Ag__', 268) /home/example/releases/20160401130435/vendor/cargomedia/cm/library/CM/MediaStreams/StreamRepository.php:27
    10. CM_Model_StreamChannel_Abstract->factory('198810904', '270') /home/example/releases/20160401130435/vendor/cargomedia/cm/library/CM/Model/StreamChannel/Abstract.php:221
    11. CM_Model_Abstract->__construct('198810904') /home/example/releases/20160401130435/vendor/cargomedia/cm/library/CM/Model/StreamChannel/Abstract.php:192
    12. CM_Model_Abstract->_construct([]) /home/example/releases/20160401130435/vendor/cargomedia/cm/library/CM/Model/Abstract.php:28
    13. CM_Model_Abstract->_getData() /home/example/releases/20160401130435/vendor/cargomedia/cm/library/CM/Model/Abstract.php:50
```

Should we catch this and return `null`?
@tomaszdurka @alexispeter  wdyt?