### PR TITLE
Check if the HTTP server is up before running QUnit tests

### DIFF
--- a/bin/qunit
+++ b/bin/qunit
@@ -1,30 +1,15 @@
-#!/usr/bin/env bash
+#!/bin/bash -e
 
 SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+while [ -h "$SOURCE" ]; do
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
   SOURCE="$(readlink "$SOURCE")"
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-function http_failed {
-  echo "Failed to start the HTTP server, abort."
-  kill ${SERVER_PID}
-  exit 1
-}
-
 php -S 127.0.0.1:8080 &>/dev/null &
 SERVER_PID=$!
-
-TRIES=10
-echo "HTTP server starting on 127.0.0.1:8080..."
-while ! nc -z 127.0.0.1 8080 &>/dev/null; do
-  sleep 0.1
-  ((--TRIES)) || http_failed
-done
-
+trap "kill ${SERVER_PID}" EXIT
+timeout --signal=9 3 bash -c "while ! (nc -z 127.0.0.1 8080 &>/dev/null); do sleep 0.1; done"
 phantomjs ${DIR}/../tests/client/phantomjs-runner.js http://127.0.0.1:8080/tests.html
-EXIT_CODE=$?
-kill ${SERVER_PID} && echo "HTTP server stopped."
-exit ${EXIT_CODE}

--- a/bin/qunit
+++ b/bin/qunit
@@ -8,9 +8,23 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-php -S 0.0.0.0:8080 &>/dev/null &
+function http_failed {
+  echo "Failed to start the HTTP server, abort."
+  kill ${SERVER_PID}
+  exit 1
+}
+
+php -S 127.0.0.1:8080 &>/dev/null &
 SERVER_PID=$!
+
+TRIES=10
+echo "HTTP server starting on 127.0.0.1:8080..."
+while ! nc -z 127.0.0.1 8080 &>/dev/null; do
+  sleep 0.1
+  ((--TRIES)) || http_failed
+done
+
 phantomjs ${DIR}/../tests/client/phantomjs-runner.js http://127.0.0.1:8080/tests.html
 EXIT_CODE=$?
-kill ${SERVER_PID}
+kill ${SERVER_PID} && echo "HTTP server stopped."
 exit ${EXIT_CODE}


### PR DESCRIPTION
`bin/qunit` may fail with this error:
```
Unable to access network: fail
phantomjs://code/phantomjs-runner.js:109
```