### PR TITLE
Add CSS function for inline image

### DIFF
--- a/library/CM/Asset/Css.php
+++ b/library/CM/Asset/Css.php
@@ -122,18 +122,16 @@ class CM_Asset_Css extends CM_Asset_Abstract {
                 $size = (int) $values[1][1];
             } else {
                 $path = $values[0];
-                $size = null;
+                $size = 0;
             }
 
             $imagePath = $render->getLayoutPath('resource/img/' . $path, null, null, true, true);
-            $cacheKey = CM_CacheConst::App_Resource . '_md5:' . md5($imagePath);
-            if (!empty($size)) {
-                $cacheKey .= '_size:' . $size;
-            }
-            $imageBase64 = CM_Cache_Persistent::getInstance()->get($cacheKey, function () use ($imagePath, $size) {
+            $cache = CM_Cache_Persistent::getInstance();
+
+            $imageBase64 = $cache->get($cache->key(__METHOD__, md5($imagePath), '_size:' . $size), function () use ($imagePath, $size) {
                 $file = new CM_File($imagePath);
                 $img = new CM_Image_Image($file->read());
-                if (!empty($size)) {
+                if ($size > 0) {
                     $img->resize($size, $size);
                 }
                 $img->setFormat(CM_Image_Image::FORMAT_GIF);

--- a/library/CM/Asset/Css.php
+++ b/library/CM/Asset/Css.php
@@ -124,10 +124,8 @@ class CM_Asset_Css extends CM_Asset_Abstract {
                 $path = $values[0];
                 $size = 0;
             }
-
             $imagePath = $render->getLayoutPath('resource/img/' . $path, null, null, true, true);
             $cache = CM_Cache_Persistent::getInstance();
-
             $imageBase64 = $cache->get($cache->key(__METHOD__, md5($imagePath), 'size:' . $size), function () use ($imagePath, $size) {
                 $file = new CM_File($imagePath);
                 $img = new CM_Image_Image($file->read());

--- a/library/CM/Asset/Css.php
+++ b/library/CM/Asset/Css.php
@@ -91,7 +91,7 @@ class CM_Asset_Css extends CM_Asset_Abstract {
         $cache = new CM_Cache_Storage_File();
         if (false === ($contentTransformed = $cache->get($cacheKey))) {
             $contentTransformed = $content;
-            $contentTransformed = $this->_compileLess($contentTransformed, $compress);
+            $contentTransformed = $this->_compileLess($contentTransformed, $compress, $cache);
             $contentTransformed = $this->_compileAutoprefixer($contentTransformed);
             $contentTransformed = trim($contentTransformed);
             $cache->set($cacheKey, $contentTransformed);
@@ -100,11 +100,12 @@ class CM_Asset_Css extends CM_Asset_Abstract {
     }
 
     /**
-     * @param string $content
-     * @param bool   $compress
+     * @param string                    $content
+     * @param bool                      $compress
+     * @param CM_Cache_Storage_Abstract $cache
      * @return string
      */
-    private function _compileLess($content, $compress) {
+    private function _compileLess($content, $compress, CM_Cache_Storage_Abstract $cache) {
         $render = $this->_render;
 
         $lessCompiler = new lessc();
@@ -113,7 +114,7 @@ class CM_Asset_Css extends CM_Asset_Abstract {
             list($type, $delimiter, $values) = $arg;
             return array('function', 'url', array('string', $delimiter, array($render->getUrlResource('layout', 'img/' . $values[0]))));
         });
-        $lessCompiler->registerFunction('image-inline', function ($arg) use ($render) {
+        $lessCompiler->registerFunction('image-inline', function ($arg) use ($render, $cache) {
             /** @var CM_Frontend_Render $render */
             list($type, $delimiter, $values) = $arg;
             if (2 == sizeof($values) && is_array($values[0]) && is_array($values[1])) {
@@ -124,13 +125,22 @@ class CM_Asset_Css extends CM_Asset_Abstract {
                 $path = $values[0];
             }
 
-            $file = new CM_File($render->getLayoutPath('resource/img/' . $path, null, null, true, true));
-            $img = new CM_Image_Image($file->read());
-            if (isset($size) && $size > 0) {
-                $img->resize($size, $size);
+            $imagePath = $render->getLayoutPath('resource/img/' . $path, null, null, true, true);
+            $cacheKey = CM_CacheConst::App_Resource . '_md5:' . md5($imagePath);
+            if (!empty($size)) {
+                $cacheKey .= '_size:' . $size;
             }
-            $img->setFormat(CM_Image_Image::FORMAT_GIF);
-            $url = 'data:image/gif;base64,' . base64_encode($img->getBlob());
+            if (false === ($imageBase64 = $cache->get($cacheKey))) {
+                $file = new CM_File($imagePath);
+                $img = new CM_Image_Image($file->read());
+                if (!empty($size)) {
+                    $img->resize($size, $size);
+                }
+                $img->setFormat(CM_Image_Image::FORMAT_GIF);
+                $imageBase64 = base64_encode($img->getBlob());
+                $cache->set($cacheKey, $imageBase64);
+            }
+            $url = 'data:image/gif;base64,' . $imageBase64;
             return array('function', 'url', array('string', $delimiter, array($url)));
         });
         $lessCompiler->registerFunction('urlFont', function ($arg) use ($render) {

--- a/library/CM/Asset/Css.php
+++ b/library/CM/Asset/Css.php
@@ -85,7 +85,6 @@ class CM_Asset_Css extends CM_Asset_Abstract {
     private function _compile($content, $compress = null) {
         $content = (string) $content;
         $compress = (bool) $compress;
-        $render = $this->_render;
 
         $cacheKey = CM_CacheConst::App_Resource . '_md5:' . md5($content);
         $cacheKey .= '_compress:' . (int) $compress;
@@ -113,6 +112,26 @@ class CM_Asset_Css extends CM_Asset_Abstract {
             /** @var CM_Frontend_Render $render */
             list($type, $delimiter, $values) = $arg;
             return array('function', 'url', array('string', $delimiter, array($render->getUrlResource('layout', 'img/' . $values[0]))));
+        });
+        $lessCompiler->registerFunction('image-inline', function ($arg) use ($render) {
+            /** @var CM_Frontend_Render $render */
+            list($type, $delimiter, $values) = $arg;
+            if (2 == sizeof($values) && is_array($values[0]) && is_array($values[1])) {
+                $delimiter = (string) $values[0][1];
+                $path = (string) $values[0][2][0];
+                $size = (int) $values[1][1];
+            } else {
+                $path = $values[0];
+            }
+
+            $file = new CM_File($render->getLayoutPath('resource/img/' . $path, null, null, true, true));
+            $img = new CM_Image_Image($file->read());
+            if (isset($size) && $size > 0) {
+                $img->resize($size, $size);
+            }
+            $img->setFormat(CM_Image_Image::FORMAT_GIF);
+            $url = 'data:image/gif;base64,' . base64_encode($img->getBlob());
+            return array('function', 'url', array('string', $delimiter, array($url)));
         });
         $lessCompiler->registerFunction('urlFont', function ($arg) use ($render) {
             /** @var CM_Frontend_Render $render */

--- a/library/CM/Asset/Css.php
+++ b/library/CM/Asset/Css.php
@@ -128,7 +128,7 @@ class CM_Asset_Css extends CM_Asset_Abstract {
             $imagePath = $render->getLayoutPath('resource/img/' . $path, null, null, true, true);
             $cache = CM_Cache_Persistent::getInstance();
 
-            $imageBase64 = $cache->get($cache->key(__METHOD__, md5($imagePath), '_size:' . $size), function () use ($imagePath, $size) {
+            $imageBase64 = $cache->get($cache->key(__METHOD__, md5($imagePath), 'size:' . $size), function () use ($imagePath, $size) {
                 $file = new CM_File($imagePath);
                 $img = new CM_Image_Image($file->read());
                 if ($size > 0) {

--- a/tests/library/CM/Asset/CssTest.php
+++ b/tests/library/CM/Asset/CssTest.php
@@ -40,6 +40,35 @@ EOD;
         $this->assertEquals(trim($expected), $css->get());
     }
 
+    public function testImageInline() {
+        $render = new CM_Frontend_Render();
+        $css = new CM_Asset_Css($render, "body { background: image-inline('select2/select2.png') no-repeat 60px 40px; }");
+
+        $encodedImage = 'R0lGODlhPAAoAPEAAEZGRoiIiAAAAAAAACH5BAEAAAIALAAAAAA8ACgAAAJ5lI+py+0Po5y02otxQDt7F3Rh95XcGJrqma4u6q5oG3/t+JJ1MuugvzvAI' .
+            'sMgj/aYGY+SXgaAgC4vAGlVOqVcr1kqt2vZgivb6nhiFnzP7Lb7DY/L5/RMsS7A4fB5HVL+l4cXCAT3FxiHhJjYU8i4ccfXt1hHSRdYAAA7';
+
+        $expected = <<<EOD
+body {
+  background: url('data:image/gif;base64,$encodedImage') no-repeat 60px 40px;
+}
+EOD;
+        $this->assertEquals(trim($expected), $css->get());
+    }
+
+    public function testImageInlineResize() {
+        $render = new CM_Frontend_Render();
+        $css = new CM_Asset_Css($render, "body { background: image-inline('select2/select2.png', 20) no-repeat 20px 20px; }");
+
+        $encodedImage = 'R0lGODlhFAANAPEAAEZGRoiIiAAAAAAAACH5BAEAAAIALAAAAAAUAA0AAAIalI+pyxINwzMTrkqtTgBs7n3iGJGOSWHjVAAAOw==';
+
+        $expected = <<<EOD
+body {
+  background: url('data:image/gif;base64,$encodedImage') no-repeat 20px 20px;
+}
+EOD;
+        $this->assertEquals(trim($expected), $css->get());
+    }
+
     public function testBackgroundImage() {
         $render = new CM_Frontend_Render();
         $css = new CM_Asset_Css($render, "body { background-image: image('icon/mailbox_read.png'); }");

--- a/tests/library/CM/Asset/CssTest.php
+++ b/tests/library/CM/Asset/CssTest.php
@@ -60,7 +60,6 @@ EOD;
 
         $encodedImageBeginning = preg_quote('R0lGODlhZAAvAPEAADw8Oz+0/wAAAAAAACH5BAEAAAIALAAAAABkAC8AAAL+lI+py+0Po5y02ouz3rz7D4ZKEIxlQorqRbZHm', '/');
         $encodedImageEnding = preg_quote('GQMJEuI8fSVFnoSWUuOxdjD3Sctm8107iMx8bnugkILCpErXrbOoK6rUqVQ9FQAAOw==', '/');
-
         $expectedRegex = <<<EOD
 /^body {
   background: url\('data\:image\/gif;base64,$encodedImageBeginning.+?$encodedImageEnding'\) no-repeat 100px 47px;

--- a/tests/library/CM/Asset/CssTest.php
+++ b/tests/library/CM/Asset/CssTest.php
@@ -44,7 +44,7 @@ EOD;
         $render = new CM_Frontend_Render();
         $css = new CM_Asset_Css($render, "body { background: image-inline('logo.png') no-repeat 200px 95px; }");
 
-        $encodedImageBeginning = preg_quote('R0lGODlhyABfAPEAADw8Oz+0/wAAAAAAACH5BAEAAAIALAAAAADIAF8AAAL+lI+py+0Po5y02ouz3rz7D4biSJbmiabqyrbuC8fyTNf2jef', '/');
+        $encodedImageBeginning = preg_quote('R0lGODlhyABfAPEAADw8Oz+0/wAAAAAAACH5BAEAAAIALAAAAADIAF8AAAL+lI+py+0Po5y02ouz3rz7D4biSJbmiabqyrbuC', '/');
         $encodedImageEnding = preg_quote('mW6WCddrhkk7dyWqiqbFLZIp7gwohcZpM9OKhd6q7LbrvuvgtvvPLOS68tBQAAOw==', '/');
         $expectedRegex = <<<EOD
 /^body {
@@ -58,8 +58,8 @@ EOD;
         $render = new CM_Frontend_Render();
         $css = new CM_Asset_Css($render, "body { background: image-inline('logo.png', 100) no-repeat 100px 47px; }");
 
-        $encodedImageBeginning = preg_quote('R0lGODlhZAAvAPEAADw8Oz+0/wAAAAAAACH5BAEAAAIALAAAAABkAC8AAAL+lI+py+0Po5y02ouz3rz', '/');
-        $encodedImageEnding = preg_quote('hxz7GQMJEuI8fSVFnoSWUuOxdjD3Sctm8107iMx8bnugkILCpErXrbOoK6rUqVQ9FQAAOw==', '/');
+        $encodedImageBeginning = preg_quote('R0lGODlhZAAvAPEAADw8Oz+0/wAAAAAAACH5BAEAAAIALAAAAABkAC8AAAL+lI+py+0Po5y02ouz3rz7D4ZKEIxlQorqRbZHm', '/');
+        $encodedImageEnding = preg_quote('GQMJEuI8fSVFnoSWUuOxdjD3Sctm8107iMx8bnugkILCpErXrbOoK6rUqVQ9FQAAOw==', '/');
 
         $expectedRegex = <<<EOD
 /^body {

--- a/tests/library/CM/Asset/CssTest.php
+++ b/tests/library/CM/Asset/CssTest.php
@@ -42,31 +42,31 @@ EOD;
 
     public function testImageInline() {
         $render = new CM_Frontend_Render();
-        $css = new CM_Asset_Css($render, "body { background: image-inline('select2/select2.png') no-repeat 60px 40px; }");
+        $css = new CM_Asset_Css($render, "body { background: image-inline('logo.png') no-repeat 200px 95px; }");
 
-        $encodedImage = 'R0lGODlhPAAoAPEAAEZGRoiIiAAAAAAAACH5BAEAAAIALAAAAAA8ACgAAAJ5lI+py+0Po5y02otxQDt7F3Rh95XcGJrqma4u6q5oG3/t+JJ1MuugvzvAI' .
-            'sMgj/aYGY+SXgaAgC4vAGlVOqVcr1kqt2vZgivb6nhiFnzP7Lb7DY/L5/RMsS7A4fB5HVL+l4cXCAT3FxiHhJjYU8i4ccfXt1hHSRdYAAA7';
-
-        $expected = <<<EOD
-body {
-  background: url('data:image/gif;base64,$encodedImage') no-repeat 60px 40px;
-}
+        $encodedImageBeginning = preg_quote('R0lGODlhyABfAPEAADw8Oz+0/wAAAAAAACH5BAEAAAIALAAAAADIAF8AAAL+lI+py+0Po5y02ouz3rz7D4biSJbmiabqyrbuC8fyTNf2jef', '/');
+        $encodedImageEnding = preg_quote('mW6WCddrhkk7dyWqiqbFLZIp7gwohcZpM9OKhd6q7LbrvuvgtvvPLOS68tBQAAOw==', '/');
+        $expectedRegex = <<<EOD
+/^body {
+  background: url\('data\:image\/gif;base64,$encodedImageBeginning.+?$encodedImageEnding'\) no-repeat 200px 95px;
+}$/
 EOD;
-        $this->assertEquals(trim($expected), $css->get());
+        $this->assertRegExp($expectedRegex, $css->get());
     }
 
     public function testImageInlineResize() {
         $render = new CM_Frontend_Render();
-        $css = new CM_Asset_Css($render, "body { background: image-inline('select2/select2.png', 20) no-repeat 20px 20px; }");
+        $css = new CM_Asset_Css($render, "body { background: image-inline('logo.png', 100) no-repeat 100px 47px; }");
 
-        $encodedImage = 'R0lGODlhFAANAPEAAEZGRoiIiAAAAAAAACH5BAEAAAIALAAAAAAUAA0AAAIalI+pyxINwzMTrkqtTgBs7n3iGJGOSWHjVAAAOw==';
+        $encodedImageBeginning = preg_quote('R0lGODlhZAAvAPEAADw8Oz+0/wAAAAAAACH5BAEAAAIALAAAAABkAC8AAAL+lI+py+0Po5y02ouz3rz', '/');
+        $encodedImageEnding = preg_quote('hxz7GQMJEuI8fSVFnoSWUuOxdjD3Sctm8107iMx8bnugkILCpErXrbOoK6rUqVQ9FQAAOw==', '/');
 
-        $expected = <<<EOD
-body {
-  background: url('data:image/gif;base64,$encodedImage') no-repeat 20px 20px;
-}
+        $expectedRegex = <<<EOD
+/^body {
+  background: url\('data\:image\/gif;base64,$encodedImageBeginning.+?$encodedImageEnding'\) no-repeat 100px 47px;
+}$/
 EOD;
-        $this->assertEquals(trim($expected), $css->get());
+        $this->assertRegExp($expectedRegex, $css->get());
     }
 
     public function testBackgroundImage() {


### PR DESCRIPTION
New LESS function to be added in `CM_Asset_Css::_compileLess()`

Will be used like this:
```less
background-image: image_inline('index/version2/bg.jpg');
```
With an optional "size" argument (so the image would be resized to max. 10x10):
```less
background-image: image_inline('index/version2/bg.jpg', 10);
```

Should be converted to:
```less
background-image: url(data:image/jpeg;base64,/9j/4QAYRXhpZgAASUkqAAgAAAAAAAAAAAAAAP/sABFEdWNreQABAAQAAAAyAAD/7gAhQWRvYmUAZMAAAAABAwAQAwMGCQAAAcMAAAH0AAACJv/bAIQACAYGBgYGCAYGCAwIBwgMDgoICAoOEA0NDg0NEBEMDg0NDgwRDxITFBMSDxgYGhoYGCMiIiIjJycnJycnJycnJwEJCAgJCgkLCQkLDgsNCw4RDg4ODhETDQ0ODQ0TGBEPDw8PERgWFxQUFBcWGhoYGBoaISEgISEnJycnJycnJycn/8IAEQgACgAKAwEiAAIRAQMRAf/EAJcAAQEAAAAAAAAAAAAAAAAAAAUGAQEBAAAAAAAAAAAAAAAAAAAEBhAAAQMFAQAAAAAAAAAAAAAAABECAwETMwQkBREAAQEIAwAAAAAAAAAAAAAAAAERITFBUYECMmFCAxIAAgEFAAAAAAAAAAAAAAAAADEBQVGRAjITAAEDAwUAAAAAAAAAAAAAAAEAYYEQEUEhcZGhsf/aAAwDAQACEQMRAAAAtEppR8t//9oACAECAAEFAeo//9oACAEDAAEFAU8dP//aAAgBAQABBQGZrY9yzUdnP//aAAgBAgIGPwGiP//aAAgBAwIGPwF782h5P//aAAgBAQEGPwFMclcyVSHNj32ud9T/2gAIAQIDAT8QV//aAAgBAwMBPxB35+Zf/9oACAEBAwE/ECJCIaYFa4MJjwhuu9fLUv/Z);
```

Maybe additionally to the CSS compilation cache, we should cache this conversion with a file cache, so it doesn't slow down development too much (when the CSS changes, but not the images).

---
Some example code:
```php
$file = new CM_File('/home/vagrant/sk/library/VR/layout/default/resource/img/index/version2/bg.jpg');
$img = new CM_Image_Image($file->read());
$img->resize(10, 10);
$img->setFormat(CM_Image_Image::FORMAT_GIF);
$url = 'data:image/gif;base64,' . base64_encode($img->getBlob());
```

@christopheschwyzer wdyt?