### PR TITLE
Allow site URLs to include path

### DIFF
--- a/library/CM/Frontend/Render.php
+++ b/library/CM/Frontend/Render.php
@@ -239,7 +239,7 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
         if (!$options['sameOrigin'] && $this->getSite()->getUrlCdn()) {
             $url = $this->getSite()->getUrlCdn();
         } else {
-            $url = $this->getSite()->getUrl();
+            $url = $this->getSite()->getUrlBase();
         }
 
         if (!is_null($type) && !is_null($path)) {
@@ -272,7 +272,7 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
             throw new CM_Exception_Invalid('Needs user');
         }
         $params = array('user' => $mail->getRecipient()->getId(), 'mailType' => $mail->getType());
-        return CM_Util::link($this->getSite()->getUrl() . '/emailtracking/' . $this->getSite()->getId(), $params);
+        return CM_Util::link($this->getSite()->getUrlBase() . '/emailtracking/' . $this->getSite()->getId(), $params);
     }
 
     /**
@@ -283,7 +283,7 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
         if ($this->getSite()->getUrlCdn()) {
             $url = $this->getSite()->getUrlCdn();
         } else {
-            $url = $this->getSite()->getUrl();
+            $url = $this->getSite()->getUrlBase();
         }
 
         $url .= '/static';

--- a/library/CM/Http/Response/Abstract.php
+++ b/library/CM/Http/Response/Abstract.php
@@ -301,7 +301,7 @@ abstract class CM_Http_Response_Abstract extends CM_Class_Abstract implements CM
                 return $responseClass;
             }
         }
-        return 'CM_Http_Response_Page';
+        return self::_getDefaultResponseClass();
     }
 
     /**
@@ -320,5 +320,12 @@ abstract class CM_Http_Response_Abstract extends CM_Class_Abstract implements CM
      */
     public static function match(CM_Http_Request_Abstract $request) {
         return false;
+    }
+
+    /**
+     * @return string
+     */
+    private static function _getDefaultResponseClass() {
+        return (string) self::_getConfig()->defaultResponse;
     }
 }

--- a/library/CM/Http/Response/Page.php
+++ b/library/CM/Http/Response/Page.php
@@ -10,8 +10,8 @@ class CM_Http_Response_Page extends CM_Http_Response_Abstract {
 
     public function __construct(CM_Http_Request_Abstract $request, CM_Service_Manager $serviceManager) {
         $this->_request = clone $request;
-        $this->_site = CM_Site_Abstract::findByRequest($this->_request);
         $this->_request->popPathLanguage();
+        $this->_site = CM_Site_Abstract::findByRequest($this->_request);
 
         $this->setServiceManager($serviceManager);
     }

--- a/library/CM/Http/Response/Page/Embed.php
+++ b/library/CM/Http/Response/Page/Embed.php
@@ -2,6 +2,19 @@
 
 class CM_Http_Response_Page_Embed extends CM_Http_Response_Page {
 
+    /**
+     * @param CM_Http_Request_Abstract $request
+     * @param CM_Site_Abstract         $site
+     * @param CM_Service_Manager       $serviceManager
+     */
+    public function __construct(CM_Http_Request_Abstract $request, CM_Site_Abstract $site, CM_Service_Manager $serviceManager) {
+        $this->_request = clone $request;
+        $this->_request->popPathLanguage();
+        $this->_site = $site;
+
+        $this->setServiceManager($serviceManager);
+    }
+
     /** @var string|null */
     private $_title;
 

--- a/library/CM/Http/Response/Resource/Abstract.php
+++ b/library/CM/Http/Response/Resource/Abstract.php
@@ -8,7 +8,8 @@ abstract class CM_Http_Response_Resource_Abstract extends CM_Http_Response_Abstr
     }
 
     protected function _setContent($content) {
-        $this->setHeader('Access-Control-Allow-Origin', $this->getSite()->getUrl());
+        $this->setHeader('Access-Control-Allow-Origin', $this->getSite()->getUrlBase());
+
         parent::_setContent($content);
     }
 }

--- a/library/CM/Http/Response/View/Abstract.php
+++ b/library/CM/Http/Response/View/Abstract.php
@@ -73,7 +73,7 @@ abstract class CM_Http_Response_View_Abstract extends CM_Http_Response_Abstract 
             if ($count++ > 10) {
                 throw new CM_Exception_Invalid('Page redirect loop detected (' . implode(' -> ', $paths) . ').');
             }
-            $responsePage = new CM_Http_Response_Page_Embed($request, $this->getServiceManager());
+            $responsePage = new CM_Http_Response_Page_Embed($request, $response->getSite(), $this->getServiceManager());
             $responsePage->process();
             $request = $responsePage->getRequest();
 

--- a/library/CM/Http/UrlParser.php
+++ b/library/CM/Http/UrlParser.php
@@ -23,4 +23,16 @@ class CM_Http_UrlParser {
         }
         return $host;
     }
+
+    /**
+     * @return string
+     * @throws CM_Exception
+     */
+    public function getScheme() {
+        $scheme = parse_url($this->_url, PHP_URL_SCHEME);
+        if (false === $scheme || null === $scheme) {
+            throw new CM_Exception('Cannot detect scheme from `' . $this->_url . '`.');
+        }
+        return $scheme;
+    }
 }

--- a/library/CM/Layout/Abstract.js
+++ b/library/CM/Layout/Abstract.js
@@ -170,7 +170,7 @@ var CM_Layout_Abstract = CM_View_Abstract.extend({
    * @param {String} responseUrl
    */
   _updateHistory: function(requestPath, responseUrl) {
-    var responseFragment = responseUrl.substr(cm.getUrl().length);
+    var responseFragment = cm.router._getFragmentByUrl(responseUrl);
     if (requestPath === responseFragment + window.location.hash) {
       responseFragment = requestPath;
     }

--- a/library/CM/Page/Abstract.js
+++ b/library/CM/Page/Abstract.js
@@ -14,7 +14,7 @@ var CM_Page_Abstract = CM_Component_Abstract.extend({
   _state: null,
 
   /** @type String|Null */
-  _fragment: null,
+  _url: null,
 
   _ready: function() {
     CM_Component_Abstract.prototype._ready.call(this);
@@ -23,15 +23,15 @@ var CM_Page_Abstract = CM_Component_Abstract.extend({
       var location = window.location;
       var params = cm.request.parseQueryParams(location.search);
       var state = _.pick(params, _.intersection(_.keys(params), this.getStateParams()));
-      this.routeToState(state, location.pathname + location.search);
+      this.routeToState(state, location.href);
     }
   },
 
   /**
    * @returns {String|Null}
    */
-  getFragment: function() {
-    return this._fragment;
+  getUrl: function() {
+    return this._url;
   },
 
   /**
@@ -73,11 +73,11 @@ var CM_Page_Abstract = CM_Component_Abstract.extend({
 
   /**
    * @param {Object} state
-   * @param {String} fragment
+   * @param {String} url
    * @returns {Boolean}
    */
-  routeToState: function(state, fragment) {
-    this._fragment = fragment;
+  routeToState: function(state, url) {
+    this._url = url;
     this.setState(state);
     return this._changeState(state);
   },

--- a/library/CM/RenderAdapter/Layout.php
+++ b/library/CM/RenderAdapter/Layout.php
@@ -46,6 +46,7 @@ class CM_RenderAdapter_Layout extends CM_RenderAdapter_Abstract {
         $options['renderStamp'] = floor(microtime(true) * 1000);
         $options['site'] = CM_Params::encode($this->getRender()->getSite());
         $options['url'] = $this->getRender()->getSite()->getUrl();
+        $options['urlBase'] = $this->getRender()->getSite()->getUrlBase();
         $options['urlCdn'] = $this->getRender()->getSite()->getUrlCdn();
         $options['urlUserContentList'] = $serviceManager->getUserContent()->getUrlList();
         $options['language'] = $this->getRender()->getLanguage();

--- a/library/CM/Site/Abstract.php
+++ b/library/CM/Site/Abstract.php
@@ -232,14 +232,18 @@ abstract class CM_Site_Abstract extends CM_Class_Abstract implements CM_ArrayCon
 
     /**
      * @param CM_Http_Request_Abstract $request
+     * @param array|null               $matchData
      * @return CM_Site_Abstract
-     * @throws CM_Exception_Invalid
+     * @throws CM_Class_Exception_TypeNotConfiguredException
      */
-    public static function findByRequest(CM_Http_Request_Abstract $request) {
+    public static function findByRequest(CM_Http_Request_Abstract $request, array $matchData = null) {
+        if (null === $matchData) {
+            $matchData = [];
+        }
         foreach (array_reverse(static::getClassChildren()) as $className) {
             /** @var CM_Site_Abstract $site */
             $site = new $className();
-            if ($site->match($request)) {
+            if ($site->match($request, $matchData)) {
                 return $site;
             }
         }

--- a/library/CM/Site/Abstract.php
+++ b/library/CM/Site/Abstract.php
@@ -130,6 +130,15 @@ abstract class CM_Site_Abstract extends CM_Class_Abstract implements CM_ArrayCon
     }
 
     /**
+     * @return string
+     * @throws CM_Exception
+     */
+    public function getUrlBase() {
+        $urlParser = new CM_Http_UrlParser($this->getUrl());
+        return $urlParser->getScheme() . '://' . $urlParser->getHost();
+    }
+
+    /**
      * @param CM_Http_Response_Page $response
      */
     public function preprocessPageResponse(CM_Http_Response_Page $response) {
@@ -174,12 +183,13 @@ abstract class CM_Site_Abstract extends CM_Class_Abstract implements CM_ArrayCon
 
     /**
      * @param CM_Http_Request_Abstract $request
-     * @return boolean
+     * @param array                    $data
+     * @return bool
+     * @throws CM_Exception
      */
-    public function match(CM_Http_Request_Abstract $request) {
-        $url = new CM_Http_UrlParser($this->getUrl());
+    public function match(CM_Http_Request_Abstract $request, array $data) {
         $hostList = [
-            $url->getHost(),
+            $this->getHost(),
             preg_replace('/^www\./', '', $this->getHost()),
         ];
 

--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -46,6 +46,8 @@ return function (CM_Config_Node $config) {
 
     $config->CM_Model_Currency->default = ['code' => '840', 'abbreviation' => 'USD'];
 
+    $config->CM_Http_Response_Abstract->defaultResponse = 'CM_Http_Response_Page';
+
     $config->CM_Http_Response_Page->exceptionsToCatch = array(
         'CM_Exception_Nonexistent'  => ['errorPage' => 'CM_Page_Error_NotFound', 'log' => true, 'level' => CM_Log_Logger::INFO],
         'CM_Exception_InvalidParam' => ['errorPage' => 'CM_Page_Error_NotFound', 'log' => true, 'level' => CM_Log_Logger::INFO],

--- a/tests/helpers/CMTest/library/CMTest/TH.php
+++ b/tests/helpers/CMTest/library/CMTest/TH.php
@@ -220,18 +220,22 @@ class CMTest_TH {
     }
 
     /**
-     * @param string             $uri
-     * @param array|null         $headers
-     * @param CM_Model_User|null $viewer
+     * @param string                $uri
+     * @param array|null            $headers
+     * @param CM_Model_User|null    $viewer
+     * @param CM_Site_Abstract|null $site
      * @return CM_Http_Response_Page
+     * @throws CM_Class_Exception_TypeNotConfiguredException
      */
-    public static function createResponsePageEmbed($uri, array $headers = null, CM_Model_User $viewer = null) {
-        if (!$headers) {
+    public static function createResponsePageEmbed($uri, array $headers = null, CM_Model_User $viewer = null, CM_Site_Abstract $site = null) {
+        if (null === $site) {
             $site = CM_Site_Abstract::factory();
+        }
+        if (!$headers) {
             $headers = array('host' => $site->getHost());
         }
         $request = new CM_Http_Request_Get($uri, $headers, null, $viewer);
-        return new CM_Http_Response_Page_Embed($request, self::getServiceManager());
+        return new CM_Http_Response_Page_Embed($request, $site, self::getServiceManager());
     }
 
     /**

--- a/tests/library/CM/Layout/AbstractTest.php
+++ b/tests/library/CM/Layout/AbstractTest.php
@@ -3,7 +3,7 @@
 class CM_Layout_AbstractTest extends CMTest_TestCase {
 
     public function testTrackingDisabled() {
-        $site = $this->getMockSite('CM_Site_Abstract');
+        $site = $this->getMockSite('CM_Site_Abstract', null, ['url' => 'http://www.my-website.net']);
         $render = new CM_Frontend_Render(new CM_Frontend_Environment($site));
         $this->getMockForAbstractClass('CM_Layout_Abstract', array(), 'CM_Layout_Default');
         $pageMock = $this->getMockForAbstractClass('CM_Page_Abstract', array(), 'CM_Page_Mock' . uniqid());

--- a/tests/library/CM/Site/AbstractTest.php
+++ b/tests/library/CM/Site/AbstractTest.php
@@ -62,16 +62,16 @@ class CM_Site_AbstractTest extends CMTest_TestCase {
         /** @var CM_Site_Abstract $siteClassMatchXxx */
 
         $requestCom = new CM_Http_Request_Get('/', array('host' => 'www.example.com'));
-        $this->assertTrue($siteClassMatchCom->match($requestCom));
+        $this->assertTrue($siteClassMatchCom->match($requestCom, []));
 
         $requestXxx = new CM_Http_Request_Get('/', array('host' => 'www.example.xxx'));
-        $this->assertTrue($siteClassMatchXxx->match($requestXxx));
+        $this->assertTrue($siteClassMatchXxx->match($requestXxx, []));
 
         $requestNot = new CM_Http_Request_Get('/', array('host' => 'www.example.foo'));
-        $this->assertFalse($siteClassMatchXxx->match($requestNot));
+        $this->assertFalse($siteClassMatchXxx->match($requestNot, []));
 
         $requestNotPartial = new CM_Http_Request_Get('/', array('host' => 'www.example.xxx.com'));
-        $this->assertFalse($siteClassMatchXxx->match($requestNotPartial));
+        $this->assertFalse($siteClassMatchXxx->match($requestNotPartial, []));
     }
 
     public function testMatchCdn() {
@@ -83,8 +83,8 @@ class CM_Site_AbstractTest extends CMTest_TestCase {
         $siteClass->expects($this->any())->method('getUrlCdn')->will($this->returnValue('http://cdn.example.com'));
         /** @var CM_Site_Abstract $siteClass */
 
-        $this->assertTrue($siteClass->match(new CM_Http_Request_Get('/', array('host' => 'cdn.example.com'))));
-        $this->assertFalse($siteClass->match(new CM_Http_Request_Get('/', array('host' => 'www.google.com'))));
+        $this->assertTrue($siteClass->match(new CM_Http_Request_Get('/', array('host' => 'cdn.example.com')), []));
+        $this->assertFalse($siteClass->match(new CM_Http_Request_Get('/', array('host' => 'www.google.com')), []));
     }
 
     public function testFactory() {


### PR DESCRIPTION
This changeset allows a site's URL to contain a *pathname*.
E.g. `http://www.denkmal.org/basel` Instead of just `http://www.denkmal.org`

Notes:
- History values in the browser contain the *full* fragment (e.g. `/basel/page1?foo=bar`)
- The value sent to `ajax_loadPage()` starts where the siteUrl ends (e.g. `/page1?foo=bar`)
- Any non-page requests (like CSS, JS etc) still go to the *root* of the URL (e.g `/vendor-css/en/…`)

Breaking: Signature of `Site::match()` changed.