### PR TITLE
make model::equals() not final again

### DIFF
--- a/library/CM/Model/Abstract.php
+++ b/library/CM/Model/Abstract.php
@@ -162,7 +162,7 @@ abstract class CM_Model_Abstract extends CM_Class_Abstract
      * @param CM_Comparable|null $model
      * @return boolean
      */
-    final public function equals(CM_Comparable $model = null) {
+    public function equals(CM_Comparable $model = null) {
         if (empty($model)) {
             return false;
         }


### PR DESCRIPTION
So this functionality can be mocked in tests.
Particular use-case: Comparing a mocked model to the real model should return true.