### PR TITLE
Introduce CM_App->getName()

### DIFF
--- a/library/CM/App.php
+++ b/library/CM/App.php
@@ -58,6 +58,18 @@ class CM_App implements CM_Service_ManagerAwareInterface {
     }
 
     /**
+     * @throws CM_Exception_Invalid
+     * @return string
+     */
+    public function getName() {
+        $config = CM_Bootloader::getInstance()->getConfig()->get();
+        if (!isset($config->installationName)) {
+            throw new CM_Exception_Invalid('The `installationName` config property is required.');
+        }
+        return $config->installationName;
+    }
+
+    /**
      * @param string|null $namespace
      * @return int
      */

--- a/library/CM/RenderAdapter/Layout.php
+++ b/library/CM/RenderAdapter/Layout.php
@@ -41,6 +41,7 @@ class CM_RenderAdapter_Layout extends CM_RenderAdapter_Abstract {
 
         $serviceManager = CM_Service_Manager::getInstance();
         $options = array();
+        $options['name'] = CM_App::getInstance()->getName();
         $options['deployVersion'] = CM_App::getInstance()->getDeployVersion();
         $options['renderStamp'] = floor(microtime(true) * 1000);
         $options['site'] = CM_Params::encode($this->getRender()->getSite());

--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -1,6 +1,9 @@
 <?php
 
 return function (CM_Config_Node $config) {
+
+    $config->installationName = 'CM';
+
     $config->CM_App->setupScriptClasses = array();
     $config->CM_App->setupScriptClasses[] = 'CM_File_Filesystem_SetupScript';
     $config->CM_App->setupScriptClasses[] = 'CM_Db_SetupScript';


### PR DESCRIPTION
Should we introduce the concept we have in SK's config in to CM?
```php
$config->installationName = 'FB';
```

Pass it to the client with `cm.options`?