### PR TITLE
Configure trackings per site

### DIFF
--- a/library/CM/Class/Abstract.php
+++ b/library/CM/Class/Abstract.php
@@ -22,6 +22,13 @@ abstract class CM_Class_Abstract {
     }
 
     /**
+     * @return string[] List of class names
+     */
+    public static function getClassHierarchyStatic() {
+        return self::_getClassHierarchy();
+    }
+    
+    /**
      * @param int $type
      * @return string
      * @throws CM_Class_Exception_TypeNotConfiguredException

--- a/library/CM/Http/Response/View/Abstract.php
+++ b/library/CM/Http/Response/View/Abstract.php
@@ -108,10 +108,11 @@ abstract class CM_Http_Response_View_Abstract extends CM_Http_Response_Abstract 
         $frontend->clear();
 
         $title = $responseEmbed->getTitle();
-        $layoutClass = get_class($page->getLayout($this->getRender()->getEnvironment()));
+        $environment = $this->getRender()->getEnvironment();
+        $layoutClass = get_class($page->getLayout($environment));
         $menuList = array_merge($this->getSite()->getMenus(), $responseEmbed->getRender()->getMenuList());
         $menuEntryHashList = $this->_getMenuEntryHashList($menuList, get_class($page), $page->getParams());
-        $jsTracking = $responseEmbed->getRender()->getServiceManager()->getTrackings()->getJs();
+        $jsTracking = $responseEmbed->getRender()->getServiceManager()->getTrackings()->getJs($environment);
 
         return array(
             'autoId'            => $autoId,

--- a/library/CM/Service/Tracking/ClientInterface.php
+++ b/library/CM/Service/Tracking/ClientInterface.php
@@ -9,20 +9,23 @@ interface CM_Service_Tracking_ClientInterface {
     public function getHtml(CM_Frontend_Environment $environment);
 
     /**
+     * @param CM_Frontend_Environment $environment
      * @return string
      */
-    public function getJs();
+    public function getJs(CM_Frontend_Environment $environment);
 
     /**
-     * @param CM_Action_Abstract $action
+     * @param CM_Frontend_Environment $environment
+     * @param CM_Action_Abstract      $action
      */
-    public function trackAction(CM_Action_Abstract $action);
+    public function trackAction(CM_Frontend_Environment $environment, CM_Action_Abstract $action);
 
     /**
-     * @param int    $requestClientId
-     * @param string $affiliateName
+     * @param CM_Frontend_Environment $environment
+     * @param int                     $requestClientId
+     * @param string                  $affiliateName
      */
-    public function trackAffiliate($requestClientId, $affiliateName);
+    public function trackAffiliate(CM_Frontend_Environment $environment, $requestClientId, $affiliateName);
 
     /**
      * @param CM_Frontend_Environment $environment
@@ -31,8 +34,9 @@ interface CM_Service_Tracking_ClientInterface {
     public function trackPageView(CM_Frontend_Environment $environment, $path);
 
     /**
+     * @param CM_Frontend_Environment     $environment
      * @param CM_Splittest_Fixture        $fixture
      * @param CM_Model_SplittestVariation $variation
      */
-    public function trackSplittest(CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation);
+    public function trackSplittest(CM_Frontend_Environment $environment, CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation);
 }

--- a/library/CM/Service/Trackings.php
+++ b/library/CM/Service/Trackings.php
@@ -9,6 +9,7 @@ class CM_Service_Trackings extends CM_Service_ManagerAware implements CM_Service
      * @param array $siteToTrackingsMap
      */
     public function __construct(array $siteToTrackingsMap) {
+        $this->_validateConfig($siteToTrackingsMap);
         $this->_siteToTrackingsMap = $siteToTrackingsMap;
     }
 
@@ -66,7 +67,7 @@ class CM_Service_Trackings extends CM_Service_ManagerAware implements CM_Service
      */
     public function getTrackingServiceList($siteClassName = null) {
         $siteClassName = null !== $siteClassName ? (string) $siteClassName : 'CM_Site_Abstract';
-        if (!is_a($siteClassName, 'CM_Site_Abstract', true)) {
+        if (!$this->_isSiteClass($siteClassName)) {
             throw new CM_Exception_Invalid('`' . $siteClassName . '` is not a child of CM_Site_Abstract');
         }
         $trackingServiceList = $this->_getTrackingServiceNameList($siteClassName);
@@ -97,5 +98,28 @@ class CM_Service_Trackings extends CM_Service_ManagerAware implements CM_Service
             }
         }
         return array_unique(array_values($trackingServiceList));
+    }
+
+    /**
+     * @param array $siteToTrackingsMap
+     * @throws CM_Exception_Invalid
+     */
+    private function _validateConfig(array $siteToTrackingsMap) {
+        foreach ($siteToTrackingsMap as $siteClassName => $trackingList) {
+            if (!$this->_isSiteClass($siteClassName)) {
+                throw new CM_Exception_Invalid('`' . $siteClassName . '` is not a child of CM_Site_Abstract');
+            }
+            if (!is_array($trackingList)) {
+                throw new CM_Exception_Invalid('Invalid tracking service list for site `' . $siteClassName . '`');
+            }
+        }
+    }
+
+    /**
+     * @param string $siteClassName
+     * @return bool
+     */
+    private function _isSiteClass($siteClassName) {
+        return is_a((string) $siteClassName, 'CM_Site_Abstract', true);
     }
 }

--- a/library/CM/Service/Trackings.php
+++ b/library/CM/Service/Trackings.php
@@ -21,7 +21,7 @@ class CM_Service_Trackings extends CM_Service_ManagerAware implements CM_Service
 
     public function getHtml(CM_Frontend_Environment $environment) {
         $html = '';
-        foreach ($this->getTrackingServiceList($environment->getSite()->getName()) as $trackingService) {
+        foreach ($this->getTrackingServiceList(get_class($environment->getSite())) as $trackingService) {
             $html .= $trackingService->getHtml($environment);
         }
         return $html;
@@ -29,32 +29,32 @@ class CM_Service_Trackings extends CM_Service_ManagerAware implements CM_Service
 
     public function getJs(CM_Frontend_Environment $environment) {
         $js = '';
-        foreach ($this->getTrackingServiceList($environment->getSite()->getName()) as $trackingService) {
+        foreach ($this->getTrackingServiceList(get_class($environment->getSite())) as $trackingService) {
             $js .= $trackingService->getJs($environment);
         }
         return $js;
     }
 
     public function trackAction(CM_Frontend_Environment $environment, CM_Action_Abstract $action) {
-        foreach ($this->getTrackingServiceList($environment->getSite()->getName()) as $trackingService) {
+        foreach ($this->getTrackingServiceList(get_class($environment->getSite())) as $trackingService) {
             $trackingService->trackAction($environment, $action);
         }
     }
 
     public function trackAffiliate(CM_Frontend_Environment $environment, $requestClientId, $affiliateName) {
-        foreach ($this->getTrackingServiceList($environment->getSite()->getName()) as $trackingService) {
+        foreach ($this->getTrackingServiceList(get_class($environment->getSite())) as $trackingService) {
             $trackingService->trackAffiliate($environment, $requestClientId, $affiliateName);
         }
     }
 
     public function trackPageView(CM_Frontend_Environment $environment, $path) {
-        foreach ($this->getTrackingServiceList($environment->getSite()->getName()) as $trackingService) {
+        foreach ($this->getTrackingServiceList(get_class($environment->getSite())) as $trackingService) {
             $trackingService->trackPageView($environment, $path);
         }
     }
 
     public function trackSplittest(CM_Frontend_Environment $environment, CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation) {
-        foreach ($this->getTrackingServiceList($environment->getSite()->getName()) as $trackingService) {
+        foreach ($this->getTrackingServiceList(get_class($environment->getSite())) as $trackingService) {
             $trackingService->trackSplittest($environment, $fixture, $variation);
         }
     }

--- a/library/CM/Service/Trackings.php
+++ b/library/CM/Service/Trackings.php
@@ -2,62 +2,100 @@
 
 class CM_Service_Trackings extends CM_Service_ManagerAware implements CM_Service_Tracking_ClientInterface {
 
-    /** @var string[] */
-    protected $_trackingServiceNameList;
+    /** @var array */
+    protected $_siteToTrackingsMap;
 
     /**
-     * @param string[] $trackingServiceNameList
+     * @param array $siteToTrackingsMap
      */
-    public function __construct(array $trackingServiceNameList) {
-        $this->_trackingServiceNameList = $trackingServiceNameList;
+    public function __construct(array $siteToTrackingsMap) {
+        $this->_siteToTrackingsMap = $siteToTrackingsMap;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSiteToTrackingsMap() {
+        return $this->_siteToTrackingsMap;
     }
 
     public function getHtml(CM_Frontend_Environment $environment) {
         $html = '';
-        foreach ($this->getTrackingServiceList() as $trackingService) {
+        foreach ($this->getTrackingServiceList($environment->getSite()->getName()) as $trackingService) {
             $html .= $trackingService->getHtml($environment);
         }
         return $html;
     }
 
-    public function getJs() {
+    public function getJs(CM_Frontend_Environment $environment) {
         $js = '';
-        foreach ($this->getTrackingServiceList() as $trackingService) {
-            $js .= $trackingService->getJs();
+        foreach ($this->getTrackingServiceList($environment->getSite()->getName()) as $trackingService) {
+            $js .= $trackingService->getJs($environment);
         }
         return $js;
     }
 
-    public function trackAction(CM_Action_Abstract $action) {
-        foreach ($this->getTrackingServiceList() as $trackingService) {
-            $trackingService->trackAction($action);
+    public function trackAction(CM_Frontend_Environment $environment, CM_Action_Abstract $action) {
+        foreach ($this->getTrackingServiceList($environment->getSite()->getName()) as $trackingService) {
+            $trackingService->trackAction($environment, $action);
         }
     }
 
-    public function trackAffiliate($requestClientId, $affiliateName) {
-        foreach ($this->getTrackingServiceList() as $trackingService) {
-            $trackingService->trackAffiliate($requestClientId, $affiliateName);
+    public function trackAffiliate(CM_Frontend_Environment $environment, $requestClientId, $affiliateName) {
+        foreach ($this->getTrackingServiceList($environment->getSite()->getName()) as $trackingService) {
+            $trackingService->trackAffiliate($environment, $requestClientId, $affiliateName);
         }
     }
 
     public function trackPageView(CM_Frontend_Environment $environment, $path) {
-        foreach ($this->getTrackingServiceList() as $trackingService) {
+        foreach ($this->getTrackingServiceList($environment->getSite()->getName()) as $trackingService) {
             $trackingService->trackPageView($environment, $path);
         }
     }
 
-    public function trackSplittest(CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation) {
-        foreach ($this->getTrackingServiceList() as $trackingService) {
-            $trackingService->trackSplittest($fixture, $variation);
+    public function trackSplittest(CM_Frontend_Environment $environment, CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation) {
+        foreach ($this->getTrackingServiceList($environment->getSite()->getName()) as $trackingService) {
+            $trackingService->trackSplittest($environment, $fixture, $variation);
         }
     }
 
     /**
+     * @param string|null $siteClassName
      * @return CM_Service_Tracking_ClientInterface[]
+     * @throws CM_Exception_Invalid
      */
-    public function getTrackingServiceList() {
+    public function getTrackingServiceList($siteClassName = null) {
+        $siteClassName = null !== $siteClassName ? (string) $siteClassName : 'CM_Site_Abstract';
+        if (!is_a($siteClassName, 'CM_Site_Abstract', true)) {
+            throw new CM_Exception_Invalid('`' . $siteClassName . '` is not a child of CM_Site_Abstract');
+        }
+        $trackingServiceList = $this->_getTrackingServiceNameList($siteClassName);
+
         return array_map(function ($trackingServiceName) {
             return $this->getServiceManager()->get($trackingServiceName, 'CM_Service_Tracking_ClientInterface');
-        }, $this->_trackingServiceNameList);
+        }, $trackingServiceList);
+    }
+
+    /**
+     * @param string $siteClassName
+     * @return string[]
+     */
+    private function _getTrackingServiceNameList($siteClassName) {
+        /** @type CM_Site_Abstract $siteClassName */
+        $siteToTrackingsMap = $this->getSiteToTrackingsMap();
+        $childSideClassNameList = array_reverse($siteClassName::getClassHierarchyStatic());
+        $trackingServiceList = [];
+        foreach ($childSideClassNameList as $childSideClassName) {
+            if (array_key_exists($childSideClassName, $siteToTrackingsMap)) {
+                foreach ($siteToTrackingsMap[$childSideClassName] as $key => $serviceName) {
+                    if (is_numeric($key)) { //key was not defined
+                        $trackingServiceList[] = $serviceName;
+                    } else {
+                        $trackingServiceList[$key] = $serviceName;
+                    }
+                }
+            }
+        }
+        return array_unique(array_values($trackingServiceList));
     }
 }

--- a/library/CMService/Adagnit/Client.php
+++ b/library/CMService/Adagnit/Client.php
@@ -52,10 +52,7 @@ class CMService_Adagnit_Client implements CM_Service_Tracking_ClientInterface {
         $this->_pageViewList = [$path];
     }
 
-    /**
-     * @return string
-     */
-    public function getJs() {
+    public function getJs(CM_Frontend_Environment $environment) {
         $js = '';
         foreach ($this->_pageViewList as $pageView) {
             $url = CM_Params::jsonEncode($pageView);
@@ -74,7 +71,7 @@ class CMService_Adagnit_Client implements CM_Service_Tracking_ClientInterface {
     }
 
     public function getHtml(CM_Frontend_Environment $environment) {
-        $js = $this->getJs();
+        $js = $this->getJs($environment);
         $html = <<<EOD
 <script type="text/javascript" src="https://via.adagnit.io/static/view/js/ada.js"></script>
 <script type="text/javascript">{$js}</script>
@@ -82,10 +79,10 @@ EOD;
         return $html;
     }
 
-    public function trackAction(CM_Action_Abstract $action) {
+    public function trackAction(CM_Frontend_Environment $environment, CM_Action_Abstract $action) {
     }
 
-    public function trackAffiliate($requestClientId, $affiliateName) {
+    public function trackAffiliate(CM_Frontend_Environment $environment, $requestClientId, $affiliateName) {
     }
 
     public function trackPageView(CM_Frontend_Environment $environment, $path = null) {
@@ -122,7 +119,7 @@ EOD;
         }
     }
 
-    public function trackSplittest(CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation) {
+    public function trackSplittest(CM_Frontend_Environment $environment, CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation) {
     }
 
     /**

--- a/library/CMService/GoogleAnalytics/Client.php
+++ b/library/CMService/GoogleAnalytics/Client.php
@@ -104,10 +104,7 @@ class CMService_GoogleAnalytics_Client implements CM_Service_Tracking_ClientInte
         $this->_setField('userId', $userId);
     }
 
-    /**
-     * @return string
-     */
-    public function getJs() {
+    public function getJs(CM_Frontend_Environment $environment) {
         $js = '';
         foreach ($this->_fieldList as $fieldName => $fieldValue) {
             $js .= 'ga("set", ' . CM_Params::jsonEncode($fieldName) . ', ' . CM_Params::jsonEncode($fieldValue) . ');';
@@ -173,16 +170,16 @@ EOF;
         }
 
         $html .= 'ga("create", ' . CM_Params::jsonEncode($this->_getCode()) . ', ' . CM_Params::jsonEncode(array_filter($fieldList)) . ');';
-        $html .= $this->getJs();
+        $html .= $this->getJs($environment);
         $html .= '</script>';
 
         return $html;
     }
 
-    public function trackAction(CM_Action_Abstract $action) {
+    public function trackAction(CM_Frontend_Environment $environment, CM_Action_Abstract $action) {
     }
 
-    public function trackAffiliate($requestClientId, $affiliateName) {
+    public function trackAffiliate(CM_Frontend_Environment $environment, $requestClientId, $affiliateName) {
     }
 
     public function trackPageView(CM_Frontend_Environment $environment, $path = null) {
@@ -193,7 +190,7 @@ EOF;
         }
     }
 
-    public function trackSplittest(CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation) {
+    public function trackSplittest(CM_Frontend_Environment $environment, CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation) {
     }
 
     /**

--- a/library/CMService/Inspectlet/Client.php
+++ b/library/CMService/Inspectlet/Client.php
@@ -29,15 +29,12 @@ EOF;
         if ($user = $environment->getViewer()) {
             $this->_setUser($user);
         }
-        $html .= $this->getJs();
+        $html .= $this->getJs($environment);
         $html .= '</script>';
         return $html;
     }
 
-    /**
-     * @return string
-     */
-    public function getJs() {
+    public function getJs(CM_Frontend_Environment $environment) {
         $js = '';
         if (isset($this->_identity)) {
             $js .= "__insp.push(['identify', '{$this->_identity}']);";
@@ -45,10 +42,10 @@ EOF;
         return $js;
     }
 
-    public function trackAction(CM_Action_Abstract $action) {
+    public function trackAction(CM_Frontend_Environment $environment, CM_Action_Abstract $action) {
     }
 
-    public function trackAffiliate($requestClientId, $affiliateName) {
+    public function trackAffiliate(CM_Frontend_Environment $environment, $requestClientId, $affiliateName) {
     }
 
     public function trackPageView(CM_Frontend_Environment $environment, $path) {
@@ -57,7 +54,7 @@ EOF;
         }
     }
 
-    public function trackSplittest(CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation) {
+    public function trackSplittest(CM_Frontend_Environment $environment, CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation) {
     }
 
     /**

--- a/library/CMService/KissMetrics/Client.php
+++ b/library/CMService/KissMetrics/Client.php
@@ -32,15 +32,12 @@ function _kms(u) {
 _kms('//i.kissmetrics.com/i.js');
 _kms('//doug1izaerwt3.cloudfront.net/' + _kmk + '.1.js');
 EOF;
-        $html .= $this->getJs();
+        $html .= $this->getJs($environment);
         $html .= '</script>';
         return $html;
     }
 
-    /**
-     * @return string
-     */
-    public function getJs() {
+    public function getJs(CM_Frontend_Environment $environment) {
         $js = '';
         $identityList = $this->_getIdentityList();
         foreach ($identityList as $identity) {
@@ -81,10 +78,7 @@ EOF;
         $this->_addIdentity($userId);
     }
 
-    /**
-     * @param CM_Action_Abstract $action
-     */
-    public function trackAction(CM_Action_Abstract $action) {
+    public function trackAction(CM_Frontend_Environment $environment, CM_Action_Abstract $action) {
         if (0 === count($this->_getIdentityList()) && $actor = $action->getActor()) {
             $this->setUserId($actor->getId());
         }
@@ -97,7 +91,7 @@ EOF;
         ));
     }
 
-    public function trackAffiliate($requestClientId, $affiliateName) {
+    public function trackAffiliate(CM_Frontend_Environment $environment, $requestClientId, $affiliateName) {
         $this->setRequestClientId($requestClientId);
         $trackEventJob = new CMService_KissMetrics_TrackPropertyListJob();
         $trackEventJob->queue([
@@ -154,7 +148,7 @@ EOF;
         $kissMetrics->submit();
     }
 
-    public function trackSplittest(CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation) {
+    public function trackSplittest(CM_Frontend_Environment $environment, CM_Splittest_Fixture $fixture, CM_Model_SplittestVariation $variation) {
         $nameSplittest = $variation->getSplittest()->getName();
         $nameVariation = $variation->getName();
         switch ($fixture->getFixtureType()) {

--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -162,12 +162,15 @@ return function (CM_Config_Node $config) {
         ),
     );
 
-    $config->services['trackings'] = array(
+    $config->services['trackings'] = [
         'class'     => 'CM_Service_Trackings',
-        'arguments' => array(
-            'trackingServiceNameList' => array(),
-        ),
-    );
+        'arguments' => [
+            'siteToTrackingsMap' => [
+                'CM_Site_Abstract' => [
+                ],
+            ],
+        ],
+    ];
 
     $config->services['tracking-adagnit'] = [
         'class'     => 'CMService_Adagnit_Client',

--- a/tests/library/CM/Http/Response/PageTest.php
+++ b/tests/library/CM/Http/Response/PageTest.php
@@ -56,7 +56,7 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
 
         $response = CMTest_TH::createResponsePage('/mock5', array('host' => $site->getHost()));
         $response->process();
-        $this->assertFalse(Functional\some($response->getHeaders(), function($header) {
+        $this->assertFalse(Functional\some($response->getHeaders(), function ($header) {
             return preg_match('/^Location:/', $header);
         }));
 
@@ -200,7 +200,12 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $serviceManager = new CM_Service_Manager();
         $serviceManager->registerInstance('googleanalytics', new CMService_GoogleAnalytics_Client($codeGoogleAnalytics));
         $serviceManager->registerInstance('kissmetrics', new CMService_KissMetrics_Client($codeKissMetrics));
-        $serviceManager->registerInstance('trackings', new CM_Service_Trackings(['googleanalytics', 'kissmetrics']));
+        $serviceManager->registerInstance('trackings', new CM_Service_Trackings([
+            'CM_Site_Abstract' => [
+                'googleanalytics',
+                'kissmetrics',
+            ]
+        ]));
         return $serviceManager;
     }
 }

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -198,7 +198,11 @@ EOL;
     private function _getServiceManagerWithGA($code) {
         $serviceManager = new CM_Service_Manager();
         $serviceManager->registerInstance('googleanalytics', new CMService_GoogleAnalytics_Client($code));
-        $serviceManager->registerInstance('trackings', new CM_Service_Trackings(['googleanalytics']));
+        $serviceManager->registerInstance('trackings', new CM_Service_Trackings([
+            'CM_Site_Abstract' => [
+                'googleanalytics',
+            ]
+        ]));
         $serviceManager->registerInstance('logger', $this->getServiceManager()->getLogger());
         $serviceManager->registerInstance('newrelic', $this->getServiceManager()->getNewrelic());
 

--- a/tests/library/CM/Layout/AbstractTest.php
+++ b/tests/library/CM/Layout/AbstractTest.php
@@ -83,7 +83,12 @@ class CM_Layout_AbstractTest extends CMTest_TestCase {
         $serviceManager = new CM_Service_Manager();
         $serviceManager->registerInstance('googleanalytics', new CMService_GoogleAnalytics_Client($codeGoogleAnalytics));
         $serviceManager->registerInstance('kissmetrics', new CMService_KissMetrics_Client($codeKissMetrics));
-        $serviceManager->registerInstance('trackings', new CM_Service_Trackings(['googleanalytics', 'kissmetrics']));
+        $serviceManager->registerInstance('trackings', new CM_Service_Trackings([
+            'CM_Site_Abstract' => [
+                'googleanalytics',
+                'kissmetrics'
+            ]
+        ]));
         return $serviceManager;
     }
 }

--- a/tests/library/CM/Service/Trackings.php
+++ b/tests/library/CM/Service/Trackings.php
@@ -1,0 +1,82 @@
+<?php
+
+class CM_Service_TrackingsTest extends CMTest_TestCase {
+
+    public function testConstructor() {
+        $siteToTrackingsMap = [
+            'CM_Site_Abstract' => [
+                'foo',
+                'bar' => 'baz'
+            ],
+        ];
+        $serviceTrackings = new CM_Service_Trackings($siteToTrackingsMap);
+        $this->assertSame($siteToTrackingsMap, $serviceTrackings->getSiteToTrackingsMap());
+    }
+
+    public function testGetTrackingServiceNameList() {
+        $siteMockClass = $this->mockClass('CM_Site_Abstract');
+        $siteMockClass->mockStaticMethod('getClassHierarchyStatic')->set([
+            'CM_Site_Mock',
+            'CM_Site_GrandMock',
+            'CM_Site_Abstract',
+        ]);
+        $siteMock = $siteMockClass->newInstanceWithoutConstructor();
+
+        $siteGrandMockClass = $this->mockClass('CM_Site_Abstract');
+        $siteGrandMockClass->mockStaticMethod('getClassHierarchyStatic')->set([
+            'CM_Site_GrandMock',
+            'CM_Site_Abstract',
+        ]);
+        $siteGrandMockClass = $siteGrandMockClass->newInstanceWithoutConstructor();
+
+        $serviceTracking = new CM_Service_Trackings([
+            'CM_Site_Abstract'  => [
+                'foo',
+                'b' => 'bar',
+                'baz',
+            ],
+            'CM_Site_GrandMock' => [
+                'b' => 'bar2',
+            ],
+            'CM_Site_Mock'      => [
+                'bb' => 'barBaz',
+                'foo',
+            ]
+        ]);
+
+        $serviceNamesList = $this->callProtectedMethod($serviceTracking, '_getTrackingServiceNameList', [get_class($siteMock)]);
+        $this->assertSame([
+            'foo',
+            'bar2',
+            'baz',
+            'barBaz',
+        ], $serviceNamesList);
+
+        $serviceNamesList = $this->callProtectedMethod($serviceTracking, '_getTrackingServiceNameList', [get_class($siteGrandMockClass)]);
+        $this->assertSame([
+            'foo',
+            'bar2',
+            'baz',
+        ], $serviceNamesList);
+
+        $serviceNamesList = $this->callProtectedMethod($serviceTracking, '_getTrackingServiceNameList', ['CM_Site_Abstract']);
+        $this->assertSame([
+            'foo',
+            'bar',
+            'baz',
+        ], $serviceNamesList);
+    }
+
+    public function testGetTrackingServiceList() {
+        $serviceTrackings = new CM_Service_Trackings(['foo' => 'bar']);
+        $exception = $this->catchException(function () use ($serviceTrackings) {
+            $serviceTrackings->getTrackingServiceList('Foo');
+        });
+        
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertSame('`Foo` is not a child of CM_Site_Abstract', $exception->getMessage());
+    }
+}
+
+
+

--- a/tests/library/CM/Service/TrackingsTest.php
+++ b/tests/library/CM/Service/TrackingsTest.php
@@ -72,11 +72,9 @@ class CM_Service_TrackingsTest extends CMTest_TestCase {
         $exception = $this->catchException(function () use ($serviceTrackings) {
             $serviceTrackings->getTrackingServiceList('Foo');
         });
-        
+
         $this->assertInstanceOf('CM_Exception_Invalid', $exception);
         $this->assertSame('`Foo` is not a child of CM_Site_Abstract', $exception->getMessage());
     }
 }
-
-
 

--- a/tests/library/CM/Service/TrackingsTest.php
+++ b/tests/library/CM/Service/TrackingsTest.php
@@ -11,6 +11,24 @@ class CM_Service_TrackingsTest extends CMTest_TestCase {
         ];
         $serviceTrackings = new CM_Service_Trackings($siteToTrackingsMap);
         $this->assertSame($siteToTrackingsMap, $serviceTrackings->getSiteToTrackingsMap());
+
+        $exception = $this->catchException(function () {
+            new CM_Service_Trackings([
+                'CM_Class_Abstract' => [
+                    'bar',
+                ]
+            ]);
+        });
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertSame('`CM_Class_Abstract` is not a child of CM_Site_Abstract', $exception->getMessage());
+
+        $exception = $this->catchException(function () {
+            new CM_Service_Trackings([
+                'CM_Site_Abstract' => 'baz'
+            ]);
+        });
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertSame('Invalid tracking service list for site `CM_Site_Abstract`', $exception->getMessage());
     }
 
     public function testGetTrackingServiceNameList() {
@@ -29,7 +47,8 @@ class CM_Service_TrackingsTest extends CMTest_TestCase {
         ]);
         $siteGrandMockClass = $siteGrandMockClass->newInstanceWithoutConstructor();
 
-        $serviceTracking = new CM_Service_Trackings([
+        $serviceTrackingClass = $this->mockClass('CM_Service_Trackings');
+        $serviceTrackingClass->mockMethod('getSiteToTrackingsMap')->set([
             'CM_Site_Abstract'  => [
                 'foo',
                 'b' => 'bar',
@@ -43,7 +62,7 @@ class CM_Service_TrackingsTest extends CMTest_TestCase {
                 'foo',
             ]
         ]);
-
+        $serviceTracking = $serviceTrackingClass->newInstanceWithoutConstructor();
         $serviceNamesList = $this->callProtectedMethod($serviceTracking, '_getTrackingServiceNameList', [get_class($siteMock)]);
         $this->assertSame([
             'foo',
@@ -68,7 +87,8 @@ class CM_Service_TrackingsTest extends CMTest_TestCase {
     }
 
     public function testGetTrackingServiceList() {
-        $serviceTrackings = new CM_Service_Trackings(['foo' => 'bar']);
+        /** @var CM_Service_Trackings|\Mocka\AbstractClassTrait $serviceTrackings */
+        $serviceTrackings = $this->mockClass('CM_Service_Trackings')->newInstanceWithoutConstructor();
         $exception = $this->catchException(function () use ($serviceTrackings) {
             $serviceTrackings->getTrackingServiceList('Foo');
         });


### PR DESCRIPTION
Allow to configure `tracking` service by site.

- Add $siteName to params of CM_Service_Tracking_ClientInterface methods
which doesn't accept `$environment` for now