### PR TITLE
Read timezone from offset cookie

### DIFF
--- a/library/CM/Http/Request/Abstract.php
+++ b/library/CM/Http/Request/Abstract.php
@@ -432,6 +432,20 @@ abstract class CM_Http_Request_Abstract {
     }
 
     /**
+     * @return DateTimeZone|null
+     */
+    public function getTimeZone() {
+        if ($timezoneOffset = $this->getCookie('timeZoneOffset')) {
+            //timezoneOffset is minutes behind UTC
+            $timezoneOffset = (int) $timezoneOffset * -1;
+            $offsetHours = intval($timezoneOffset / 60);
+            $offsetMinutes = intval($timezoneOffset % 60);
+            return DateTime::createFromFormat('O', sprintf("%+03d%02d", $offsetHours, $offsetMinutes))->getTimezone();
+        }
+        return null;
+    }
+
+    /**
      * @return string
      */
     public function getUserAgent() {

--- a/library/CM/Http/Request/Abstract.php
+++ b/library/CM/Http/Request/Abstract.php
@@ -436,10 +436,10 @@ abstract class CM_Http_Request_Abstract {
      */
     public function getTimeZone() {
         if ($timeZoneOffset = $this->getCookie('timezoneOffset')) {
-            //timezoneOffset is minutes behind UTC
+            //timezoneOffset is seconds behind UTC
             $timeZoneOffset = (int) $timeZoneOffset * -1;
-            $offsetHours = intval($timeZoneOffset / 60);
-            $offsetMinutes = intval($timeZoneOffset % 60);
+            $offsetHours = floor($timeZoneOffset / 3600);
+            $offsetMinutes = floor($timeZoneOffset % 3600 / 60);
             return DateTime::createFromFormat('O', sprintf("%+03d%02d", $offsetHours, $offsetMinutes))->getTimezone();
         }
         return null;

--- a/library/CM/Http/Request/Abstract.php
+++ b/library/CM/Http/Request/Abstract.php
@@ -435,11 +435,11 @@ abstract class CM_Http_Request_Abstract {
      * @return DateTimeZone|null
      */
     public function getTimeZone() {
-        if ($timezoneOffset = $this->getCookie('timeZoneOffset')) {
+        if ($timeZoneOffset = $this->getCookie('timezoneOffset')) {
             //timezoneOffset is minutes behind UTC
-            $timezoneOffset = (int) $timezoneOffset * -1;
-            $offsetHours = intval($timezoneOffset / 60);
-            $offsetMinutes = intval($timezoneOffset % 60);
+            $timeZoneOffset = (int) $timeZoneOffset * -1;
+            $offsetHours = intval($timeZoneOffset / 60);
+            $offsetMinutes = intval($timeZoneOffset % 60);
             return DateTime::createFromFormat('O', sprintf("%+03d%02d", $offsetHours, $offsetMinutes))->getTimezone();
         }
         return null;

--- a/library/CM/Http/Request/Abstract.php
+++ b/library/CM/Http/Request/Abstract.php
@@ -435,14 +435,7 @@ abstract class CM_Http_Request_Abstract {
      * @return DateTimeZone|null
      */
     public function getTimeZone() {
-        if ($timeZoneOffset = $this->getCookie('timezoneOffset')) {
-            //timezoneOffset is seconds behind UTC
-            $timeZoneOffset = (int) $timeZoneOffset * -1;
-            $offsetHours = floor($timeZoneOffset / 3600);
-            $offsetMinutes = floor($timeZoneOffset % 3600 / 60);
-            return DateTime::createFromFormat('O', sprintf("%+03d%02d", $offsetHours, $offsetMinutes))->getTimezone();
-        }
-        return null;
+        return $this->_getTimeZoneFromCookie();
     }
 
     /**
@@ -518,6 +511,20 @@ abstract class CM_Http_Request_Abstract {
                     return $language;
                 }
             }
+        }
+        return null;
+    }
+
+    /**
+     * @return DateTimeZone|null
+     */
+    private function _getTimeZoneFromCookie() {
+        if ($timeZoneOffset = $this->getCookie('timezoneOffset')) {
+            //timezoneOffset is seconds behind UTC
+            $timeZoneOffset = (int) $timeZoneOffset * -1;
+            $offsetHours = floor($timeZoneOffset / 3600);
+            $offsetMinutes = floor($timeZoneOffset % 3600 / 60);
+            return DateTime::createFromFormat('O', sprintf("%+03d%02d", $offsetHours, $offsetMinutes))->getTimezone();
         }
         return null;
     }

--- a/library/CM/Http/Response/Abstract.php
+++ b/library/CM/Http/Response/Abstract.php
@@ -127,15 +127,8 @@ abstract class CM_Http_Response_Abstract extends CM_Class_Abstract implements CM
             $currency = CM_Model_Currency::findByLocation($location);
         }
         $clientDevice = new CM_Http_ClientDevice($this->getRequest());
-        $timezone = null;
-        if ($timezoneOffset = $this->getRequest()->getCookie('timezoneOffset')) {
-            //timezoneOffset is minutes behind UTC
-            $timezoneOffset = (int) $timezoneOffset * -1;
-            $offsetHours = intval($timezoneOffset / 60);
-            $offsetMinutes = intval($timezoneOffset % 60);
-            $timezone = DateTime::createFromFormat('O', sprintf("%+03d%02d", $offsetHours , $offsetMinutes))->getTimezone();
-        }
-        return new CM_Frontend_Environment($this->getSite(), $viewer, $this->getRequest()->getLanguage(), $timezone, null, $location, $currency, $clientDevice);
+        $timeZone = $this->getRequest()->getTimeZone();
+        return new CM_Frontend_Environment($this->getSite(), $viewer, $this->getRequest()->getLanguage(), $timeZone, null, $location, $currency, $clientDevice);
     }
 
     /**

--- a/library/CM/Http/Response/Abstract.php
+++ b/library/CM/Http/Response/Abstract.php
@@ -127,7 +127,15 @@ abstract class CM_Http_Response_Abstract extends CM_Class_Abstract implements CM
             $currency = CM_Model_Currency::findByLocation($location);
         }
         $clientDevice = new CM_Http_ClientDevice($this->getRequest());
-        return new CM_Frontend_Environment($this->getSite(), $viewer, $this->getRequest()->getLanguage(), null, null, $location, $currency, $clientDevice);
+        $timezone = null;
+        if ($timezoneOffset = $this->getRequest()->getCookie('timezoneOffset')) {
+            //timezoneOffset is minutes behind UTC
+            $timezoneOffset = (int) $timezoneOffset * -1;
+            $offsetHours = intval($timezoneOffset / 60);
+            $offsetMinutes = intval($timezoneOffset % 60);
+            $timezone = DateTime::createFromFormat('O', sprintf("%+03d%02d", $offsetHours , $offsetMinutes))->getTimezone();
+        }
+        return new CM_Frontend_Environment($this->getSite(), $viewer, $this->getRequest()->getLanguage(), $timezone, null, $location, $currency, $clientDevice);
     }
 
     /**

--- a/library/CM/Http/Response/Abstract.php
+++ b/library/CM/Http/Response/Abstract.php
@@ -117,8 +117,9 @@ abstract class CM_Http_Response_Abstract extends CM_Class_Abstract implements CM
      * @throws CM_Exception_AuthRequired
      */
     public function getEnvironment() {
-        $location = $this->getRequest()->getLocation();
-        $viewer = $this->getRequest()->getViewer();
+        $request = $this->getRequest();
+        $location = $request->getLocation();
+        $viewer = $request->getViewer();
         $currency = null;
         if (null === $currency && null !== $viewer) {
             $currency = $viewer->getCurrency();
@@ -126,9 +127,8 @@ abstract class CM_Http_Response_Abstract extends CM_Class_Abstract implements CM
         if (null === $currency && null !== $location) {
             $currency = CM_Model_Currency::findByLocation($location);
         }
-        $clientDevice = new CM_Http_ClientDevice($this->getRequest());
-        $timeZone = $this->getRequest()->getTimeZone();
-        return new CM_Frontend_Environment($this->getSite(), $viewer, $this->getRequest()->getLanguage(), $timeZone, null, $location, $currency, $clientDevice);
+        $clientDevice = new CM_Http_ClientDevice($request);
+        return new CM_Frontend_Environment($this->getSite(), $viewer, $request->getLanguage(), $request->getTimeZone(), null, $location, $currency, $clientDevice);
     }
 
     /**

--- a/tests/library/CM/Http/Request/AbstractTest.php
+++ b/tests/library/CM/Http/Request/AbstractTest.php
@@ -268,12 +268,12 @@ class CM_Http_Request_AbstractTest extends CMTest_TestCase {
     }
 
     public function testGetTimezone() {
-        $request = new CM_Http_Request_Get('/foo/bar/', ['cookie' => 'timezoneOffset=-150; clientId=7']);
+        $request = new CM_Http_Request_Get('/foo/bar/', ['cookie' => 'timezoneOffset=-9000; clientId=7']);
         $timeZone = $request->getTimeZone();
         $this->assertInstanceOf('DateTimeZone', $timeZone);
         $this->assertSame('+02:30', $timeZone->getName());
 
-        $request =new CM_Http_Request_Post('/foo/bar/', ['cookie' => 'timezoneOffset=60']);
+        $request =new CM_Http_Request_Post('/foo/bar/', ['cookie' => 'timezoneOffset=3600']);
         $timeZone = $request->getTimeZone();
         $this->assertInstanceOf('DateTimeZone', $timeZone);
         $this->assertSame('-01:00', $timeZone->getName());

--- a/tests/library/CM/Http/Request/AbstractTest.php
+++ b/tests/library/CM/Http/Request/AbstractTest.php
@@ -267,6 +267,22 @@ class CM_Http_Request_AbstractTest extends CMTest_TestCase {
         $this->assertSame(null, $request->getViewer());
     }
 
+    public function testGetTimezone() {
+        $request = new CM_Http_Request_Get('/foo/bar/', ['cookie' => 'timeZoneOffset=-150; clientId=7']);
+        $timeZone = $request->getTimeZone();
+        $this->assertInstanceOf('DateTimeZone', $timeZone);
+        $this->assertSame('+02:30', $timeZone->getName());
+
+        $request =new CM_Http_Request_Post('/foo/bar/', ['cookie' => 'timeZoneOffset=60']);
+        $timeZone = $request->getTimeZone();
+        $this->assertInstanceOf('DateTimeZone', $timeZone);
+        $this->assertSame('-01:00', $timeZone->getName());
+
+        $request =new CM_Http_Request_Get('/foo/baz/');
+        $timeZone = $request->getTimeZone();
+        $this->assertNull($timeZone);
+    }
+
     /**
      * @param string             $uri
      * @param array|null         $additionalHeaders

--- a/tests/library/CM/Http/Request/AbstractTest.php
+++ b/tests/library/CM/Http/Request/AbstractTest.php
@@ -267,19 +267,19 @@ class CM_Http_Request_AbstractTest extends CMTest_TestCase {
         $this->assertSame(null, $request->getViewer());
     }
 
-    public function testGetTimezone() {
+    public function testGetTimeZoneFromCookie() {
         $request = new CM_Http_Request_Get('/foo/bar/', ['cookie' => 'timezoneOffset=-9000; clientId=7']);
-        $timeZone = $request->getTimeZone();
+        $timeZone = $this->callProtectedMethod($request, 'getTimeZone');
         $this->assertInstanceOf('DateTimeZone', $timeZone);
         $this->assertSame('+02:30', $timeZone->getName());
 
         $request =new CM_Http_Request_Post('/foo/bar/', ['cookie' => 'timezoneOffset=3600']);
-        $timeZone = $request->getTimeZone();
+        $timeZone = $this->callProtectedMethod($request, 'getTimeZone');
         $this->assertInstanceOf('DateTimeZone', $timeZone);
         $this->assertSame('-01:00', $timeZone->getName());
 
         $request =new CM_Http_Request_Get('/foo/baz/');
-        $timeZone = $request->getTimeZone();
+        $timeZone = $this->callProtectedMethod($request, 'getTimeZone');
         $this->assertNull($timeZone);
     }
 

--- a/tests/library/CM/Http/Request/AbstractTest.php
+++ b/tests/library/CM/Http/Request/AbstractTest.php
@@ -268,12 +268,12 @@ class CM_Http_Request_AbstractTest extends CMTest_TestCase {
     }
 
     public function testGetTimezone() {
-        $request = new CM_Http_Request_Get('/foo/bar/', ['cookie' => 'timeZoneOffset=-150; clientId=7']);
+        $request = new CM_Http_Request_Get('/foo/bar/', ['cookie' => 'timezoneOffset=-150; clientId=7']);
         $timeZone = $request->getTimeZone();
         $this->assertInstanceOf('DateTimeZone', $timeZone);
         $this->assertSame('+02:30', $timeZone->getName());
 
-        $request =new CM_Http_Request_Post('/foo/bar/', ['cookie' => 'timeZoneOffset=60']);
+        $request =new CM_Http_Request_Post('/foo/bar/', ['cookie' => 'timezoneOffset=60']);
         $timeZone = $request->getTimeZone();
         $this->assertInstanceOf('DateTimeZone', $timeZone);
         $this->assertSame('-01:00', $timeZone->getName());

--- a/tests/library/CM/Http/Response/AbstractTest.php
+++ b/tests/library/CM/Http/Response/AbstractTest.php
@@ -162,4 +162,22 @@ class CM_Http_Response_AbstractTest extends CMTest_TestCase {
 
         $this->assertSame(1, $exceptionCodeExecutionCounter);
     }
+
+    public function testGetEnvironmentTimezone() {
+        /** @var CM_Http_Response_Abstract|\Mocka\AbstractClassTrait $response */
+        $response = $this->mockClass('CM_Http_Response_Abstract')->newInstanceWithoutConstructor();
+
+        $response->mockMethod('getRequest')->set(new CM_Http_Request_Get('/foo/bar/', ['cookie' => 'timezoneOffset=-150; clientId=7']));
+        $response->setServiceManager($this->getServiceManager());
+        $environment = $response->getEnvironment();
+        $this->assertInstanceOf('CM_Frontend_Environment', $environment);
+        $this->assertInstanceOf('DateTimeZone', $environment->getTimeZone());
+        $this->assertSame('+02:30', $environment->getTimeZone()->getName());
+
+        $response->mockMethod('getRequest')->set(new CM_Http_Request_Get('/foo/bar/', ['cookie' => 'timezoneOffset=60']));
+        $environment = $response->getEnvironment();
+        $this->assertInstanceOf('CM_Frontend_Environment', $environment);
+        $this->assertInstanceOf('DateTimeZone', $environment->getTimeZone());
+        $this->assertSame('-01:00', $environment->getTimeZone()->getName());
+    }
 }

--- a/tests/library/CM/Http/Response/AbstractTest.php
+++ b/tests/library/CM/Http/Response/AbstractTest.php
@@ -162,22 +162,4 @@ class CM_Http_Response_AbstractTest extends CMTest_TestCase {
 
         $this->assertSame(1, $exceptionCodeExecutionCounter);
     }
-
-    public function testGetEnvironmentTimezone() {
-        /** @var CM_Http_Response_Abstract|\Mocka\AbstractClassTrait $response */
-        $response = $this->mockClass('CM_Http_Response_Abstract')->newInstanceWithoutConstructor();
-
-        $response->mockMethod('getRequest')->set(new CM_Http_Request_Get('/foo/bar/', ['cookie' => 'timezoneOffset=-150; clientId=7']));
-        $response->setServiceManager($this->getServiceManager());
-        $environment = $response->getEnvironment();
-        $this->assertInstanceOf('CM_Frontend_Environment', $environment);
-        $this->assertInstanceOf('DateTimeZone', $environment->getTimeZone());
-        $this->assertSame('+02:30', $environment->getTimeZone()->getName());
-
-        $response->mockMethod('getRequest')->set(new CM_Http_Request_Get('/foo/bar/', ['cookie' => 'timezoneOffset=60']));
-        $environment = $response->getEnvironment();
-        $this->assertInstanceOf('CM_Frontend_Environment', $environment);
-        $this->assertInstanceOf('DateTimeZone', $environment->getTimeZone());
-        $this->assertSame('-01:00', $environment->getTimeZone()->getName());
-    }
 }


### PR DESCRIPTION
- read offset from cookie
- instantiate timezone using `DateTime::createFromFormat('O', $offset)->getTimezone();`
- use this timezone in Frontend_Environemnt (precedence over location-based and bootloader timezones)