### PR TITLE
[Experimental] Modules with Browserify support

### DIFF
--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -1,3 +1,5 @@
+var CM_Class_Abstract = require('CM/Class/Abstract');
+
 /**
  * @class CM_App
  * @extends CM_Class_Abstract
@@ -1048,7 +1050,8 @@ var CM_App = CM_Class_Abstract.extend({
      */
     _getAdapter: function() {
       if (!this._adapter) {
-        this._adapter = new window[cm.options.stream.adapter](cm.options.stream.options);
+        var Adapter = require(cm.options.stream.adapter);
+        this._adapter = new Adapter(cm.options.stream.options);
       }
       return this._adapter;
     },
@@ -1400,4 +1403,9 @@ var CM_App = CM_Class_Abstract.extend({
   userAgent: (function(ua) {
     return window.UserAgentParser.parse(ua);
   })(navigator.userAgent || '')
+}, {
+  require: require
 });
+
+
+module.exports = CM_App;

--- a/library/CM/Asset/Javascript/Internal.php
+++ b/library/CM/Asset/Javascript/Internal.php
@@ -6,7 +6,14 @@ class CM_Asset_Javascript_Internal extends CM_Asset_Javascript_Abstract {
      * @param CM_Site_Abstract $site
      */
     public function __construct(CM_Site_Abstract $site) {
-        $this->_content = 'var cm = new ' . $this->_getAppClassName($site) . '();' . PHP_EOL;
+        $this->_content = 'var CM_Exception = require("CM_Exception");';
+        $this->_content .= 'var CM_Exception_AuthRequired = require("CM_Exception_AuthRequired");' . PHP_EOL;
+        $this->_content .= 'var CM_Exception_FormFieldValidation = require("CM_Exception_FormFieldValidation");' . PHP_EOL;
+        $this->_content .= 'var CM_Exception_Invalid = require("CM_Exception_Invalid");' . PHP_EOL;
+        $this->_content .= 'var CM_Exception_Nonexistent = require("CM_Exception_Nonexistent");' . PHP_EOL;
+        $this->_content .= 'var CM_Exception_RequestFailed = require("CM_Exception_RequestFailed");' . PHP_EOL;
+        $this->_content .= 'var App = require("' . $this->_getAppClassName($site) . '");' . PHP_EOL;
+        $this->_content .= 'var cm = new App();' . PHP_EOL;
         $this->_content .= (new CM_File(DIR_ROOT . 'resources/config/js/internal.js'))->read();
     }
 

--- a/library/CM/Asset/Javascript/Library.php
+++ b/library/CM/Asset/Javascript/Library.php
@@ -6,21 +6,18 @@ class CM_Asset_Javascript_Library extends CM_Asset_Javascript_Abstract {
      * @param CM_Site_Abstract $site
      */
     public function __construct(CM_Site_Abstract $site) {
-        $content = '';
-        foreach (self::getIncludedPaths($site) as $path) {
-            $content .= (new CM_File($path))->read();
+        $debug = CM_Bootloader::getInstance()->isDebug();
+        $moduleFiles = [];
+        $modulePaths = [];
+
+        foreach($site->getModules() as $moduleName) {
+            $moduleFiles = array_merge($moduleFiles, CM_Util::rglobLibrariesByModule('*.js', $moduleName));
+            $modulePaths[] = CM_Util::getModulePath($moduleName, false, true) . '/library/';
         }
+
+        $content = $this->_browserify($moduleFiles, $modulePaths, $debug, true);
         $internal = new CM_Asset_Javascript_Internal($site);
         $content .= $internal->get();
         $this->_content = $content;
-    }
-
-    /**
-     * @param CM_Site_Abstract $site
-     * @return string[]
-     */
-    public static function getIncludedPaths(CM_Site_Abstract $site) {
-        $pathsUnsorted = CM_Util::rglobLibraries('*.js', $site);
-        return array_keys(CM_Util::getClasses($pathsUnsorted));
     }
 }

--- a/library/CM/Class/Abstract.js
+++ b/library/CM/Class/Abstract.js
@@ -18,3 +18,5 @@ CM_Class_Abstract.prototype = {
  * @param {Object} prototype
  */
 CM_Class_Abstract.extend = Backbone.Model.extend;
+
+module.exports = CM_Class_Abstract;

--- a/library/CM/Component/Abstract.js
+++ b/library/CM/Component/Abstract.js
@@ -1,3 +1,5 @@
+var CM_View_Abstract = require('CM/View/Abstract');
+
 /**
  * @class CM_Component_Abstract
  * @extends CM_View_Abstract
@@ -103,3 +105,6 @@ var CM_Component_Abstract = CM_View_Abstract.extend({
       });
   }
 });
+
+
+module.exports = CM_Component_Abstract;

--- a/library/CM/Component/Debug.js
+++ b/library/CM/Component/Debug.js
@@ -1,3 +1,5 @@
+var CM_Component_Abstract = require('CM/Component/Abstract');
+
 /**
  * @class CM_Component_Debug
  * @extends CM_Component_Abstract
@@ -75,3 +77,6 @@ var CM_Component_Debug = CM_Component_Abstract.extend({
     });
   }
 });
+
+
+module.exports = CM_Component_Debug;

--- a/library/CM/Component/EmailPreview.js
+++ b/library/CM/Component/EmailPreview.js
@@ -1,3 +1,5 @@
+var CM_Component_Abstract = require('CM/Component/Abstract');
+
 /**
  * @class CM_Component_EmailPreview
  * @extends CM_Component_Abstract
@@ -12,3 +14,6 @@ var CM_Component_EmailPreview = CM_Component_Abstract.extend({
     $iframe.attr('src', 'data:text/html;charset=utf-8,' + encodeURI(this.html));
   }
 });
+
+
+module.exports = CM_Component_EmailPreview;

--- a/library/CM/Component/Example.js
+++ b/library/CM/Component/Example.js
@@ -1,3 +1,5 @@
+var CM_Component_Abstract = require('CM/Component/Abstract');
+
 /**
  * @class CM_Component_Example
  * @extends CM_Component_Abstract
@@ -138,3 +140,6 @@ var CM_Component_Example = CM_Component_Abstract.extend({
     });
   }
 });
+
+
+module.exports = CM_Component_Example;

--- a/library/CM/Component/Graph.js
+++ b/library/CM/Component/Graph.js
@@ -1,3 +1,5 @@
+var CM_Component_Abstract = require('CM/Component/Abstract');
+
 /**
  * @class CM_Component_Graph
  * @extends CM_Component_Abstract
@@ -30,3 +32,6 @@ var CM_Component_Graph = CM_Component_Abstract.extend({
     $.plot(this.$(), flotSeries, this.flotOptions);
   }
 });
+
+
+module.exports = CM_Component_Graph;

--- a/library/CM/Component/LogList.js
+++ b/library/CM/Component/LogList.js
@@ -1,3 +1,5 @@
+var CM_Component_Abstract = require('CM/Component/Abstract');
+
 /**
  * @class CM_Component_LogList
  * @extends CM_Component_Abstract
@@ -17,3 +19,6 @@ var CM_Component_LogList = CM_Component_Abstract.extend({
     this.ajaxModal('flushLog', {'type': this.type});
   }
 });
+
+
+module.exports = CM_Component_LogList;

--- a/library/CM/Component/NotAllowed.js
+++ b/library/CM/Component/NotAllowed.js
@@ -1,3 +1,5 @@
+var CM_Component_Abstract = require('CM/Component/Abstract');
+
 /**
  * @class CM_Component_NotAllowed
  * @extends CM_Component_Abstract
@@ -5,3 +7,6 @@
 var CM_Component_NotAllowed = CM_Component_Abstract.extend({
   _class: 'CM_Component_NotAllowed'
 });
+
+
+module.exports = CM_Component_NotAllowed;

--- a/library/CM/Component/Notfound.js
+++ b/library/CM/Component/Notfound.js
@@ -1,3 +1,5 @@
+var CM_Component_Abstract = require('CM/Component/Abstract');
+
 /**
  * @class CM_Component_Notfound
  * @extends CM_Component_Abstract
@@ -5,3 +7,6 @@
 var CM_Component_Notfound = CM_Component_Abstract.extend({
   _class: 'CM_Component_Notfound'
 });
+
+
+module.exports = CM_Component_Notfound;

--- a/library/CM/Exception.js
+++ b/library/CM/Exception.js
@@ -1,59 +1,55 @@
-(function(scope) {
+/**
+ * @class CM_Exception
+ * @extends Error
+ *
+ * @param {String} message
+ * @param {Boolean} [isPublic]
+ * @constructor
+ */
+function CM_Exception(message, isPublic) {
+  var temp = Error.call(this, message);
+  this.name = 'CM_Exception';
+  this.stack = temp.stack;
+  this.message = temp.message;
+  this.isPublic = isPublic;
+  return this;
+}
 
-  /**
-   * @class CM_Exception
-   * @extends Error
-   *
-   * @param {String} message
-   * @param {Boolean} [isPublic]
-   * @constructor
-   */
-  function CM_Exception(message, isPublic) {
-    var temp = Error.call(this, message);
-    this.name = 'CM_Exception';
-    this.stack = temp.stack;
-    this.message = temp.message;
-    this.isPublic = isPublic;
-    return this;
+CM_Exception.prototype = Object.create(Error.prototype, {
+  constructor: {
+    value: CM_Exception,
+    writable: true,
+    configurable: true
   }
+});
 
-  CM_Exception.prototype = Object.create(Error.prototype, {
-    constructor: {
-      value: CM_Exception,
-      writable: true,
-      configurable: true
-    }
-  });
+var exceptionMap = {};
+exceptionMap['CM_Exception'] = CM_Exception;
 
-  var exceptionMap = {};
-  exceptionMap['CM_Exception'] = CM_Exception;
-
-  /**
-   * @param {String} className
-   * @returns {Function} exception constructor
-   */
-  CM_Exception.extend = function(className) {
-    var extension = function() {
-      CM_Exception.apply(this, arguments);
-      this.name = className;
-    };
-    extension.prototype = Object.create(CM_Exception.prototype);
-    extension.prototype.constructor = CM_Exception;
-    exceptionMap[className] = extension;
-    return extension;
+/**
+ * @param {String} className
+ * @returns {Function} exception constructor
+ */
+CM_Exception.extend = function(className) {
+  var extension = function() {
+    CM_Exception.apply(this, arguments);
+    this.name = className;
   };
+  extension.prototype = Object.create(CM_Exception.prototype);
+  extension.prototype.constructor = CM_Exception;
+  exceptionMap[className] = extension;
+  return extension;
+};
 
-  /**
-   * @param {String} className
-   * @returns {Function} exception constructor
-   */
-  CM_Exception.factory = function(className) {
-    if (!exceptionMap[className]) {
-      window[className] = exceptionMap[className] = CM_Exception.extend(className);
-    }
-    return exceptionMap[className];
-  };
+/**
+ * @param {String} className
+ * @returns {Function} exception constructor
+ */
+CM_Exception.factory = function(className) {
+  if (!exceptionMap[className]) {
+    window[className] = exceptionMap[className] = CM_Exception.extend(className);
+  }
+  return exceptionMap[className];
+};
 
-  scope['CM_Exception'] = CM_Exception;
-
-})(window);
+module.exports = CM_Exception;

--- a/library/CM/Exception/AuthRequired.js
+++ b/library/CM/Exception/AuthRequired.js
@@ -2,4 +2,4 @@
  * @class CM_Exception_AuthRequired
  * @extends CM_Exception
  */
-window.CM_Exception_AuthRequired = CM_Exception.extend('CM_Exception_AuthRequired');
+module.exports = CM_Exception.extend('CM_Exception_AuthRequired');

--- a/library/CM/Exception/FormFieldValidation.js
+++ b/library/CM/Exception/FormFieldValidation.js
@@ -2,4 +2,4 @@
  * @class CM_Exception_FormFieldValidation
  * @extends CM_Exception
  */
-window.CM_Exception_FormFieldValidation = CM_Exception.extend('CM_Exception_FormFieldValidation');
+module.exports = CM_Exception.extend('CM_Exception_FormFieldValidation');

--- a/library/CM/Exception/Invalid.js
+++ b/library/CM/Exception/Invalid.js
@@ -2,4 +2,4 @@
  * @class CM_Exception_Invalid
  * @extends CM_Exception
  */
-window.CM_Exception_Invalid = CM_Exception.extend('CM_Exception_Invalid');
+module.exports = CM_Exception.extend('CM_Exception_Invalid');

--- a/library/CM/Exception/Nonexistent.js
+++ b/library/CM/Exception/Nonexistent.js
@@ -2,4 +2,4 @@
  * @class CM_Exception_Nonexistent
  * @extends CM_Exception
  */
-window.CM_Exception_Nonexistent = CM_Exception.extend('CM_Exception_Nonexistent');
+module.exports = CM_Exception.extend('CM_Exception_Nonexistent');

--- a/library/CM/Exception/RequestFailed.js
+++ b/library/CM/Exception/RequestFailed.js
@@ -2,4 +2,4 @@
  * @class CM_Exception_RequestFailed
  * @extends CM_Exception
  */
-window.CM_Exception_RequestFailed = CM_Exception.extend('CM_Exception_RequestFailed');
+module.exports = CM_Exception.extend('CM_Exception_RequestFailed');

--- a/library/CM/Form/Abstract.js
+++ b/library/CM/Form/Abstract.js
@@ -1,3 +1,5 @@
+var CM_View_Abstract = require('CM/View/Abstract');
+
 /**
  * @class CM_Form_Abstract
  * @extends CM_View_Abstract
@@ -323,3 +325,6 @@ var CM_Form_Abstract = CM_View_Abstract.extend({
     return null;
   }
 });
+
+
+module.exports = CM_Form_Abstract;

--- a/library/CM/Form/Example.js
+++ b/library/CM/Form/Example.js
@@ -9,6 +9,7 @@ var CM_Form_Example = CM_Form_Abstract.extend({
 
   ready: function() {
     var form = this;
+    var CM_FormField_Text = require('CM_FormField_Text');
     this.getFields().forEach(function(field) {
       field.on('ready', function() {
         field.on('change', form.logData.bind(form));

--- a/library/CM/Form/Example.js
+++ b/library/CM/Form/Example.js
@@ -1,3 +1,5 @@
+var CM_Form_Abstract = require('CM/Form/Abstract');
+
 /**
  * @class CM_Form_Example
  * @extends CM_Form_Abstract
@@ -48,3 +50,6 @@ var CM_Form_Example = CM_Form_Abstract.extend({
     return table;
   }
 });
+
+
+module.exports = CM_Form_Example;

--- a/library/CM/Form/ExampleIcon.js
+++ b/library/CM/Form/ExampleIcon.js
@@ -1,3 +1,5 @@
+var CM_Form_Abstract = require('CM/Form/Abstract');
+
 /**
  * @class CM_Form_ExampleIcon
  * @extends CM_Form_Abstract
@@ -46,3 +48,6 @@ var CM_Form_ExampleIcon = CM_Form_Abstract.extend({
     }, ''));
   }
 });
+
+
+module.exports = CM_Form_ExampleIcon;

--- a/library/CM/FormField/Abstract.js
+++ b/library/CM/FormField/Abstract.js
@@ -1,3 +1,5 @@
+var CM_View_Abstract = require('CM/View/Abstract');
+
 /**
  * @class CM_FormField_Abstract
  * @extends CM_View_Abstract
@@ -168,3 +170,6 @@ var CM_FormField_Abstract = CM_View_Abstract.extend({
     return 0 === String(value).trim().length;
   }
 });
+
+
+module.exports = CM_FormField_Abstract;

--- a/library/CM/FormField/Birthdate.js
+++ b/library/CM/FormField/Birthdate.js
@@ -1,3 +1,5 @@
+var CM_FormField_Date = require('CM/FormField/Date');
+
 /**
  * @class CM_FormField_Birthdate
  * @extends CM_FormField_Date
@@ -5,3 +7,6 @@
 var CM_FormField_Birthdate = CM_FormField_Date.extend({
   _class: 'CM_FormField_Birthdate'
 });
+
+
+module.exports = CM_FormField_Birthdate;

--- a/library/CM/FormField/Boolean.js
+++ b/library/CM/FormField/Boolean.js
@@ -1,3 +1,5 @@
+var CM_FormField_Abstract = require('CM/FormField/Abstract');
+
 /**
  * @class CM_FormField_Boolean
  * @extends CM_FormField_Abstract
@@ -33,3 +35,6 @@ var CM_FormField_Boolean = CM_FormField_Abstract.extend({
     }
   }
 });
+
+
+module.exports = CM_FormField_Boolean;

--- a/library/CM/FormField/Captcha.js
+++ b/library/CM/FormField/Captcha.js
@@ -1,3 +1,5 @@
+var CM_FormField_Abstract = require('CM/FormField/Abstract');
+
 /**
  * @class CM_FormField_Captcha
  * @extends CM_FormField_Abstract
@@ -48,3 +50,6 @@ var CM_FormField_Captcha = CM_FormField_Abstract.extend({
     this.$("input[name*=value]").val(captcha.value);
   }
 });
+
+
+module.exports = CM_FormField_Captcha;

--- a/library/CM/FormField/Color.js
+++ b/library/CM/FormField/Color.js
@@ -1,3 +1,5 @@
+var CM_FormField_Abstract = require('CM/FormField/Abstract');
+
 /**
  * @class CM_FormField_Color
  * @extends CM_FormField_Abstract
@@ -11,3 +13,6 @@ var CM_FormField_Color = CM_FormField_Abstract.extend({
     }
   }
 });
+
+
+module.exports = CM_FormField_Color;

--- a/library/CM/FormField/Date.js
+++ b/library/CM/FormField/Date.js
@@ -1,3 +1,5 @@
+var CM_FormField_Abstract = require('CM/FormField/Abstract');
+
 /**
  * @class CM_FormField_Date
  * @extends CM_FormField_Abstract
@@ -39,3 +41,6 @@ var CM_FormField_Date = CM_FormField_Abstract.extend({
     this.$('select.year').val(date.year);
   }
 });
+
+
+module.exports = CM_FormField_Date;

--- a/library/CM/FormField/Distance.js
+++ b/library/CM/FormField/Distance.js
@@ -1,3 +1,5 @@
+var CM_FormField_Integer = require('CM/FormField/Integer');
+
 /**
  * @class CM_FormField_Distance
  * @extends CM_FormField_Integer
@@ -5,3 +7,6 @@
 var CM_FormField_Distance = CM_FormField_Integer.extend({
   _class: 'CM_FormField_Distance'
 });
+
+
+module.exports = CM_FormField_Distance;

--- a/library/CM/FormField/Email.js
+++ b/library/CM/FormField/Email.js
@@ -1,3 +1,5 @@
+var CM_FormField_Text = require('CM/FormField/Text');
+
 /**
  * @class CM_FormField_Email
  * @extends CM_FormField_Text
@@ -5,3 +7,6 @@
 var CM_FormField_Email = CM_FormField_Text.extend({
   _class: 'CM_FormField_Email'
 });
+
+
+module.exports = CM_FormField_Email;

--- a/library/CM/FormField/File.js
+++ b/library/CM/FormField/File.js
@@ -1,3 +1,5 @@
+var CM_FormField_Abstract = require('CM/FormField/Abstract');
+
 /**
  * @class CM_FormField_File
  * @extends CM_FormField_Abstract
@@ -124,3 +126,6 @@ var CM_FormField_File = CM_FormField_Abstract.extend({
     this.$('.previews').empty();
   }
 });
+
+
+module.exports = CM_FormField_File;

--- a/library/CM/FormField/FileImage.js
+++ b/library/CM/FormField/FileImage.js
@@ -1,3 +1,5 @@
+var CM_FormField_File = require('CM/FormField/File');
+
 /**
  * @class CM_FormField_FileImage
  * @extends CM_FormField_File
@@ -5,3 +7,6 @@
 var CM_FormField_FileImage = CM_FormField_File.extend({
   _class: 'CM_FormField_FileImage'
 });
+
+
+module.exports = CM_FormField_FileImage;

--- a/library/CM/FormField/Float.js
+++ b/library/CM/FormField/Float.js
@@ -1,3 +1,5 @@
+var CM_FormField_Text = require('CM/FormField/Text');
+
 /**
  * @class CM_FormField_Float
  * @extends CM_FormField_Text
@@ -5,3 +7,6 @@
 var CM_FormField_Float = CM_FormField_Text.extend({
   _class: 'CM_FormField_Float'
 });
+
+
+module.exports = CM_FormField_Float;

--- a/library/CM/FormField/GeoPoint.js
+++ b/library/CM/FormField/GeoPoint.js
@@ -1,3 +1,5 @@
+var CM_FormField_Abstract = require('CM/FormField/Abstract');
+
 /**
  * @class CM_FormField_GeoPoint
  * @extends CM_FormField_Abstract
@@ -27,3 +29,6 @@ var CM_FormField_GeoPoint = CM_FormField_Abstract.extend({
     this.$('[name*=longitude]').val(data.longitude);
   }
 });
+
+
+module.exports = CM_FormField_GeoPoint;

--- a/library/CM/FormField/Hidden.js
+++ b/library/CM/FormField/Hidden.js
@@ -1,3 +1,5 @@
+var CM_FormField_Abstract = require('CM/FormField/Abstract');
+
 /**
  * @class CM_FormField_Hidden
  * @extends CM_FormField_Abstract
@@ -5,3 +7,6 @@
 var CM_FormField_Hidden = CM_FormField_Abstract.extend({
   _class: 'CM_FormField_Hidden'
 });
+
+
+module.exports = CM_FormField_Hidden;

--- a/library/CM/FormField/Integer.js
+++ b/library/CM/FormField/Integer.js
@@ -1,3 +1,5 @@
+var CM_FormField_Abstract = require('CM/FormField/Abstract');
+
 /**
  * @class CM_FormField_Integer
  * @extends CM_FormField_Abstract
@@ -88,3 +90,6 @@ var CM_FormField_Integer = CM_FormField_Abstract.extend({
     }
   }
 });
+
+
+module.exports = CM_FormField_Integer;

--- a/library/CM/FormField/Location.js
+++ b/library/CM/FormField/Location.js
@@ -1,3 +1,5 @@
+var CM_FormField_SuggestOne = require('CM/FormField/SuggestOne');
+
 /**
  * @class CM_FormField_Location
  * @extends CM_FormField_SuggestOne
@@ -83,3 +85,6 @@ var CM_FormField_Location = CM_FormField_SuggestOne.extend({
     return this.ajax('getSuggestionByCoordinates', {lat: lat, lon: lon, levelMin: this.getOption('levelMin'), levelMax: this.getOption('levelMax')});
   }
 });
+
+
+module.exports = CM_FormField_Location;

--- a/library/CM/FormField/Money.js
+++ b/library/CM/FormField/Money.js
@@ -1,3 +1,5 @@
+var CM_FormField_Float = require('CM/FormField/Float');
+
 /**
  * @class CM_FormField_Money
  * @extends CM_FormField_Float
@@ -5,3 +7,6 @@
 var CM_FormField_Money = CM_FormField_Float.extend({
   _class: 'CM_FormField_Money'
 });
+
+
+module.exports = CM_FormField_Money;

--- a/library/CM/FormField/Password.js
+++ b/library/CM/FormField/Password.js
@@ -1,3 +1,5 @@
+var CM_FormField_Text = require('CM/FormField/Text');
+
 /**
  * @class CM_FormField_Password
  * @extends CM_FormField_Text
@@ -63,3 +65,6 @@ var CM_FormField_Password = CM_FormField_Text.extend({
     this.getInput().attr('type', state ? 'text' : 'password').focus();
   }
 });
+
+
+module.exports = CM_FormField_Password;

--- a/library/CM/FormField/Search.js
+++ b/library/CM/FormField/Search.js
@@ -1,3 +1,5 @@
+var CM_FormField_Text = require('CM/FormField/Text');
+
 /**
  * @class CM_FormField_Search
  * @extends CM_FormField_Text
@@ -5,3 +7,6 @@
 var CM_FormField_Search = CM_FormField_Text.extend({
   _class: 'CM_FormField_Search'
 });
+
+
+module.exports = CM_FormField_Search;

--- a/library/CM/FormField/Set.js
+++ b/library/CM/FormField/Set.js
@@ -1,3 +1,5 @@
+var CM_FormField_Abstract = require('CM/FormField/Abstract');
+
 /**
  * @class CM_FormField_Set
  * @extends CM_FormField_Abstract
@@ -43,3 +45,6 @@ var CM_FormField_Set = CM_FormField_Abstract.extend({
     return $input;
   }
 });
+
+
+module.exports = CM_FormField_Set;

--- a/library/CM/FormField/Set/Select.js
+++ b/library/CM/FormField/Set/Select.js
@@ -1,3 +1,5 @@
+var CM_FormField_Set = require('CM/FormField/Set');
+
 /**
  * @class CM_FormField_Set_Select
  * @extends CM_FormField_Set
@@ -47,3 +49,6 @@ var CM_FormField_Set_Select = CM_FormField_Set.extend({
     return this.getInput().is('[type=radio]');
   }
 });
+
+
+module.exports = CM_FormField_Set_Select;

--- a/library/CM/FormField/Site.js
+++ b/library/CM/FormField/Site.js
@@ -1,3 +1,5 @@
+var CM_FormField_Set_Select = require('CM/FormField/Set/Select');
+
 /**
  * @class CM_FormField_Site
  * @extends CM_FormField_Set_Select
@@ -5,3 +7,6 @@
 var CM_FormField_Site = CM_FormField_Set_Select.extend({
   _class: 'CM_FormField_Site'
 });
+
+
+module.exports = CM_FormField_Site;

--- a/library/CM/FormField/Suggest.js
+++ b/library/CM/FormField/Suggest.js
@@ -1,3 +1,5 @@
+var CM_FormField_Abstract = require('CM/FormField/Abstract');
+
 /**
  * @class CM_FormField_Suggest
  * @extends CM_FormField_Abstract
@@ -142,3 +144,6 @@ var CM_FormField_Suggest = CM_FormField_Abstract.extend({
     return output;
   }
 });
+
+
+module.exports = CM_FormField_Suggest;

--- a/library/CM/FormField/SuggestOne.js
+++ b/library/CM/FormField/SuggestOne.js
@@ -1,3 +1,5 @@
+var CM_FormField_Suggest = require('CM/FormField/Suggest');
+
 /**
  * @class CM_FormField_SuggestOne
  * @extends CM_FormField_Suggest
@@ -28,3 +30,6 @@ var CM_FormField_SuggestOne = CM_FormField_Suggest.extend({
   }
 
 });
+
+
+module.exports = CM_FormField_SuggestOne;

--- a/library/CM/FormField/Text.js
+++ b/library/CM/FormField/Text.js
@@ -1,3 +1,5 @@
+var CM_FormField_Abstract = require('CM/FormField/Abstract');
+
 /**
  * @class CM_FormField_Text
  * @extends CM_FormField_Abstract
@@ -51,3 +53,6 @@ var CM_FormField_Text = CM_FormField_Abstract.extend({
     this.getInput().on('input propertychange keyup', _.bind(this.triggerChange, this));
   }
 });
+
+
+module.exports = CM_FormField_Text;

--- a/library/CM/FormField/Textarea.js
+++ b/library/CM/FormField/Textarea.js
@@ -1,3 +1,5 @@
+var CM_FormField_Text = require('CM/FormField/Text');
+
 /**
  * @class CM_FormField_Textarea
  * @extends CM_FormField_Text
@@ -5,3 +7,6 @@
 var CM_FormField_Textarea = CM_FormField_Text.extend({
   _class: 'CM_FormField_Textarea'
 });
+
+
+module.exports = CM_FormField_Textarea;

--- a/library/CM/FormField/TreeSelect.js
+++ b/library/CM/FormField/TreeSelect.js
@@ -1,3 +1,5 @@
+var CM_FormField_Abstract = require('CM/FormField/Abstract');
+
 /**
  * @class CM_FormField_TreeSelect
  * @extends CM_FormField_Abstract
@@ -84,3 +86,6 @@ var CM_FormField_TreeSelect = CM_FormField_Abstract.extend({
     return this.$('.node[data-id="' + this.getValue() + '"]');
   }
 });
+
+
+module.exports = CM_FormField_TreeSelect;

--- a/library/CM/FormField/Url.js
+++ b/library/CM/FormField/Url.js
@@ -1,3 +1,5 @@
+var CM_FormField_Text = require('CM/FormField/Text');
+
 /**
  * @class CM_FormField_Url
  * @extends CM_FormField_Text
@@ -5,3 +7,6 @@
 var CM_FormField_Url = CM_FormField_Text.extend({
   _class: 'CM_FormField_Url'
 });
+
+
+module.exports = CM_FormField_Url;

--- a/library/CM/Frontend/GlobalResponse.php
+++ b/library/CM/Frontend/GlobalResponse.php
@@ -189,7 +189,8 @@ class CM_Frontend_GlobalResponse {
         $viewResponse = $node->getValue();
         $reference = 'cm.views["' . $viewResponse->getAutoId() . '"]';
         $view = $viewResponse->getView();
-        $code = $reference . ' = new ' . get_class($view) . '({';
+        $code = 'var ' . get_class($view) . ' = require("' . get_class($view) . '");';
+        $code .= $reference . ' = new ' . get_class($view) . '({';
         $code .= 'el:$("#' . $viewResponse->getAutoId() . '").get(0),';
         $code .= 'params:' . CM_Params::jsonEncode($view->getParams()->getParamsEncoded());
         if (!$node->isRoot()) {

--- a/library/CM/Javascript/Cli.php
+++ b/library/CM/Javascript/Cli.php
@@ -1,0 +1,45 @@
+<?php
+
+class CM_Javascript_Cli extends CM_Cli_Runnable_Abstract {
+
+    /**
+     * @param string|null $namespace
+     */
+    public function browserify($namespace = null) {
+        if (null == $namespace) {
+            $this->_getStreamError()->writeln('--namespace=<NAMESPACE> option required.');
+            return 1;
+        }
+
+        $this->_getStreamOutput()->writeln('Convert javascript library code to support browserify...');
+        foreach (CM_Util::rglobLibrariesByModule('*.js', $namespace) as $path) {
+            $file = new CM_File($path);
+            $content = $file->read();
+            $shortPath = preg_replace('/^.*(' . $namespace . ')/', '$1', $path);
+            $matches = null;
+
+            if (preg_match('/require\(/', $content)) {
+                $this->_getStreamOutput()->writeln('done: ' . $shortPath);
+            } elseif (preg_match('/var ([^ ]+) = ([^ \.]+)\.extend\({/', $content, $matches)) {
+                $className = $matches[1];
+                $extendClassName = $matches[2];
+                $extendClassPath = preg_replace('/_/', '/', $matches[2]);
+
+                $this->_getStreamOutput()->writeln('processing: ' . $shortPath . ' > class `' . $className . '` extend `' . $extendClassName . '`');
+                $file->write(join(PHP_EOL, [
+                    "var " . $extendClassName . " = require('" . $extendClassPath . "');",
+                    "",
+                    $content,
+                    "",
+                    "module.exports = " . $className . ";"
+                ]));
+            } else {
+                $this->_getStreamOutput()->writeln('not supported: ' . $shortPath);
+            }
+        }
+    }
+
+    public static function getPackageName() {
+        return 'js';
+    }
+}

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -1,3 +1,5 @@
+var CM_View_Abstract = require('CM/View/Abstract');
+
 /**
  * @class CM_Layout_Abstract
  * @extends CM_View_Abstract
@@ -181,3 +183,6 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
   }
 
 });
+
+
+module.exports = CM_Layout_Abstract;

--- a/library/CM/MessageStream/Adapter/Abstract.js
+++ b/library/CM/MessageStream/Adapter/Abstract.js
@@ -1,3 +1,5 @@
+var CM_Class_Abstract = require('CM/Class/Abstract');
+
 /**
  * @class CM_MessageStream_Adapter_Abstract
  * @extends CM_Class_Abstract
@@ -36,3 +38,6 @@ var CM_MessageStream_Adapter_Abstract = CM_Class_Abstract.extend({
     throw 'Not implemented';
   }
 });
+
+
+module.exports = CM_MessageStream_Adapter_Abstract;

--- a/library/CM/MessageStream/Adapter/SocketRedis.js
+++ b/library/CM/MessageStream/Adapter/SocketRedis.js
@@ -1,3 +1,5 @@
+var CM_MessageStream_Adapter_Abstract = require('CM/MessageStream/Adapter/Abstract');
+
 /**
  * @class CM_MessageStream_Adapter_SocketRedis
  * @extends CM_MessageStream_Adapter_Abstract
@@ -23,3 +25,6 @@ var CM_MessageStream_Adapter_SocketRedis = CM_MessageStream_Adapter_Abstract.ext
     this._socketRedis.publish(channel, event, data);
   }
 });
+
+
+module.exports = CM_MessageStream_Adapter_SocketRedis;

--- a/library/CM/Page/Abstract.js
+++ b/library/CM/Page/Abstract.js
@@ -1,3 +1,5 @@
+var CM_Component_Abstract = require('CM/Component/Abstract');
+
 /**
  * @class CM_Page_Abstract
  * @extends CM_Component_Abstract
@@ -91,3 +93,6 @@ var CM_Page_Abstract = CM_Component_Abstract.extend({
   }
 
 });
+
+
+module.exports = CM_Page_Abstract;

--- a/library/CM/Page/Error/AuthRequired.js
+++ b/library/CM/Page/Error/AuthRequired.js
@@ -1,3 +1,5 @@
+var CM_Page_Abstract = require('CM/Page/Abstract');
+
 /**
  * @class CM_Page_Error_AuthRequired
  * @extends CM_Page_Abstract
@@ -7,3 +9,6 @@ var CM_Page_Error_AuthRequired = CM_Page_Abstract.extend({
   /** @type String */
   _class: 'CM_Page_Error_AuthRequired'
 });
+
+
+module.exports = CM_Page_Error_AuthRequired;

--- a/library/CM/Page/Error/NotAllowed.js
+++ b/library/CM/Page/Error/NotAllowed.js
@@ -1,3 +1,5 @@
+var CM_Page_Abstract = require('CM/Page/Abstract');
+
 /**
  * @class CM_Page_Error_NotAllowed
  * @extends CM_Page_Abstract
@@ -7,3 +9,6 @@ var CM_Page_Error_NotAllowed = CM_Page_Abstract.extend({
   /** @type String */
   _class: 'CM_Page_Error_NotAllowed'
 });
+
+
+module.exports = CM_Page_Error_NotAllowed;

--- a/library/CM/Page/Error/NotFound.js
+++ b/library/CM/Page/Error/NotFound.js
@@ -1,3 +1,5 @@
+var CM_Page_Abstract = require('CM/Page/Abstract');
+
 /**
  * @class CM_Page_Error_NotFound
  * @extends CM_Page_Abstract
@@ -7,3 +9,6 @@ var CM_Page_Error_NotFound = CM_Page_Abstract.extend({
   /** @type String */
   _class: 'CM_Page_Error_NotFound'
 });
+
+
+module.exports = CM_Page_Error_NotFound;

--- a/library/CM/Page/Example.js
+++ b/library/CM/Page/Example.js
@@ -1,3 +1,5 @@
+var CM_Page_Abstract = require('CM/Page/Abstract');
+
 /**
  * @class CM_Page_Example
  * @extends CM_Page_Abstract
@@ -15,3 +17,6 @@ var CM_Page_Example = CM_Page_Abstract.extend({
     }
   }
 });
+
+
+module.exports = CM_Page_Example;

--- a/library/CM/Util.php
+++ b/library/CM/Util.php
@@ -47,17 +47,13 @@ class CM_Util {
     }
 
     /**
-     * @param string           $pattern
-     * @param CM_Site_Abstract $site
+     * @param string $pattern
+     * @param string $moduleName
      * @return string[]
      */
-    public static function rglobLibraries($pattern, CM_Site_Abstract $site) {
-        $paths = array();
-        foreach ($site->getModules() as $moduleName) {
-            $libraryPath = CM_Util::getModulePath($moduleName) . 'library/' . $moduleName . '/';
-            $paths = array_merge($paths, CM_Util::rglob($pattern, $libraryPath));
-        }
-        return $paths;
+    public static function rglobLibrariesByModule($pattern, $moduleName) {
+        $libraryPath = CM_Util::getModulePath($moduleName, false, true) . '/library/' . $moduleName . '/';
+        return CM_Util::rglob($pattern, $libraryPath);
     }
 
     /**
@@ -265,12 +261,16 @@ class CM_Util {
     /**
      * @param string    $name
      * @param bool|null $relative
+     * @param bool|null $canonical
      * @return string
      */
-    public static function getModulePath($name, $relative = null) {
+    public static function getModulePath($name, $relative = null, $canonical = null) {
         $path = CM_Bootloader::getInstance()->getModulePath($name);
         if (!$relative) {
             $path = DIR_ROOT . $path;
+        }
+        if ($canonical) {
+            $path = realpath($path);
         }
         return $path;
     }

--- a/library/CM/View/Abstract.js
+++ b/library/CM/View/Abstract.js
@@ -636,3 +636,5 @@ var CM_View_Abstract = Backbone.View.extend({
     return view;
   }
 });
+
+module.exports = CM_View_Abstract;


### PR DESCRIPTION
*done during the 13 April 2016 research day*

I've achieved my goal but I'm not satisfied, there's not enough benefit and too many changes with this current implementation...

Pros:
- Clean global scope
- `sourcemaps` supported for module JS files (in dev)    
  
<img width="994" alt="screen shot 2016-04-13 at 18 13 11" src="https://cloud.githubusercontent.com/assets/401598/14493733/12290fd4-01b1-11e6-8ebd-f7448a5795c9.png">


Cons:
- generating the `library.js` must be optimized (could take >10s!)
- all JS files need to be CommonJS compliant
- no way to load external JS module (`require()` from `source-after-body` for example) currently

My last thought: loading external JS module would make it more useful and could worth the effort to support `browserify` (or maybe an alternative module system?)...