### PR TITLE
Make CM_Params::encode() work with JsonSerializable

### DIFF
--- a/library/CM/Action/Abstract.php
+++ b/library/CM/Action/Abstract.php
@@ -192,7 +192,7 @@ abstract class CM_Action_Abstract extends CM_Class_Abstract implements CM_ArrayC
         $this->_prepare();
     }
 
-    public function toArrayIdOnly() {
+    public function toArray() {
         return array('actor' => $this->getActor(), 'verb' => $this->getVerb(), 'type' => $this->getType());
     }
 

--- a/library/CM/Action/Abstract.php
+++ b/library/CM/Action/Abstract.php
@@ -196,10 +196,6 @@ abstract class CM_Action_Abstract extends CM_Class_Abstract implements CM_ArrayC
         return array('actor' => $this->getActor(), 'verb' => $this->getVerb(), 'type' => $this->getType());
     }
 
-    public function toArray() {
-        return $this->toArrayIdOnly();
-    }
-
     /**
      * @return CM_Paging_ActionLimit_Action
      */

--- a/library/CM/ArrayConvertible.php
+++ b/library/CM/ArrayConvertible.php
@@ -7,13 +7,6 @@ interface CM_ArrayConvertible {
      *
      * @return array
      */
-    public function toArray();
-
-    /**
-     * Object representation as array
-     *
-     * @return array
-     */
     public function toArrayIdOnly();
 
     /**

--- a/library/CM/ArrayConvertible.php
+++ b/library/CM/ArrayConvertible.php
@@ -7,7 +7,7 @@ interface CM_ArrayConvertible {
      *
      * @return array
      */
-    public function toArrayIdOnly();
+    public function toArray();
 
     /**
      * Return object from array-representation

--- a/library/CM/FormField/Location.php
+++ b/library/CM/FormField/Location.php
@@ -13,15 +13,20 @@ class CM_FormField_Location extends CM_FormField_SuggestOne {
         parent::_initialize();
     }
 
+    /**
+     * @param CM_Model_Location  $location
+     * @param CM_Frontend_Render $render
+     * @return array list('id' => $id, 'name' => $name[, 'description' => $description, 'img' => $img, 'class' => string])
+     */
     public function getSuggestion($location, CM_Frontend_Render $render) {
         $names = array();
         for ($level = $location->getLevel(); $level >= CM_Model_Location::LEVEL_COUNTRY; $level--) {
             $names[] = $location->getName($level);
         }
         return array(
-            'id'    => $location->toArray(),
-            'name'  => implode(', ', array_filter($names)),
-            'img'   => $render->getUrlResource('layout',
+            'id'   => $location->toArrayIdOnly(),
+            'name' => implode(', ', array_filter($names)),
+            'img'  => $render->getUrlResource('layout',
                 'img/flags/' . strtolower($location->getAbbreviation(CM_Model_Location::LEVEL_COUNTRY)) . '.png'),
         );
     }

--- a/library/CM/FormField/Location.php
+++ b/library/CM/FormField/Location.php
@@ -24,7 +24,7 @@ class CM_FormField_Location extends CM_FormField_SuggestOne {
             $names[] = $location->getName($level);
         }
         return array(
-            'id'   => $location->toArrayIdOnly(),
+            'id'   => $location->toArray(),
             'name' => implode(', ', array_filter($names)),
             'img'  => $render->getUrlResource('layout',
                 'img/flags/' . strtolower($location->getAbbreviation(CM_Model_Location::LEVEL_COUNTRY)) . '.png'),

--- a/library/CM/Model/Abstract.php
+++ b/library/CM/Model/Abstract.php
@@ -693,16 +693,10 @@ abstract class CM_Model_Abstract extends CM_Class_Abstract
         return array('_type' => $this->getType(), '_id' => $this->getIdRaw());
     }
 
-    public function toArray() {
-        $array = $this->toArrayIdOnly();
-        if ($this->hasId()) {
-            $array['id'] = $this->getId();
-        }
-        return $array;
-    }
-
     public function jsonSerialize() {
-        return $this->toArray();
+        return [
+            'id' => $this->getId(),
+        ];
     }
 
     public static function fromArray(array $data) {

--- a/library/CM/Model/Abstract.php
+++ b/library/CM/Model/Abstract.php
@@ -689,7 +689,7 @@ abstract class CM_Model_Abstract extends CM_Class_Abstract
         return $resultList;
     }
 
-    public function toArrayIdOnly() {
+    public function toArray() {
         return array('_type' => $this->getType(), '_id' => $this->getIdRaw());
     }
 

--- a/library/CM/Model/Abstract.php
+++ b/library/CM/Model/Abstract.php
@@ -1,7 +1,7 @@
 <?php
 
 abstract class CM_Model_Abstract extends CM_Class_Abstract
-    implements CM_Comparable, CM_ArrayConvertible, CM_Cacheable, Serializable, CM_Typed, CM_Debug_DebugInfoInterface {
+    implements CM_Comparable, CM_ArrayConvertible, JsonSerializable, CM_Cacheable, Serializable, CM_Typed, CM_Debug_DebugInfoInterface {
 
     /** @var array|null */
     protected $_id;
@@ -699,6 +699,10 @@ abstract class CM_Model_Abstract extends CM_Class_Abstract
             $array['id'] = $this->getId();
         }
         return $array;
+    }
+
+    public function jsonSerialize() {
+        return $this->toArray();
     }
 
     public static function fromArray(array $data) {

--- a/library/CM/Model/Entity/Abstract.php
+++ b/library/CM/Model/Entity/Abstract.php
@@ -56,8 +56,8 @@ abstract class CM_Model_Entity_Abstract extends CM_Model_Abstract {
         return new $className($id);
     }
 
-    public function toArray() {
-        $array = parent::toArray();
+    public function jsonSerialize() {
+        $array = parent::jsonSerialize();
         $array['path'] = $this->getPath();
         return $array;
     }

--- a/library/CM/Model/Language.php
+++ b/library/CM/Model/Language.php
@@ -134,8 +134,8 @@ class CM_Model_Language extends CM_Model_Abstract {
         $this->getTranslations()->set($phrase, $value, $variables);
     }
 
-    public function toArray() {
-        $array = parent::toArray();
+    public function jsonSerialize() {
+        $array = parent::jsonSerialize();
         $array['abbreviation'] = $this->getAbbreviation();
         return $array;
     }

--- a/library/CM/Model/Location.php
+++ b/library/CM/Model/Location.php
@@ -298,10 +298,6 @@ class CM_Model_Location extends CM_Model_Abstract {
         return array('level' => $this->getLevel(), 'id' => $this->getId());
     }
 
-    public function toArray() {
-        return $this->toArrayIdOnly();
-    }
-
     public static function fromArray(array $data) {
         return new self($data['level'], $data['id']);
     }

--- a/library/CM/Model/Location.php
+++ b/library/CM/Model/Location.php
@@ -294,7 +294,7 @@ class CM_Model_Location extends CM_Model_Abstract {
         return null;
     }
 
-    public function toArrayIdOnly() {
+    public function toArray() {
         return array('level' => $this->getLevel(), 'id' => $this->getId());
     }
 

--- a/library/CM/Model/StreamChannel/Abstract.php
+++ b/library/CM/Model/StreamChannel/Abstract.php
@@ -131,8 +131,8 @@ abstract class CM_Model_StreamChannel_Abstract extends CM_Model_Abstract {
         return new CM_StreamChannel_Definition($this->getKey(), $this->getType(), $this->getAdapterType());
     }
 
-    public function toArray() {
-        $array = parent::toArray();
+    public function jsonSerialize() {
+        $array = parent::jsonSerialize();
         $array['key'] = $this->getKey();
         $array['type'] = $this->getType();
         return $array;

--- a/library/CM/Model/StreamChannel/Media.php
+++ b/library/CM/Model/StreamChannel/Media.php
@@ -55,8 +55,8 @@ class CM_Model_StreamChannel_Media extends CM_Model_StreamChannel_Abstract {
         return (int) $this->_get('serverId');
     }
 
-    public function toArray() {
-        $array = parent::toArray();
+    public function jsonSerialize() {
+        $array = parent::jsonSerialize();
         if ($this->hasStreamPublish()) {
             $array['user'] = $this->getStreamPublish()->getUser();
         }

--- a/library/CM/Model/User.php
+++ b/library/CM/Model/User.php
@@ -328,8 +328,8 @@ class CM_Model_User extends CM_Model_Abstract {
         CM_Db_Db::delete('cm_user', array('userId' => $this->getId()));
     }
 
-    public function toArray() {
-        $array = parent::toArray();
+    public function jsonSerialize() {
+        $array = parent::jsonSerialize();
         $array['displayName'] = $this->getDisplayName();
         $array['visible'] = $this->getVisible();
         return $array;

--- a/library/CM/Paging/ContentList/Abstract.php
+++ b/library/CM/Paging/ContentList/Abstract.php
@@ -66,10 +66,6 @@ abstract class CM_Paging_ContentList_Abstract extends CM_Paging_Abstract impleme
         return array('type' => static::getTypeStatic());
     }
 
-    public function toArray() {
-        return $this->toArrayIdOnly();
-    }
-
     /**
      * @param int $type
      * @return CM_Paging_ContentList_Abstract

--- a/library/CM/Paging/ContentList/Abstract.php
+++ b/library/CM/Paging/ContentList/Abstract.php
@@ -62,7 +62,7 @@ abstract class CM_Paging_ContentList_Abstract extends CM_Paging_Abstract impleme
         return false;
     }
 
-    public function toArrayIdOnly() {
+    public function toArray() {
         return array('type' => static::getTypeStatic());
     }
 

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -543,15 +543,24 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
             $value = array_map('self::encode', $value);
         }
         if ($value instanceof CM_ArrayConvertible) {
-            $array = $value->toArray();
-            $array = array_map('self::encode', $array);
-            $value = array_merge($array, array('_class' => get_class($value)));
+            $class = get_class($value);
+            $value = $value->toArray();
+            $value = array_map('self::encode', $value);
+            $value = array_merge($value, array('_class' => $class));
+        }
+        if ($value instanceof JsonSerializable) {
+            $class = get_class($value);
+            $value = $value->jsonSerialize();
+            if (is_array($value)) {
+                $value = array_map('self::encode', $value);
+                $value = array_merge($value, array('_class' => $class));
+            }
         }
         if ($json) {
             if (is_object($value)) {
                 $value = 'null';
             } else {
-                $value = self::jsonEncode($value);
+                $value = CM_Util::jsonEncode($value);
             }
         }
         return $value;
@@ -564,7 +573,7 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
     public static function encodeObjectId(CM_ArrayConvertible $object) {
         $array = $object->toArrayIdOnly();
         $value = array_merge($array, array('_class' => get_class($object)));
-        return self::jsonEncode($value);
+        return CM_Util::jsonEncode($value);
     }
 
     /**
@@ -575,7 +584,7 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
      */
     public static function decode($value, $json = null) {
         if ($json) {
-            $value = self::jsonDecode($value);
+            $value = CM_Util::jsonDecode($value);
         }
         if (is_array($value) && isset($value['_class'])) {
             // CM_ArrayConvertible

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -545,7 +545,7 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
             $class = get_class($value);
             $result = [];
             if ($value instanceof CM_ArrayConvertible) {
-                $array = $value->toArrayIdOnly();
+                $array = $value->toArray();
                 $array = array_merge($array, array('_class' => $class));
                 $result = array_merge($result, $array);
             }
@@ -574,7 +574,7 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
      * @return string JSON
      */
     public static function encodeObjectId(CM_ArrayConvertible $object) {
-        $array = $object->toArrayIdOnly();
+        $array = $object->toArray();
         $value = array_merge($array, array('_class' => get_class($object)));
         return CM_Util::jsonEncode($value);
     }

--- a/library/CM/Site/Abstract.php
+++ b/library/CM/Site/Abstract.php
@@ -157,10 +157,6 @@ abstract class CM_Site_Abstract extends CM_Class_Abstract implements CM_ArrayCon
         return array('type' => $this->getType());
     }
 
-    public function toArray() {
-        return $this->toArrayIdOnly();
-    }
-
     /**
      * @param string $theme
      * @return CM_Site_Abstract

--- a/library/CM/Site/Abstract.php
+++ b/library/CM/Site/Abstract.php
@@ -153,7 +153,7 @@ abstract class CM_Site_Abstract extends CM_Class_Abstract implements CM_ArrayCon
         }
     }
 
-    public function toArrayIdOnly() {
+    public function toArray() {
         return array('type' => $this->getType());
     }
 

--- a/library/CM/StreamChannel/Definition.php
+++ b/library/CM/StreamChannel/Definition.php
@@ -82,7 +82,7 @@ class CM_StreamChannel_Definition implements CM_ArrayConvertible, JsonSerializab
         ];
     }
 
-    public function toArrayIdOnly() {
+    public function toArray() {
         return $this->jsonSerialize();
     }
 

--- a/library/CM/StreamChannel/Definition.php
+++ b/library/CM/StreamChannel/Definition.php
@@ -1,6 +1,6 @@
 <?php
 
-class CM_StreamChannel_Definition implements CM_ArrayConvertible {
+class CM_StreamChannel_Definition implements CM_ArrayConvertible, JsonSerializable {
 
     /** @var string */
     private $_key;
@@ -74,7 +74,7 @@ class CM_StreamChannel_Definition implements CM_ArrayConvertible {
         return $channel;
     }
 
-    public function toArray() {
+    public function jsonSerialize() {
         return [
             'key'         => $this->getKey(),
             'type'        => $this->getType(),
@@ -83,7 +83,7 @@ class CM_StreamChannel_Definition implements CM_ArrayConvertible {
     }
 
     public function toArrayIdOnly() {
-        return $this->toArray();
+        return $this->jsonSerialize();
     }
 
     public static function fromArray(array $array) {

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -170,7 +170,7 @@ EOL;
 
         $expected = <<<EOL
 cm.window.appendHidden("<div id=\\"$newAutoId\\" class=\\"CM_Component_Mock CM_Component_Notfound CM_Component_Abstract CM_View_Abstract\\">Sorry, this page was not found. It has been removed or never existed.\\n<\/div>");
-cm.views["$newAutoId"] = new CM_Component_Mock({el:$("#$newAutoId").get(0),params:{"entity":{"_type":123,"_id":{"id":"1"},"id":1,"path":null,"_class":"CM_Model_Entity_Mock2"}}});
+cm.views["$newAutoId"] = new CM_Component_Mock({el:$("#$newAutoId").get(0),params:{"entity":{"_type":123,"_id":{"id":"1"},"_class":"CM_Model_Entity_Mock2","id":1,"path":null}}});
 cm.views["$oldAutoId"].getParent().registerChild(cm.views["$newAutoId"]);
 cm.views["$oldAutoId"].replaceWithHtml(cm.views["$newAutoId"].\$el);
 cm.views["$newAutoId"]._ready();

--- a/tests/library/CM/Model/Entity/AbstractTest.php
+++ b/tests/library/CM/Model/Entity/AbstractTest.php
@@ -65,17 +65,26 @@ class CM_Model_Entity_AbstractTest extends CMTest_TestCase {
         $this->assertFalse($entity->isOwner($stranger));
     }
 
-    public function testToArray() {
+    public function testArrayConvertible() {
         $user = CMTest_TH::createUser();
         $id = CM_Model_Entity_Mock::createStatic(array('userId' => $user->getId(), 'foo' => 'boo'));
         $mock = $this->getMockBuilder('CM_Model_Entity_Mock')->setConstructorArgs(array($id->getId()))->setMethods(array('getType'))->getMock();
         $mock->expects($this->any())->method('getType')->will($this->returnValue(null));
         /** @var $mock CM_Model_Entity_Abstract */
-        $data = $mock->toArray();
-        $this->assertArrayHasKey('path', $data);
-        $this->assertNull($data['path']);
+        $data = $mock->toArrayIdOnly();
         $this->assertArrayHasKey('_type', $data);
         $this->assertNull($data['_type']);
+    }
+
+    public function testJsonSerializable() {
+        $user = CMTest_TH::createUser();
+        $id = CM_Model_Entity_Mock::createStatic(array('userId' => $user->getId(), 'foo' => 'boo'));
+        $mock = $this->getMockBuilder('CM_Model_Entity_Mock')->setConstructorArgs(array($id->getId()))->setMethods(array('getType'))->getMock();
+        $mock->expects($this->any())->method('getType')->will($this->returnValue(null));
+        /** @var $mock CM_Model_Entity_Abstract */
+        $data = $mock->jsonSerialize();
+        $this->assertArrayHasKey('path', $data);
+        $this->assertNull($data['path']);
     }
 }
 

--- a/tests/library/CM/Model/Entity/AbstractTest.php
+++ b/tests/library/CM/Model/Entity/AbstractTest.php
@@ -71,7 +71,7 @@ class CM_Model_Entity_AbstractTest extends CMTest_TestCase {
         $mock = $this->getMockBuilder('CM_Model_Entity_Mock')->setConstructorArgs(array($id->getId()))->setMethods(array('getType'))->getMock();
         $mock->expects($this->any())->method('getType')->will($this->returnValue(null));
         /** @var $mock CM_Model_Entity_Abstract */
-        $data = $mock->toArrayIdOnly();
+        $data = $mock->toArray();
         $this->assertArrayHasKey('_type', $data);
         $this->assertNull($data['_type']);
     }

--- a/tests/library/CM/Model/LocationTest.php
+++ b/tests/library/CM/Model/LocationTest.php
@@ -370,7 +370,6 @@ class CM_Model_LocationTest extends CMTest_TestCase {
     public function testArrayConvertible() {
         $location = CMTest_TH::createLocation();
 
-        $this->assertEquals($location, CM_Model_Location::fromArray($location->toArray()));
         $this->assertEquals($location, CM_Model_Location::fromArray($location->toArrayIdOnly()));
     }
 }

--- a/tests/library/CM/Model/LocationTest.php
+++ b/tests/library/CM/Model/LocationTest.php
@@ -370,6 +370,6 @@ class CM_Model_LocationTest extends CMTest_TestCase {
     public function testArrayConvertible() {
         $location = CMTest_TH::createLocation();
 
-        $this->assertEquals($location, CM_Model_Location::fromArray($location->toArrayIdOnly()));
+        $this->assertEquals($location, CM_Model_Location::fromArray($location->toArray()));
     }
 }

--- a/tests/library/CM/ParamsTest.php
+++ b/tests/library/CM/ParamsTest.php
@@ -187,61 +187,78 @@ class CM_ParamsTest extends CMTest_TestCase {
     }
 
     public function testDecodeArrayConvertible() {
-        $arrayConvertibleClass = $this->mockInterface('CM_ArrayConvertible');
-        $fromArrayMethod = $arrayConvertibleClass->mockStaticMethod('fromArray')->set(function ($encoded) {
+        $object = $this->mockInterface('CM_ArrayConvertible');
+        $fromArrayMethod = $object->mockStaticMethod('fromArray')->set(function ($encoded) {
             $this->assertSame(['foo' => 1], $encoded);
             return $encoded['foo'];
         });
         $encodedArrayConvertible = [
             'foo'    => 1,
-            '_class' => get_class($arrayConvertibleClass->newInstance()),
+            '_class' => get_class($object->newInstance()),
         ];
         $this->assertEquals(1, CM_Params::decode($encodedArrayConvertible));
         $this->assertSame(1, $fromArrayMethod->getCallCount());
     }
 
     public function testEncodeArrayConvertible() {
-        $arrayConvertible = $this->mockInterface('CM_ArrayConvertible')->newInstance();
-        $toArrayMethod = $arrayConvertible->mockMethod('toArray')->set([
-            'foo' => 1
+        $object = $this->mockInterface('CM_ArrayConvertible')->newInstance();
+        $toArrayMethod = $object->mockMethod('toArrayIdOnly')->set([
+            'myId' => 1
         ]);
         $expectedEncoded = array(
-            'foo'    => 1,
-            '_class' => get_class($arrayConvertible),
+            'myId'   => 1,
+            '_class' => get_class($object),
         );
-        $this->assertEquals($expectedEncoded, CM_Params::encode($arrayConvertible));
-        $this->assertSame(1, $toArrayMethod->getCallCount());
-    }
-
-    public function testEncodeJsonSerializable() {
-        $jsonSerializable = $this->mockInterface('JsonSerializable')->newInstance();
-        $toArrayMethod = $jsonSerializable->mockMethod('jsonSerialize')->set([
-            'foo' => 1
-        ]);
-        $expectedEncoded = array(
-            'foo' => 1,
-            '_class' => get_class($jsonSerializable),
-        );
-        $this->assertEquals($expectedEncoded, CM_Params::encode($jsonSerializable));
+        $this->assertEquals($expectedEncoded, CM_Params::encode($object));
         $this->assertSame(1, $toArrayMethod->getCallCount());
     }
 
     public function testEncodeObjectId() {
-        /** @var CM_ArrayConvertible|\Mocka\ClassMock $arrayConvertible */
-        $arrayConvertible = $this->mockInterface('CM_ArrayConvertible')->newInstance();
-        $arrayConvertible->mockMethod('toArrayIdOnly')->set([
-            'id' => 3
+        /** @var CM_ArrayConvertible|\Mocka\AbstractClassTrait $object */
+        $object = $this->mockClass(null, ['CM_ArrayConvertible', 'JsonSerializable'])->newInstance();
+        $toArrayMethod = $object->mockMethod('toArrayIdOnly')->set([
+            'myId' => 1
         ]);
-        $arrayConvertible->mockMethod('toArray')->set([
-            'id'  => 3,
-            'foo' => 'bar',
+        $jsonSerializeMethod = $object->mockMethod('jsonSerialize')->set([
+            'myData' => 1
         ]);
+        $expectedEncoded = array(
+            'myId'   => 1,
+            '_class' => get_class($object),
+        );
+        $this->assertEquals(json_encode($expectedEncoded), CM_Params::encodeObjectId($object));
+        $this->assertSame(1, $toArrayMethod->getCallCount());
+        $this->assertSame(0, $jsonSerializeMethod->getCallCount());
+    }
 
-        $expectedEncoded = json_encode([
-            'id'     => 3,
-            '_class' => get_class($arrayConvertible),
+    public function testEncodeJsonSerializable() {
+        $object = $this->mockInterface('JsonSerializable')->newInstance();
+        $toArrayMethod = $object->mockMethod('jsonSerialize')->set([
+            'foo' => 1
         ]);
-        $this->assertEquals($expectedEncoded, CM_Params::encodeObjectId($arrayConvertible));
+        $expectedEncoded = array(
+            'foo'    => 1,
+        );
+        $this->assertEquals($expectedEncoded, CM_Params::encode($object));
+        $this->assertSame(1, $toArrayMethod->getCallCount());
+    }
+
+    public function testEncodeArrayConvertibleAndJsonSerializable() {
+        $object = $this->mockClass(null, ['CM_ArrayConvertible', 'JsonSerializable'])->newInstance();
+        $toArrayMethod = $object->mockMethod('toArrayIdOnly')->set([
+            'foo' => 1
+        ]);
+        $jsonSerializeMethod = $object->mockMethod('jsonSerialize')->set([
+            'bar' => 1
+        ]);
+        $expectedEncoded = array(
+            'foo'    => 1,
+            'bar'    => 1,
+            '_class' => get_class($object),
+        );
+        $this->assertEquals($expectedEncoded, CM_Params::encode($object));
+        $this->assertSame(1, $toArrayMethod->getCallCount());
+        $this->assertSame(1, $jsonSerializeMethod->getCallCount());
     }
 
     public function testGetDateTime() {

--- a/tests/library/CM/ParamsTest.php
+++ b/tests/library/CM/ParamsTest.php
@@ -202,7 +202,7 @@ class CM_ParamsTest extends CMTest_TestCase {
 
     public function testEncodeArrayConvertible() {
         $object = $this->mockInterface('CM_ArrayConvertible')->newInstance();
-        $toArrayMethod = $object->mockMethod('toArrayIdOnly')->set([
+        $toArrayMethod = $object->mockMethod('toArray')->set([
             'myId' => 1
         ]);
         $expectedEncoded = array(
@@ -216,7 +216,7 @@ class CM_ParamsTest extends CMTest_TestCase {
     public function testEncodeObjectId() {
         /** @var CM_ArrayConvertible|\Mocka\AbstractClassTrait $object */
         $object = $this->mockClass(null, ['CM_ArrayConvertible', 'JsonSerializable'])->newInstance();
-        $toArrayMethod = $object->mockMethod('toArrayIdOnly')->set([
+        $toArrayMethod = $object->mockMethod('toArray')->set([
             'myId' => 1
         ]);
         $jsonSerializeMethod = $object->mockMethod('jsonSerialize')->set([
@@ -237,7 +237,7 @@ class CM_ParamsTest extends CMTest_TestCase {
             'foo' => 1
         ]);
         $expectedEncoded = array(
-            'foo'    => 1,
+            'foo' => 1,
         );
         $this->assertEquals($expectedEncoded, CM_Params::encode($object));
         $this->assertSame(1, $toArrayMethod->getCallCount());
@@ -245,7 +245,7 @@ class CM_ParamsTest extends CMTest_TestCase {
 
     public function testEncodeArrayConvertibleAndJsonSerializable() {
         $object = $this->mockClass(null, ['CM_ArrayConvertible', 'JsonSerializable'])->newInstance();
-        $toArrayMethod = $object->mockMethod('toArrayIdOnly')->set([
+        $toArrayMethod = $object->mockMethod('toArray')->set([
             'foo' => 1
         ]);
         $jsonSerializeMethod = $object->mockMethod('jsonSerialize')->set([

--- a/tests/library/CM/ParamsTest.php
+++ b/tests/library/CM/ParamsTest.php
@@ -213,6 +213,19 @@ class CM_ParamsTest extends CMTest_TestCase {
         $this->assertSame(1, $toArrayMethod->getCallCount());
     }
 
+    public function testEncodeJsonSerializable() {
+        $jsonSerializable = $this->mockInterface('JsonSerializable')->newInstance();
+        $toArrayMethod = $jsonSerializable->mockMethod('jsonSerialize')->set([
+            'foo' => 1
+        ]);
+        $expectedEncoded = array(
+            'foo' => 1,
+            '_class' => get_class($jsonSerializable),
+        );
+        $this->assertEquals($expectedEncoded, CM_Params::encode($jsonSerializable));
+        $this->assertSame(1, $toArrayMethod->getCallCount());
+    }
+
     public function testEncodeObjectId() {
         /** @var CM_ArrayConvertible|\Mocka\ClassMock $arrayConvertible */
         $arrayConvertible = $this->mockInterface('CM_ArrayConvertible')->newInstance();

--- a/tests/library/CM/StreamChannel/DefinitionTest.php
+++ b/tests/library/CM/StreamChannel/DefinitionTest.php
@@ -62,10 +62,10 @@ class CM_StreamChannel_DefinitionTest extends CMTest_TestCase {
         $this->assertSame(null, $definition->findStreamChannel());
     }
 
-    public function testToFromArray() {
+    public function testArrayConvertible() {
         $definition = new CM_StreamChannel_Definition('foo', 12);
 
-        $array = $definition->toArray();
+        $array = $definition->toArrayIdOnly();
         $this->assertEquals(CM_StreamChannel_Definition::fromArray($array), $definition);
     }
 }

--- a/tests/library/CM/StreamChannel/DefinitionTest.php
+++ b/tests/library/CM/StreamChannel/DefinitionTest.php
@@ -65,7 +65,7 @@ class CM_StreamChannel_DefinitionTest extends CMTest_TestCase {
     public function testArrayConvertible() {
         $definition = new CM_StreamChannel_Definition('foo', 12);
 
-        $array = $definition->toArrayIdOnly();
+        $array = $definition->toArray();
         $this->assertEquals(CM_StreamChannel_Definition::fromArray($array), $definition);
     }
 }


### PR DESCRIPTION
- Remove `ArrayConvertible::toArray()` in favor of  `JsonSerializable::jsonSerialize()`
- Rename `ArrayConvertible::toArrayIdOnly()` to `toArray()`