### PR TITLE
Page navigation doesn't inject "pagePlaceholder" anymore

### DIFF
--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -13,6 +13,7 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
   /** @type PromiseThrottled|Null */
   _loadPageThrottled: promiseThrottler(function(path) {
     var layout = this;
+    layout._createPagePlaceholder();
     layout._chargeSpinnerTimeout();
 
     return this.ajaxModal('loadPage', {path: path})

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -18,7 +18,7 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
 
     return this.ajaxModal('loadPage', {path: path})
       .finally(function() {
-        layout._clearSpinnerTimeout();
+        clearTimeout(this._timeoutLoading);
       })
       .then(function(response) {
         if (response.redirectExternal) {
@@ -159,14 +159,10 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
   },
 
   _chargeSpinnerTimeout: function() {
-    this._clearSpinnerTimeout();
+    clearTimeout(this._timeoutLoading);
     this._timeoutLoading = this.setTimeout(function() {
       this._getPagePlaceholder().html('<div class="spinner spinner-expanded" />');
     }, 750);
-  },
-
-  _clearSpinnerTimeout: function() {
-    clearTimeout(this._timeoutLoading);
   },
 
   /**


### PR DESCRIPTION
How it should work:
1. When you start navigating to a different page we replace the current page with the "placeholder" (empty).
2. After a short timeout we inject a spinner into the placeholder
3. Once loaded we replace the placeholder with the actual content

Looks to me like step 1) doesn't work anymore.
I think this was lost in 2e60c6fd7ca9b631e0c466de8772b3c9c70a82d4.

cc @christopheschwyzer