### PR TITLE
Add an index on "cm_log.message"?

### DIFF
--- a/resources/db/mongo/collections.json
+++ b/resources/db/mongo/collections.json
@@ -26,6 +26,14 @@
       "options": {
         "name": "context_extra_type_1_level_1_createdAt_1"
       }
+    },
+    {
+      "key": {
+        "message": 1
+      },
+      "options": {
+        "name": "message_1"
+      }
     }
   ]
 }

--- a/resources/db/update/68.php
+++ b/resources/db/update/68.php
@@ -1,0 +1,7 @@
+<?php
+
+$mongo = CM_Service_Manager::getInstance()->getMongoDb();
+
+if (!$mongo->hasIndex('cm_log', ['message' => 1])) {
+    $mongo->createIndex('cm_log', ['message' => 1], ['background' => true]);
+}

--- a/resources/db/update/68.php
+++ b/resources/db/update/68.php
@@ -1,6 +1,5 @@
 <?php
 
-echo 'Please run CM script 68 manually' . PHP_EOL;
 return;
 
 $mongo = CM_Service_Manager::getInstance()->getMongoDb();

--- a/resources/db/update/68.php
+++ b/resources/db/update/68.php
@@ -1,5 +1,8 @@
 <?php
 
+echo 'Please run CM script 68 manually' . PHP_EOL;
+return;
+
 $mongo = CM_Service_Manager::getInstance()->getMongoDb();
 
 if (!$mongo->hasIndex('cm_log', ['message' => 1])) {


### PR DESCRIPTION
Via https://github.com/cargomedia/sk-analytics/issues/397

There should not be so many different values for `message`. In the long run we rather want to keep the message static, and move variable parts to other parts.

@fvovan @alexispeter wdyt?
cc @eillasti 