### PR TITLE
Caching of query: cm_model_languagekey

### DIFF
--- a/library/CM/App.php
+++ b/library/CM/App.php
@@ -47,16 +47,25 @@ class CM_App implements CM_Service_ManagerAwareInterface {
             $assetList[] = new CM_Asset_Css_Vendor($render);
             $assetList[] = new CM_Asset_Css_Library($render);
         }
+        $this->fillLanguageCache();
         $languageList = new CM_Paging_Language_Enabled();
         /** @var CM_Model_Language $language */
         foreach ($languageList as $language) {
-            $language->getTranslations()->getItemsRaw();
             $assetList[] = new CM_Asset_Javascript_Translations($language);
         }
         foreach ($assetList as $asset) {
             $asset->get(!$debug);
         }
         CM_Bootloader::getInstance()->getModules();
+    }
+    
+    public function fillLanguageCache() {
+        $languageList = new CM_Paging_Language_Enabled();
+        /** @var CM_Model_Language $language */
+        foreach ($languageList as $language) {
+            $language->getTranslations()->getItemsRaw();
+            $language->getTranslations(true)->getItemsRaw();
+        }
     }
 
     /**

--- a/library/CM/App.php
+++ b/library/CM/App.php
@@ -48,8 +48,10 @@ class CM_App implements CM_Service_ManagerAwareInterface {
             $assetList[] = new CM_Asset_Css_Library($render);
         }
         $languageList = new CM_Paging_Language_Enabled();
+        /** @var CM_Model_Language $language */
         foreach ($languageList as $language) {
             $assetList[] = new CM_Asset_Javascript_Translations($language);
+            $language->getTranslations()->getItemsRaw();
         }
         foreach ($assetList as $asset) {
             $asset->get(!$debug);

--- a/library/CM/App.php
+++ b/library/CM/App.php
@@ -47,8 +47,12 @@ class CM_App implements CM_Service_ManagerAwareInterface {
             $assetList[] = new CM_Asset_Css_Vendor($render);
             $assetList[] = new CM_Asset_Css_Library($render);
         }
-        $this->fillLanguageCache();
         $languageList = new CM_Paging_Language_Enabled();
+        /** @var CM_Model_Language $language */
+        foreach ($languageList as $language) {
+            $language->getTranslations()->getItemsRaw();
+            $language->getTranslations(true)->getItemsRaw();
+        }
         /** @var CM_Model_Language $language */
         foreach ($languageList as $language) {
             $assetList[] = new CM_Asset_Javascript_Translations($language);
@@ -57,15 +61,6 @@ class CM_App implements CM_Service_ManagerAwareInterface {
             $asset->get(!$debug);
         }
         CM_Bootloader::getInstance()->getModules();
-    }
-    
-    public function fillLanguageCache() {
-        $languageList = new CM_Paging_Language_Enabled();
-        /** @var CM_Model_Language $language */
-        foreach ($languageList as $language) {
-            $language->getTranslations()->getItemsRaw();
-            $language->getTranslations(true)->getItemsRaw();
-        }
     }
 
     /**

--- a/library/CM/App.php
+++ b/library/CM/App.php
@@ -50,8 +50,8 @@ class CM_App implements CM_Service_ManagerAwareInterface {
         $languageList = new CM_Paging_Language_Enabled();
         /** @var CM_Model_Language $language */
         foreach ($languageList as $language) {
-            $assetList[] = new CM_Asset_Javascript_Translations($language);
             $language->getTranslations()->getItemsRaw();
+            $assetList[] = new CM_Asset_Javascript_Translations($language);
         }
         foreach ($assetList as $asset) {
             $asset->get(!$debug);

--- a/library/CM/App/Cli.php
+++ b/library/CM/App/Cli.php
@@ -21,6 +21,11 @@ class CM_App_Cli extends CM_Cli_Runnable_Abstract {
         CM_App::getInstance()->fillCaches();
     }
 
+    public function fillLanguageCache() {
+        $this->_getStreamOutput()->writeln('Warming up language cache…');
+        CM_App::getInstance()->fillLanguageCache();
+    }
+
     public function deploy() {
         $this->setup();
         $this->setDeployVersion();

--- a/library/CM/App/Cli.php
+++ b/library/CM/App/Cli.php
@@ -21,11 +21,6 @@ class CM_App_Cli extends CM_Cli_Runnable_Abstract {
         CM_App::getInstance()->fillCaches();
     }
 
-    public function fillLanguageCache() {
-        $this->_getStreamOutput()->writeln('Warming up language cache…');
-        CM_App::getInstance()->fillLanguageCache();
-    }
-
     public function deploy() {
         $this->setup();
         $this->setDeployVersion();

--- a/library/CM/Asset/Javascript/Translations.php
+++ b/library/CM/Asset/Javascript/Translations.php
@@ -7,7 +7,7 @@ class CM_Asset_Javascript_Translations extends CM_Asset_Javascript_Abstract {
      */
     public function __construct(CM_Model_Language $language) {
         $translations = array();
-        foreach (new CM_Paging_Translation_Language_All($language, true) as $translation) {
+        foreach ($language->getTranslations(true) as $translation) {
             $translations[$translation['key']] = $language->getTranslation($translation['key']);
         }
         $this->_content = 'cm.language.setAll(' . CM_Params::encode($translations, true) . ');';

--- a/library/CM/Asset/Javascript/Translations.php
+++ b/library/CM/Asset/Javascript/Translations.php
@@ -7,7 +7,7 @@ class CM_Asset_Javascript_Translations extends CM_Asset_Javascript_Abstract {
      */
     public function __construct(CM_Model_Language $language) {
         $translations = array();
-        foreach (new CM_Paging_Translation_Language($language, null, null, null, true) as $translation) {
+        foreach (new CM_Paging_Translation_Language_All($language, true) as $translation) {
             $translations[$translation['key']] = $language->getTranslation($translation['key']);
         }
         $this->_content = 'cm.language.setAll(' . CM_Params::encode($translations, true) . ');';

--- a/library/CM/Model/Language.php
+++ b/library/CM/Model/Language.php
@@ -73,10 +73,10 @@ class CM_Model_Language extends CM_Model_Abstract {
     }
 
     /**
-     * @return CM_Paging_Translation_Language
+     * @return CM_Paging_Translation_Language_All
      */
     public function getTranslations() {
-        return new CM_Paging_Translation_Language($this);
+        return new CM_Paging_Translation_Language_All($this);
     }
 
     /**

--- a/library/CM/Model/Language.php
+++ b/library/CM/Model/Language.php
@@ -73,10 +73,11 @@ class CM_Model_Language extends CM_Model_Abstract {
     }
 
     /**
+     * @param boolean|null $javascriptOnly
      * @return CM_Paging_Translation_Language_All
      */
-    public function getTranslations() {
-        return new CM_Paging_Translation_Language_All($this);
+    public function getTranslations($javascriptOnly = null) {
+        return new CM_Paging_Translation_Language_All($this, $javascriptOnly);
     }
 
     /**

--- a/library/CM/Model/LanguageKey.php
+++ b/library/CM/Model/LanguageKey.php
@@ -36,6 +36,7 @@ class CM_Model_LanguageKey extends CM_Model_Abstract {
             $this->_set('variables', $variablesEncoded);
 
             $this->_increaseUpdateCount();
+            $this->_changeContainingCacheables();
             if ($this->_getUpdateCount() > self::MAX_UPDATE_COUNT) {
                 $message = [
                     'Variables for languageKey `' . $this->getName() . '` have been updated over ' . self::MAX_UPDATE_COUNT . ' times since release.',
@@ -97,6 +98,13 @@ class CM_Model_LanguageKey extends CM_Model_Abstract {
 
     protected function _onDeleteBefore() {
         CM_Db_Db::delete('cm_languageValue', array('languageKeyId' => $this->getId()));
+    }
+
+    protected function _getContainingCacheables() {
+        $languages = new CM_Paging_Language_All();
+        return array_flatten(\Functional\map($languages, function (CM_Model_Language $language) {
+            return [$language->getTranslations(false), $language->getTranslations(true)];
+        }));
     }
 
     protected function _changeContainingCacheables() {

--- a/library/CM/Paging/Translation/Language/Abstract.php
+++ b/library/CM/Paging/Translation/Language/Abstract.php
@@ -31,37 +31,6 @@ abstract class CM_Paging_Translation_Language_Abstract extends CM_Paging_Abstrac
         return $translations[$phrase]['value'];
     }
 
-    /**
-     * @param string      $phrase
-     * @param string|null $value
-     * @param array|null  $variables
-     */
-    public function set($phrase, $value = null, array $variables = null) {
-        if (null === $value) {
-            $value = $phrase;
-        }
-
-        $languageKey = CM_Model_LanguageKey::replace($phrase, $variables);
-        CM_Db_Db::insert('cm_languageValue', array(
-            'value'         => $value,
-            'languageKeyId' => $languageKey->getId(),
-            'languageId'    => $this->_language->getId()
-        ), null, array('value' => $value));
-        $this->_change();
-    }
-
-    /**
-     * @param string $phrase
-     */
-    public function remove($phrase) {
-        $languageKey = CM_Model_LanguageKey::findByName($phrase);
-        if (!$languageKey) {
-            return;
-        }
-        CM_Db_Db::delete('cm_languageValue', array('languageKeyId' => $languageKey->getId(), 'languageId' => $this->_language->getId()));
-        $this->_change();
-    }
-
     protected function _processItem($item) {
         $item['variables'] = ($item['variables']) ? json_decode($item['variables']) : array();
         sort($item['variables']);

--- a/library/CM/Paging/Translation/Language/Abstract.php
+++ b/library/CM/Paging/Translation/Language/Abstract.php
@@ -1,47 +1,9 @@
 <?php
 
-class CM_Paging_Translation_Language extends CM_Paging_Abstract {
+abstract class CM_Paging_Translation_Language_Abstract extends CM_Paging_Abstract {
 
     /** @var CM_Model_Language */
     protected $_language;
-
-    /**
-     * @param CM_Model_Language $language
-     * @param string|null       $searchPhrase
-     * @param string|null       $section
-     * @param bool|null         $translated
-     * @param bool|null         $javascriptOnly
-     */
-    public function __construct(CM_Model_Language $language, $searchPhrase = null, $section = null, $translated = null, $javascriptOnly = null) {
-        $this->_language = $language;
-        $where = array();
-        $parameters = array();
-        if ($searchPhrase) {
-            $where[] = '(k.name LIKE ? OR v.value LIKE ?)';
-            $parameters[] = '%' . $searchPhrase . '%';
-            $parameters[] = '%' . $searchPhrase . '%';
-        }
-        if ($section) {
-            $where[] = 'k.name LIKE ?';
-            $parameters[] = $section . '%';
-        }
-        if ($translated === true) {
-            $where[] = 'v.value IS NOT NULL';
-        }
-        if ($translated === false) {
-            $where[] = 'v.value IS NULL';
-        }
-        if ($javascriptOnly) {
-            $where[] = 'k.javascript = 1';
-        }
-
-        $orderBy = 'k.name ASC';
-        $join = 'LEFT JOIN `cm_languageValue` AS v ON k.id = v.languageKeyId AND v.languageId = ' . $this->_language->getId() . ' ';
-        $groupBy = 'BINARY k.name';
-        $source = new CM_PagingSource_Sql_Deferred('k.name AS `key`, v.value, k.variables',
-            'cm_model_languagekey` as `k', implode(' AND ', $where), $orderBy, $join, $groupBy, $parameters);
-        parent::__construct($source);
-    }
 
     /**
      * @return string[]

--- a/library/CM/Paging/Translation/Language/All.php
+++ b/library/CM/Paging/Translation/Language/All.php
@@ -12,15 +12,15 @@ class CM_Paging_Translation_Language_All extends CM_Paging_Translation_Language_
     public function __construct(CM_Model_Language $language, $javascriptOnly = null) {
         $this->_language = $language;
         $this->_javascriptOnly = (boolean) $javascriptOnly;
-        $where = array();
+        $where = null;
         if ($javascriptOnly) {
-            $where[] = 'k.javascript = 1';
+            $where = 'k.javascript = 1';
         }
         $orderBy = 'k.name ASC';
         $join = 'LEFT JOIN `cm_languageValue` AS v ON k.id = v.languageKeyId AND v.languageId = ' . $this->_language->getId() . ' ';
         $groupBy = 'BINARY k.name';
         $source = new CM_PagingSource_Sql_Deferred('k.name AS `key`, v.value, k.variables',
-            'cm_model_languagekey` as `k', implode(' AND ', $where), $orderBy, $join, $groupBy);
+            'cm_model_languagekey` as `k', $where, $orderBy, $join, $groupBy);
         $source->enableCache(null, CM_Cache_Persistent::getInstance());
         parent::__construct($source);
     }

--- a/library/CM/Paging/Translation/Language/All.php
+++ b/library/CM/Paging/Translation/Language/All.php
@@ -58,4 +58,9 @@ class CM_Paging_Translation_Language_All extends CM_Paging_Translation_Language_
         (new self($this->_language, !$this->_javascriptOnly))->_change();
     }
 
+    public function _change() {
+        parent::_change();
+        $this->getItemsRaw(); // eagerly refill the cache
+    }
+
 }

--- a/library/CM/Paging/Translation/Language/All.php
+++ b/library/CM/Paging/Translation/Language/All.php
@@ -1,0 +1,25 @@
+<?php
+
+class CM_Paging_Translation_Language_All extends CM_Paging_Translation_Language_Abstract {
+
+    // TODO: consider removing javascriptOnly option and using a languagekey paging instead
+
+    /**
+     * @param CM_Model_Language $language
+     * @param bool|null         $javascriptOnly
+     */
+    public function __construct(CM_Model_Language $language, $javascriptOnly = null) {
+        $this->_language = $language;
+        $where = array();
+        if ($javascriptOnly) {
+            $where[] = 'k.javascript = 1';
+        }
+        $orderBy = 'k.name ASC';
+        $join = 'LEFT JOIN `cm_languageValue` AS v ON k.id = v.languageKeyId AND v.languageId = ' . $this->_language->getId() . ' ';
+        $groupBy = 'BINARY k.name';
+        $source = new CM_PagingSource_Sql_Deferred('k.name AS `key`, v.value, k.variables',
+            'cm_model_languagekey` as `k', implode(' AND ', $where), $orderBy, $join, $groupBy);
+        parent::__construct($source);
+    }
+
+}

--- a/library/CM/Paging/Translation/Language/Search.php
+++ b/library/CM/Paging/Translation/Language/Search.php
@@ -7,9 +7,8 @@ class CM_Paging_Translation_Language_Search extends CM_Paging_Translation_Langua
      * @param string|null       $searchPhrase
      * @param string|null       $section
      * @param bool|null         $translated
-     * @param bool|null         $javascriptOnly
      */
-    public function __construct(CM_Model_Language $language, $searchPhrase = null, $section = null, $translated = null, $javascriptOnly = null) {
+    public function __construct(CM_Model_Language $language, $searchPhrase = null, $section = null, $translated = null) {
         $this->_language = $language;
         $where = array();
         $parameters = array();
@@ -27,9 +26,6 @@ class CM_Paging_Translation_Language_Search extends CM_Paging_Translation_Langua
         }
         if ($translated === false) {
             $where[] = 'v.value IS NULL';
-        }
-        if ($javascriptOnly) {
-            $where[] = 'k.javascript = 1';
         }
 
         $orderBy = 'k.name ASC';

--- a/library/CM/Paging/Translation/Language/Search.php
+++ b/library/CM/Paging/Translation/Language/Search.php
@@ -1,0 +1,42 @@
+<?php
+
+class CM_Paging_Translation_Language_Search extends CM_Paging_Translation_Language_Abstract {
+    
+    /**
+     * @param CM_Model_Language $language
+     * @param string|null       $searchPhrase
+     * @param string|null       $section
+     * @param bool|null         $translated
+     * @param bool|null         $javascriptOnly
+     */
+    public function __construct(CM_Model_Language $language, $searchPhrase = null, $section = null, $translated = null, $javascriptOnly = null) {
+        $this->_language = $language;
+        $where = array();
+        $parameters = array();
+        if ($searchPhrase) {
+            $where[] = '(k.name LIKE ? OR v.value LIKE ?)';
+            $parameters[] = '%' . $searchPhrase . '%';
+            $parameters[] = '%' . $searchPhrase . '%';
+        }
+        if ($section) {
+            $where[] = 'k.name LIKE ?';
+            $parameters[] = $section . '%';
+        }
+        if ($translated === true) {
+            $where[] = 'v.value IS NOT NULL';
+        }
+        if ($translated === false) {
+            $where[] = 'v.value IS NULL';
+        }
+        if ($javascriptOnly) {
+            $where[] = 'k.javascript = 1';
+        }
+
+        $orderBy = 'k.name ASC';
+        $join = 'LEFT JOIN `cm_languageValue` AS v ON k.id = v.languageKeyId AND v.languageId = ' . $this->_language->getId() . ' ';
+        $groupBy = 'BINARY k.name';
+        $source = new CM_PagingSource_Sql_Deferred('k.name AS `key`, v.value, k.variables',
+            'cm_model_languagekey` as `k', implode(' AND ', $where), $orderBy, $join, $groupBy, $parameters);
+        parent::__construct($source);
+    }
+}

--- a/library/CM/Paging/Translation/Language/Search.php
+++ b/library/CM/Paging/Translation/Language/Search.php
@@ -1,7 +1,7 @@
 <?php
 
 class CM_Paging_Translation_Language_Search extends CM_Paging_Translation_Language_Abstract {
-    
+
     /**
      * @param CM_Model_Language $language
      * @param string|null       $searchPhrase

--- a/library/CM/PagingSource/Abstract.php
+++ b/library/CM/PagingSource/Abstract.php
@@ -11,8 +11,8 @@ abstract class CM_PagingSource_Abstract {
      * Enable cache
      * Cost: 2 memcache requests
      *
-     * @param int               $lifetime
-     * @param CM_Cache_Abstract $cache
+     * @param int                    $lifetime
+     * @param CM_Cache_Abstract|null $cache
      */
     public function enableCache($lifetime = 600, CM_Cache_Abstract $cache = null) {
         if (!$cache) {
@@ -51,7 +51,7 @@ abstract class CM_PagingSource_Abstract {
 
     /**
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      */
     protected function _cacheSet($key, $value) {
         if ($this->_cache) {

--- a/library/CM/PagingSource/Abstract.php
+++ b/library/CM/PagingSource/Abstract.php
@@ -4,7 +4,6 @@ abstract class CM_PagingSource_Abstract {
 
     /** @var int */
     private $_cacheLifetime;
-    private $_cacheLocalLifetime;
     /** @var CM_Cache_Abstract|null */
     private $_cache;
 

--- a/tests/library/CM/Paging/Translation/Language/AbstractTest.php
+++ b/tests/library/CM/Paging/Translation/Language/AbstractTest.php
@@ -1,10 +1,13 @@
 <?php
 
-class CM_Paging_Translation_LanguageTest extends CMTest_TestCase {
+class CM_Paging_Translation_Language_AbstractTest extends CMTest_TestCase {
 
     public function tearDown() {
         CMTest_TH::clearEnv();
     }
+
+    // TODO: consider the paging that is to be cached, add a test for set()
+
 
     public function testRemove() {
         $languagePagingFoo = CM_Model_Language::create('Foo', 'foo', true)->getTranslations();

--- a/tests/library/CM/Paging/Translation/Language/AbstractTest.php
+++ b/tests/library/CM/Paging/Translation/Language/AbstractTest.php
@@ -6,23 +6,6 @@ class CM_Paging_Translation_Language_AbstractTest extends CMTest_TestCase {
         CMTest_TH::clearEnv();
     }
 
-    // TODO: consider the paging that is to be cached, add a test for set()
-
-
-    public function testRemove() {
-        $languagePagingFoo = CM_Model_Language::create('Foo', 'foo', true)->getTranslations();
-        $languagePagingBar = CM_Model_Language::create('Bar', 'bar', true)->getTranslations();
-
-        $languagePagingFoo->set('phrase', 'foo');
-        $languagePagingBar->set('phrase', 'bar');
-        $this->assertSame('foo', $languagePagingFoo->get('phrase', null, true));
-        $this->assertSame('bar', $languagePagingBar->get('phrase', null, true));
-
-        $languagePagingFoo->remove('phrase');
-        $this->assertNull($languagePagingFoo->get('phrase', null, true));
-        $this->assertSame('bar', $languagePagingBar->get('phrase', null, true));
-    }
-
     public function testTrailingWhitespaceInLanguageKeyName() {
         CM_Db_Db::insert('cm_model_languagekey', ['name'], [['foo '],['foo']]);
 

--- a/tests/library/CM/Paging/Translation/Language/AllTest.php
+++ b/tests/library/CM/Paging/Translation/Language/AllTest.php
@@ -1,0 +1,46 @@
+<?php
+
+class CM_Paging_Translation_Language_AllTest extends CMTest_TestCase {
+
+    public function tearDown() {
+        CMTest_TH::clearEnv();
+    }
+
+    public function testPaging() {
+        $language = CM_Model_Language::create('Foo', 'foo', true);
+        $languagePagingAll = $language->getTranslations();
+        $languagePagingJavascriptOnly = $language->getTranslations(true);
+        $this->assertEquals([], $languagePagingAll);
+        $this->assertEquals([], $languagePagingJavascriptOnly);
+
+        $languagePagingAll->set('foo', 'foo'); // js
+        CM_Db_Db::update('cm_model_languagekey', ['javascript' => 1], ['name' => 'foo']);
+        $languagePagingJavascriptOnly->set('bar', 'bar'); // js
+        CM_Db_Db::update('cm_model_languagekey', ['javascript' => 1], ['name' => 'bar']);
+        $languagePagingAll->set('baz', 'baz'); // no js
+        $this->assertSame('foo', $language->getTranslations()->get('foo'));
+        $this->assertSame('foo', $language->getTranslations(true)->get('foo'));
+        $this->assertSame('bar', $language->getTranslations()->get('bar'));
+        $this->assertSame('bar', $language->getTranslations(true)->get('bar'));
+        $this->assertSame('baz', $language->getTranslations()->get('baz'));
+
+        $exception = $this->catchException(function() use ($language) {
+            $language->getTranslations(true)->get('baz');
+        });
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+
+        $languagePagingJavascriptOnly->set('foo', 'bar');
+        $this->assertSame('bar', $language->getTranslations(true)->get('foo'));
+        $this->assertSame('bar', $language->getTranslations()->get('foo'));
+        $languagePagingAll->set('bar', 'foo');
+        $this->assertSame('foo', $language->getTranslations()->get('bar'));
+        $this->assertSame('foo', $language->getTranslations(true)->get('bar'));
+
+        $languagePagingAll->remove('foo');
+        $this->assertSame(null, $language->getTranslations()->get('foo'));
+        $this->assertSame(null, $language->getTranslations(true)->get('foo'));
+        $languagePagingJavascriptOnly->remove('bar');
+        $this->assertSame(null, $language->getTranslations()->get('bar'));
+        $this->assertSame(null, $language->getTranslations(true)->get('bar'));
+    }
+}

--- a/tests/library/CM/PagingSource/AbstractTest.php
+++ b/tests/library/CM/PagingSource/AbstractTest.php
@@ -15,6 +15,9 @@ class CM_PagingSource_AbstractTest extends CMTest_TestCase {
 
     public function tearDown() {
         CM_Db_Db::exec('DROP TABLE `test`');
+        $paging = new CM_PagingSource_Sql('`num`', 'test');
+        $paging->enableCache();
+        $paging->clearCache();
     }
 
     public function testCacheLocal() {

--- a/tests/library/CM/PagingSource/AbstractTest.php
+++ b/tests/library/CM/PagingSource/AbstractTest.php
@@ -4,7 +4,7 @@ class CM_PagingSource_AbstractTest extends CMTest_TestCase {
 
     public function setUp() {
         CM_Db_Db::exec('CREATE TABLE `test` (
-						`id` INT(10) unsigned NOT NULL AUTO_INCREMENT,
+						`id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
 						`num` INT(10) NOT NULL,
 						PRIMARY KEY (`id`)
 						)');
@@ -26,10 +26,13 @@ class CM_PagingSource_AbstractTest extends CMTest_TestCase {
         $this->assertEquals(100, $source->getCount());
         $source->clearCache();
         $this->assertEquals(99, $source->getCount());
+        CM_Db_Db::delete('test', array('num' => 1));
+        $this->assertEquals(99, $source->getCount());
         CM_Cache_Local::getInstance()->flush();
+        $this->assertEquals(98, $source->getCount());
     }
 
-    public function testCache() {
+    public function testCacheShared() {
         $source = new CM_PagingSource_Sql('`num`', 'test');
         $source->enableCache();
         $this->assertSame(100, $source->getCount());
@@ -43,6 +46,27 @@ class CM_PagingSource_AbstractTest extends CMTest_TestCase {
         $source->clearCache();
         $this->assertSame(99, $source->getCount());
         $this->assertSame(99, $sourceNocache->getCount());
+        CM_Db_Db::delete('test', array('num' => 1));
+        $this->assertSame(99, $source->getCount());
+        $this->assertSame(98, $sourceNocache->getCount());
         CM_Cache_Shared::getInstance()->flush();
+        $this->assertSame(98, $source->getCount());
+        CM_Cache_Shared::getInstance()->flush();
+    }
+
+    public function testCacheCustom() {
+        $source = new CM_PagingSource_Sql('`num`', 'test');
+        $fileCache = CM_Cache_Persistent::getInstance();
+        $source->enableCache(null, $fileCache);
+        $this->assertEquals(100, $source->getCount());
+
+        CM_Db_Db::delete('test', array('num' => 0));
+        $this->assertEquals(100, $source->getCount());
+        $source->clearCache();
+        $this->assertEquals(99, $source->getCount());
+        CM_Db_Db::delete('test', array('num' => 1));
+        $this->assertEquals(99, $source->getCount());
+        $fileCache->flush();
+        $this->assertEquals(98, $source->getCount());
     }
 }


### PR DESCRIPTION
The following query is part of the translation module. When starting an application up an application (or releasing a new version), this query piles up. Since it's quite heavy this becomes a problem quickly.

> SELECT k.name AS `key`, v.value, k.variables FROM `cm_model_languagekey` as `k` LEFT JOIN `cm_langua[…]

@fvovan @alexispeter could you have a look?
Can we make the caching smarter (prevent many cuncurrent lookups)? Or can we warm up this cache in `fillCaches()`?