### PR TITLE
Fluentd handler: add site reference

### DIFF
--- a/library/CM/Log/Handler/Fluentd.php
+++ b/library/CM/Log/Handler/Fluentd.php
@@ -77,6 +77,9 @@ class CM_Log_Handler_Fluentd extends CM_Log_Handler_Abstract {
             if ($ip = $request->getIp()) {
                 $formattedRequest['ip'] = (string) $ip;
             }
+            if ($request->hasHeader('host')) {
+                $formattedRequest['hostname'] = $request->getHost();
+            }
             $formattedRecord['httpRequest'] = $formattedRequest;
         }
 

--- a/tests/library/CM/Log/Handler/FluentdTest.php
+++ b/tests/library/CM/Log/Handler/FluentdTest.php
@@ -20,7 +20,10 @@ class CM_Log_Handler_FluentdTest extends CMTest_TestCase {
         $httpRequest = CM_Http_Request_Abstract::factory(
             'post',
             '/foo?bar=1&baz=quux',
-            ['bar' => 'baz'],
+            [
+                'bar' => 'baz',
+                'host' => 'foo.bar:8080'
+            ],
             [
                 'http_referrer'   => 'http://bar/baz',
                 'http_user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_10)',
@@ -49,6 +52,7 @@ class CM_Log_Handler_FluentdTest extends CMTest_TestCase {
         $this->assertSame('POST', $formattedRecord['httpRequest']['method']);
         $this->assertSame('http://bar/baz', $formattedRecord['httpRequest']['referrer']);
         $this->assertSame('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_10)', $formattedRecord['httpRequest']['user_agent']);
+        $this->assertSame('foo.bar', $formattedRecord['httpRequest']['hostname']);
         $this->assertSame($user->getId(), $formattedRecord['appName']['user']);
         $this->assertSame($clientId, $formattedRecord['appName']['clientId']);
         $this->assertSame('baz', $formattedRecord['appName']['bar']);

--- a/tests/library/CM/Log/Handler/FluentdTest.php
+++ b/tests/library/CM/Log/Handler/FluentdTest.php
@@ -21,13 +21,13 @@ class CM_Log_Handler_FluentdTest extends CMTest_TestCase {
             'post',
             '/foo?bar=1&baz=quux',
             [
-                'bar' => 'baz',
-                'host' => 'foo.bar:8080'
+                'bar'  => 'baz',
+                'host' => 'foo.bar:8080',
             ],
             [
                 'http_referrer'   => 'http://bar/baz',
                 'http_user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_10)',
-                'foo'             => 'quux'
+                'foo'             => 'quux',
             ]
         );
         $clientId = $httpRequest->getClientId();


### PR DESCRIPTION
Currently exception log entries in Loggly have no reference to the *site* they were thrown on.

For the HTTP request there's only `uri: /form/en/190`.

I see two options:
- Add full URI with hostname (see [guidelines](https://github.com/cargomedia/guides/tree/master/logging))
- Add additional "siteName" field to app specific data

@fvovan @tomaszdurka wdyt?