### PR TITLE
Replace SplEnum with own implementation

### DIFF
--- a/library/CM/Type/Enum.php
+++ b/library/CM/Type/Enum.php
@@ -1,0 +1,63 @@
+<?php
+
+abstract class CM_Type_Enum {
+
+    /** @var string */
+    private $_currentValue;
+
+    /** @var array */
+    protected static $_constantsCache = [];
+
+    /**
+     * @param string|null $value
+     * @throws CM_Exception_Invalid
+     */
+    public function __construct($value = null) {
+        if (null === $value) {
+            $defaultValue = (string) $this->_getDefaultValue();
+            if (!$this->_isValidValue($defaultValue)) {
+                throw new CM_Exception_Invalid('Invalid default value for enum class `' . get_class($this) . '`');
+            }
+            $this->_currentValue = $defaultValue;
+        } else {
+            $value = (string) $value;
+            if (!$this->_isValidValue($value)) {
+                throw new CM_Exception_Invalid('Invalid value `' . $value . '` for enum class `' . get_class($this) . '`');
+            }
+            $this->_currentValue = $value;
+        }
+    }
+
+    final public function __toString() {
+        return (string) $this->_currentValue;
+    }
+
+    /**
+     * @return string
+     * @throws CM_Exception_Invalid
+     */
+    protected function _getDefaultValue() {
+        throw new CM_Exception_Invalid('Default value in not defined for enum class `' . get_class($this) . '`');
+    }
+
+    /**
+     * @param string $value
+     * @return bool
+     */
+    protected function _isValidValue($value) {
+        $value = (string) $value;
+        return in_array($value, static::getConstantList(), true);
+    }
+
+    /**
+     * @return array
+     */
+    public static function getConstantList() {
+        $class = get_called_class();
+        if (!array_key_exists($class, static::$_constantsCache)) {
+            $reflection = new ReflectionClass($class);
+            static::$_constantsCache[$class] = $reflection->getConstants();
+        }
+        return static::$_constantsCache[$class];
+    }
+}

--- a/tests/library/CM/Type/EnumTest.php
+++ b/tests/library/CM/Type/EnumTest.php
@@ -1,0 +1,68 @@
+<?php
+
+class CM_Type_EnumTest extends CMTest_TestCase {
+
+    public function testValid() {
+        $circle = new FiguresValidMock('circle');
+        $this->assertSame('circle', (string) $circle);
+
+        $this->assertSame(
+            [
+                'CIRCLE'   => 'circle',
+                'SQUARE'   => 'square',
+                'TRIANGLE' => 'triangle',
+            ],
+            FiguresValidMock::getConstantList()
+        );
+
+        $default = new FiguresValidMock();
+        $this->assertSame('square', (string) $default);
+    }
+
+    public function testInvalid() {
+        $exception = $this->catchException(function () {
+            new FiguresValidMock('bar');
+        });
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertSame('Invalid value `bar` for enum class `FiguresValidMock`', $exception->getMessage());
+
+        $exception = $this->catchException(function () {
+            new FiguresInvalidNoDefaultMock();
+        });
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertSame('Default value in not defined for enum class `FiguresInvalidNoDefaultMock`', $exception->getMessage());
+
+        $exception = $this->catchException(function () {
+            new FiguresInvalidValidDefaultMock();
+        });
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertSame('Invalid default value for enum class `FiguresInvalidValidDefaultMock`', $exception->getMessage());
+    }
+}
+
+class FiguresValidMock extends CM_Type_Enum {
+
+    protected function _getDefaultValue() {
+        return self::SQUARE;
+    }
+
+    const CIRCLE = 'circle';
+    const SQUARE = 'square';
+    const TRIANGLE = 'triangle';
+}
+
+class FiguresInvalidNoDefaultMock extends CM_Type_Enum {
+
+    const SQUARE = 'square';
+    const TRIANGLE = 'triangle';
+}
+
+class FiguresInvalidValidDefaultMock extends CM_Type_Enum {
+
+    protected function _getDefaultValue() {
+        return 'foo';
+    }
+
+    const SQUARE = 'square';
+    const TRIANGLE = 'triangle';
+}


### PR DESCRIPTION
After experiencing a lot of segmentation faults that were obviously caused by SplEnum, we decided to implement our own solution.

There are some limitations as to what we can do, e.g. SplEnum supports typecasts for all types, whereas we can only do this for strings. That shouldn't prevent us from using different types though.

cc @njam 
@fvovan maybe this is something for you?