### PR TITLE
Logger backup handler reliability (NR)

### DIFF
--- a/library/CMService/NewRelic/Log/Handler.php
+++ b/library/CMService/NewRelic/Log/Handler.php
@@ -11,6 +11,9 @@ class CMService_NewRelic_Log_Handler extends CM_Log_Handler_Abstract {
     }
 
     public function isHandling(CM_Log_Record $record) {
+        if (true !== $this->_newRelicService->getEnabled()) {
+            return false;
+        }
         if (!$record->getContext()->getException()) {
             return false;
         }

--- a/library/CMService/NewRelic/Log/Handler.php
+++ b/library/CMService/NewRelic/Log/Handler.php
@@ -2,11 +2,15 @@
 
 class CMService_NewRelic_Log_Handler extends CM_Log_Handler_Abstract {
 
+    /** @var CMService_Newrelic */
+    protected $_newRelicService;
+
+    public function __construct($minLevel) {
+        parent::__construct($minLevel);
+        $this->_newRelicService = CM_Service_Manager::getInstance()->getNewrelic();
+    }
+
     public function isHandling(CM_Log_Record $record) {
-        $newRelic = CM_Service_Manager::getInstance()->getNewrelic();
-        if (true !== $newRelic->isEnabled()) {
-            return false;
-        }
         if (!$record->getContext()->getException()) {
             return false;
         }
@@ -14,7 +18,6 @@ class CMService_NewRelic_Log_Handler extends CM_Log_Handler_Abstract {
     }
 
     protected function _writeRecord(CM_Log_Record $record) {
-        $newRelic = CM_Service_Manager::getInstance()->getNewrelic();
-        $newRelic->setNoticeError($record->getContext()->getException());
+        $this->_newRelicService->setNoticeError($record->getContext()->getException());
     }
 }

--- a/library/CMService/NewRelic/Log/Handler.php
+++ b/library/CMService/NewRelic/Log/Handler.php
@@ -3,6 +3,10 @@
 class CMService_NewRelic_Log_Handler extends CM_Log_Handler_Abstract {
 
     public function isHandling(CM_Log_Record $record) {
+        $newRelic = CM_Service_Manager::getInstance()->getNewrelic();
+        if (true !== $newRelic->isEnabled()) {
+            return false;
+        }
         if (!$record->getContext()->getException()) {
             return false;
         }

--- a/library/CMService/Newrelic.php
+++ b/library/CMService/Newrelic.php
@@ -21,7 +21,7 @@ class CMService_Newrelic extends CM_Class_Abstract {
     }
 
     public function setConfig() {
-        if ($this->_getEnabled()) {
+        if ($this->getEnabled()) {
             newrelic_set_appname($this->_appName);
         }
     }
@@ -30,7 +30,7 @@ class CMService_Newrelic extends CM_Class_Abstract {
      * @param Exception $exception
      */
     public function setNoticeError(Exception $exception) {
-        if ($this->_getEnabled()) {
+        if ($this->getEnabled()) {
             newrelic_notice_error($exception->getMessage(), $exception);
         }
     }
@@ -39,7 +39,7 @@ class CMService_Newrelic extends CM_Class_Abstract {
      * @param string $name
      */
     public function startTransaction($name) {
-        if ($this->_getEnabled()) {
+        if ($this->getEnabled()) {
             $this->endTransaction();
             newrelic_start_transaction($this->_appName);
             $this->setNameTransaction($name);
@@ -51,19 +51,19 @@ class CMService_Newrelic extends CM_Class_Abstract {
      */
     public function setNameTransaction($name) {
         $name = (string) $name;
-        if ($this->_getEnabled()) {
+        if ($this->getEnabled()) {
             newrelic_name_transaction($name);
         }
     }
 
     public function endTransaction() {
-        if ($this->_getEnabled()) {
+        if ($this->getEnabled()) {
             newrelic_end_transaction();
         }
     }
 
     public function ignoreTransaction() {
-        if ($this->_getEnabled()) {
+        if ($this->getEnabled()) {
             newrelic_ignore_transaction();
         }
     }
@@ -75,7 +75,7 @@ class CMService_Newrelic extends CM_Class_Abstract {
         if (null === $flag) {
             $flag = true;
         }
-        if ($this->_getEnabled()) {
+        if ($this->getEnabled()) {
             newrelic_background_job($flag);;
         }
     }
@@ -87,28 +87,16 @@ class CMService_Newrelic extends CM_Class_Abstract {
     public function setCustomMetric($name, $milliseconds) {
         $name = 'Custom/' . (string) $name;
         $milliseconds = (int) $milliseconds;
-        if ($this->_getEnabled()) {
+        if ($this->getEnabled()) {
             newrelic_custom_metric($name, $milliseconds);
         }
-    }
-
-    /**
-     * @return bool
-     */
-    public function isEnabled() {
-        try {
-            $isEnabled = $this->_getEnabled();
-        } catch (CM_Exception_Invalid $e) {
-            $isEnabled = false;
-        }
-        return $isEnabled;
     }
 
     /**
      * @throws CM_Exception_Invalid
      * @return bool
      */
-    protected function _getEnabled() {
+    public function getEnabled() {
         if ($this->_enabled) {
             if (!extension_loaded('newrelic')) {
                 throw new CM_Exception_Invalid('Newrelic Extension is not installed.');

--- a/library/CMService/Newrelic.php
+++ b/library/CMService/Newrelic.php
@@ -93,6 +93,18 @@ class CMService_Newrelic extends CM_Class_Abstract {
     }
 
     /**
+     * @return bool
+     */
+    public function isEnabled() {
+        try {
+            $isEnabled = $this->_getEnabled();
+        } catch (CM_Exception_Invalid $e) {
+            $isEnabled = false;
+        }
+        return $isEnabled;
+    }
+
+    /**
      * @throws CM_Exception_Invalid
      * @return bool
      */


### PR DESCRIPTION
Vladimir:
> I have a suggestion regarding NR handler, 
What if we exclude it from handlers list by default?
the thing is, since it presents on dev environment but never actually sends any data, all mongo handler's exceptions go to nowhere (because backup handler believes that record was processed correctly) what is not convenient. 
Another way is checking if NR is enabled in `CMService_NewRelic_Log_Handler->isHandling()`

cc @tomaszdurka 