### PR TITLE
Allow any ArrayConvertible to be stored with model schema

### DIFF
--- a/tests/library/CM/Model/Schema/DefinitionTest.php
+++ b/tests/library/CM/Model/Schema/DefinitionTest.php
@@ -573,24 +573,26 @@ class CM_Model_Schema_DefinitionTest extends CMTest_TestCase {
 
     public function testEncodeArrayConvertible() {
         $class = $this->mockInterface('CM_ArrayConvertible');
+        $className = $class->getClassName();
         $arrayConvertible = $class->newInstanceWithoutConstructor();
         $toArray = ['key' => 'value'];
         $arrayConvertible->mockMethod('toArray')->set($toArray);
         $schema = new CM_Model_Schema_Definition([
-            'arrayConvertible' => ['type' => 'CM_ArrayConvertible']
+            'arrayConvertible' => ['type' => $className]
         ]);
         $value = $schema->encodeField('arrayConvertible', $arrayConvertible);
-        $this->assertSame('{"key":"value","_class":"' . get_class($arrayConvertible) . '"}', $value);
+        $this->assertSame('{"key":"value"}', $value);
     }
 
     public function testDecodeArrayConvertible() {
         $class = $this->mockInterface('CM_ArrayConvertible');
+        $className = $class->getClassName();
         $arrayConvertible = $class->newInstanceWithoutConstructor();
         $fromArray = $class->mockStaticMethod('fromArray')->set($arrayConvertible);
         $schema = new CM_Model_Schema_Definition([
-            'arrayConvertible' => ['type' => 'CM_ArrayConvertible']
+            'arrayConvertible' => ['type' => $className]
         ]);
-        $jsonData = CM_Params::jsonEncode(['_class' => $class->getClassName(), 'key' => 'value']);
+        $jsonData = '{"key":"value"}';
         $value = $schema->decodeField('arrayConvertible', $jsonData);
         
         $this->assertSame(['key' => 'value'], $fromArray->getLastCall()->getArgument(0));

--- a/tests/library/CM/Model/Schema/DefinitionTest.php
+++ b/tests/library/CM/Model/Schema/DefinitionTest.php
@@ -571,6 +571,32 @@ class CM_Model_Schema_DefinitionTest extends CMTest_TestCase {
         }
     }
 
+    public function testEncodeArrayConvertible() {
+        $class = $this->mockInterface('CM_ArrayConvertible');
+        $arrayConvertible = $class->newInstanceWithoutConstructor();
+        $toArray = ['key' => 'value'];
+        $arrayConvertible->mockMethod('toArray')->set($toArray);
+        $schema = new CM_Model_Schema_Definition([
+            'arrayConvertible' => ['type' => 'CM_ArrayConvertible']
+        ]);
+        $value = $schema->encodeField('arrayConvertible', $arrayConvertible);
+        $this->assertSame('{"key":"value","_class":"' . get_class($arrayConvertible) . '"}', $value);
+    }
+
+    public function testDecodeArrayConvertible() {
+        $class = $this->mockInterface('CM_ArrayConvertible');
+        $arrayConvertible = $class->newInstanceWithoutConstructor();
+        $fromArray = $class->mockStaticMethod('fromArray')->set($arrayConvertible);
+        $schema = new CM_Model_Schema_Definition([
+            'arrayConvertible' => ['type' => 'CM_ArrayConvertible']
+        ]);
+        $jsonData = CM_Params::jsonEncode(['_class' => $class->getClassName(), 'key' => 'value']);
+        $value = $schema->decodeField('arrayConvertible', $jsonData);
+        
+        $this->assertSame(['key' => 'value'], $fromArray->getLastCall()->getArgument(0));
+        $this->assertSame($arrayConvertible, $value);
+    }
+
     /**
      * @expectedException CM_Model_Exception_Validation
      * @expectedExceptionMessage Value `bar` is not an instance of `CM_Model_Mock_Validation2`

--- a/tests/library/CM/Model/Schema/DefinitionTest.php
+++ b/tests/library/CM/Model/Schema/DefinitionTest.php
@@ -608,7 +608,7 @@ class CM_Model_Schema_DefinitionTest extends CMTest_TestCase {
 
     /**
      * @expectedException CM_Model_Exception_Validation
-     * @expectedExceptionMessage Field `foo` is not a valid model
+     * @expectedExceptionMessage Value `bar` is not an instance of `CM_Class_Abstract`
      */
     public function testEncodeInvalidClass() {
         $schema = new CM_Model_Schema_Definition(array('foo' => array('type' => 'CM_Class_Abstract')));


### PR DESCRIPTION
How about we allow to store any instance of `CM_ArrayConvertible` in `CM_Model_Schema_Definition`, by json stringifying the array structure and storing it in the persistence layer?
We're doing something similar for models already.

@alexispeter @tomaszdurka wdyt?