### PR TITLE
Janus server: return different URL for watching and publishing

### DIFF
--- a/library/CM/Janus/Server.php
+++ b/library/CM/Janus/Server.php
@@ -76,6 +76,13 @@ class CM_Janus_Server {
     }
 
     /**
+     * @return string
+     */
+    public function getWebSocketAddressSubscribeOnly() {
+        return CM_Util::link($this->getWebSocketAddress(), ['subscribeOnly' => 1]);
+    }
+
+    /**
      * @return string[]
      */
     public function getPluginList() {

--- a/tests/helpers/CMTest/library/CMTest/TH.php
+++ b/tests/helpers/CMTest/library/CMTest/TH.php
@@ -239,6 +239,13 @@ class CMTest_TH {
     }
 
     /**
+     * @return CM_Geo_Point
+     */
+    public static function createGeoPoint() {
+        return new CM_Geo_Point(rand(-90, 90), rand(-180, 180));
+    }
+
+    /**
      * @param int|null $level
      * @return CM_Model_Location
      */

--- a/tests/library/CM/Janus/ServerTest.php
+++ b/tests/library/CM/Janus/ServerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+class CM_Janus_ServerTest extends CMTest_TestCase {
+
+    public function testConstructorAndBasicGetters() {
+        $serverId = 1;
+        $key = 'server-key';
+        $httpAddress = 'http://api';
+        $webSocketAddress = 'ws://connect:8810';
+        $pluginList = ['my-plugin'];
+        $location = CMTest_TH::createGeoPoint();
+        $iceServerList = ['ice-server'];
+
+        $server = new CM_Janus_Server($serverId, $key, $httpAddress, $webSocketAddress, $pluginList, $location, $iceServerList);
+
+        $this->assertSame($serverId, $server->getId());
+        $this->assertSame($key, $server->getKey());
+        $this->assertSame($httpAddress, $server->getHttpAddress());
+        $this->assertSame($webSocketAddress, $server->getWebSocketAddress());
+        $this->assertSame($pluginList, $server->getPluginList());
+        $this->assertSame($location, $server->getLocation());
+        $this->assertSame($iceServerList, $server->getIceServerList());
+    }
+
+    public function testGetWebSocketAddressSubscribeOnly() {
+        $server = $this->mockClass('CM_Janus_Server')->newInstanceWithoutConstructor();
+        $server->mockMethod('getWebSocketAddress')->set('ws://connect:8810');
+        /** @var CM_Janus_Server $server */
+        $this->assertSame('ws://connect:8810?subscribeOnly=1', $server->getWebSocketAddressSubscribeOnly());
+    }
+}


### PR DESCRIPTION
Part of https://github.com/cargomedia/puppet-cargomedia/issues/1080

Watching will use a different endpoint (`/edge`).

cc @tomaszdurka 