### PR TITLE
In cm.factory.create, check the instance type instead of a cid property

### DIFF
--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -290,11 +290,8 @@ var CM_App = CM_Class_Abstract.extend({
     _isCmObject: function(data) {
       var className = data && data['_class'];
       var isClass = className && cm.model.types[className] && window[className];
-      if (isClass) {
-        var isBackbone = data instanceof Backbone.Model || data instanceof Backbone.Collection;
-        return !isBackbone;
-      }
-      return false;
+      var isBackbone = data instanceof Backbone.Model || data instanceof Backbone.Collection;
+      return isClass && !isBackbone;
     },
 
     /**

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -289,7 +289,12 @@ var CM_App = CM_Class_Abstract.extend({
      */
     _isCmObject: function(data) {
       var className = data && data['_class'];
-      return className && cm.model.types[className] && window[className] && !data.cid;
+      var isClass = className && cm.model.types[className] && window[className];
+      if (isClass) {
+        var isBackbone = data instanceof Backbone.Model || data instanceof Backbone.Collection;
+        return !isBackbone;
+      }
+      return false;
     },
 
     /**


### PR DESCRIPTION
In https://github.com/cargomedia/cm/blob/master/library/CM/App.js#L292, it's not so clear what is this `data.cid`. 
I think it would be better to explicitly check if `data` in not an instance of `Backbone.Model` or `Backbone.Collection`, wdyt @vogdb?