### PR TITLE
Set minLevel for NewRelic log handler to ERROR

### DIFF
--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -251,7 +251,7 @@ return function (CM_Config_Node $config) {
     $config->services['logger-handler-newrelic'] = [
         'class'     => 'CMService_NewRelic_Log_Handler',
         'arguments' => [
-            'minLevel' => CM_Log_Logger::WARNING,
+            'minLevel' => CM_Log_Logger::ERROR,
         ],
     ];
 


### PR DESCRIPTION
This way we can keep using NR error alerts, which has nice features (like alert if the percentage of pageviews with errors exceeds a certain threshold).
Since there's no way to distinguish warnings from errors in NR I think this is the only way to do it.

@fvovan @tomaszdurka wdyt?