### PR TITLE
Page navigation doesn't inject "pagePlaceholder" anymore II

### DIFF
--- a/client-vendor/after-body/promise-utils/promise-throttler.js
+++ b/client-vendor/after-body/promise-utils/promise-throttler.js
@@ -42,11 +42,15 @@
     var promise;
 
     return function() {
-      var cancelLeading = options.cancelLeading && promise && promise.isPending() && promise.isCancellable();
+      if (!promise || !promise.isPending()) {
+        promise = fn.apply(this, arguments);
+        return promise;
+      }
+      var cancelLeading = options.cancelLeading;
       if (cancelLeading) {
         promise.cancel();
       }
-      var addToQueue = options.queue && promise && promise.isPending();
+      var addToQueue = options.queue;
       if (cancelLeading || addToQueue) {
         var args = arguments;
         var self = this;
@@ -57,9 +61,6 @@
           });
         });
         return promise;
-      }
-      if (!promise || !promise.isPending()) {
-        promise = fn.apply(this, arguments);
       }
       return promise;
     };

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -13,12 +13,15 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
   /** @type PromiseThrottled|Null */
   _loadPageThrottled: promiseThrottler(function(path) {
     var layout = this;
+    console.log('preparing a new request');
     layout._createPagePlaceholder();
     layout._chargeSpinnerTimeout();
 
+    console.log('starting a new request');
     return this.ajaxModal('loadPage', {path: path})
       .finally(function() {
-        clearTimeout(this._timeoutLoading);
+        console.log('finally cancels the request');
+        clearTimeout(layout._timeoutLoading);
       })
       .then(function(response) {
         if (response.redirectExternal) {

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -13,11 +13,12 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
   /** @type PromiseThrottled|Null */
   _loadPageThrottled: promiseThrottler(function(path) {
     var layout = this;
+    layout._createPagePlaceholder();
     layout._chargeSpinnerTimeout();
 
     return this.ajaxModal('loadPage', {path: path})
       .finally(function() {
-        layout._clearSpinnerTimeout();
+        clearTimeout(this._timeoutLoading);
       })
       .then(function(response) {
         if (response.redirectExternal) {
@@ -158,14 +159,10 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
   },
 
   _chargeSpinnerTimeout: function() {
-    this._clearSpinnerTimeout();
+    clearTimeout(this._timeoutLoading);
     this._timeoutLoading = this.setTimeout(function() {
       this._getPagePlaceholder().html('<div class="spinner spinner-expanded" />');
     }, 750);
-  },
-
-  _clearSpinnerTimeout: function() {
-    clearTimeout(this._timeoutLoading);
   },
 
   /**

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -13,14 +13,11 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
   /** @type PromiseThrottled|Null */
   _loadPageThrottled: promiseThrottler(function(path) {
     var layout = this;
-    console.log('preparing a new request');
     layout._createPagePlaceholder();
     layout._chargeSpinnerTimeout();
 
-    console.log('starting a new request');
     return this.ajaxModal('loadPage', {path: path})
       .finally(function() {
-        console.log('finally cancels the request');
         clearTimeout(layout._timeoutLoading);
       })
       .then(function(response) {


### PR DESCRIPTION
Added: https://github.com/cargomedia/cm/pull/2131
Reverted: https://github.com/cargomedia/cm/pull/2133

Looks like the spinner timeout didn't clear. Spinner would show up *after* successful page load.

cc @zazabe 