### PR TITLE
Check performance of mongodb queries to retrieve logs in admin II

### DIFF
--- a/library/CM/Paging/Log.php
+++ b/library/CM/Paging/Log.php
@@ -73,7 +73,7 @@ class CM_Paging_Log extends CM_Paging_Abstract implements CM_Typed {
             ];
             $source = new CM_PagingSource_MongoDb(self::COLLECTION_NAME, null, null, $aggregate);
         } else {
-            $source = new CM_PagingSource_MongoDb(self::COLLECTION_NAME, $criteria, null, null, ['_id' => -1]);
+            $source = new CM_PagingSource_MongoDb(self::COLLECTION_NAME, $criteria, null, null, ['createdAt' => -1]);
         }
 
         parent::__construct($source);


### PR DESCRIPTION
Was addressed before in: https://github.com/cargomedia/cm/pull/2160

Loading the *error log page* (`/log?level=400`) still regularly takes a long time and often times out.

```
MongoCursorTimeoutException: www3.example.com:27017: Read timed out after reading 0 bytes, waited for 30.000000 seconds in /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/PagingSource/MongoDb.php on line 89
0. {main} at /home/example/serve/public/index.php line 0
1. CM_Http_Handler->processRequest(CM_Http_Request_Get) at /home/example/releases/20160623140811/public/index.php line 8
2. CM_Http_Response_Abstract->process() at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Http/Handler.php line 27
3. CM_Http_Response_Page->_process() at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php line 50
4. CM_Http_Response_Page->_processContentOrRedirect() at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Http/Response/Page.php line 72
5. CM_Http_Response_Page->_processPageLoop(CM_Http_Request_Get) at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Http/Response/Page.php line 90
6. CM_Http_Response_Page->_processPage(CM_Http_Request_Get, CM_Http_Response_Page_ProcessingResult) at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Http/Response/Page.php line 103
7. CM_Http_Response_Abstract->_runWithCatching(Closure, Closure) at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Http/Response/Page.php line 155
8. CM_Http_Response_Page->{closure}() at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php line 275
9. CM_Http_Response_Page->_renderPage(Admin_Page_Log) at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Http/Response/Page.php line 146
10. CM_RenderAdapter_Layout->fetch() at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Http/Response/Page.php line 66
11. CM_Frontend_Render->fetchViewResponse(CM_Frontend_ViewResponse) at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/RenderAdapter/Layout.php line 70
12. CM_Frontend_Render->fetchViewTemplate(Admin_Layout_Default, 'default', []) at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Frontend/Render.php line 473
13. CM_Frontend_Render->fetchTemplate('library/Admin/layout/default/L...', [], []) at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Frontend/Render.php line 465
14. Smarty_Internal_TemplateBase->fetch() at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Frontend/Render.php line 85
15. content_576bee46981405_66285246(Smarty_Internal_Template) at /home/example/releases/20160623140811/vendor/smarty/smarty/libs/sysplugins/smarty_internal_templatebase.php line 182
16. CM_RenderAdapter_Layout->fetchPage() at /home/example/releases/20160623140811/tmp/smarty/Admin_Layout_Default_101_en^1946f6863e8a0574cb2fbab7c83b6bd9af318bc3.file.default.tpl.php line 53
17. CM_RenderAdapter_Component->fetch() at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/RenderAdapter/Layout.php line 81
18. CM_Frontend_Render->fetchViewResponse(CM_Frontend_ViewResponse) at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/RenderAdapter/Component.php line 23
19. CM_Frontend_Render->fetchViewTemplate(Admin_Page_Log, 'default', []) at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Frontend/Render.php line 473
20. CM_Frontend_Render->fetchTemplate('library/Admin/layout/default/P...', [], []) at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Frontend/Render.php line 465
21. Smarty_Internal_TemplateBase->fetch() at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Frontend/Render.php line 85
22. content_576bee52047b31_17914791(Smarty_Internal_Template) at /home/example/releases/20160623140811/vendor/smarty/smarty/libs/sysplugins/smarty_internal_templatebase.php line 182
23. smarty_function_component([], Smarty_Internal_Template) at /home/example/releases/20160623140811/tmp/smarty/Admin_Page_Log_101_en^85241a3f18d0140bfea68fa3f940f3514abeafab.file.default.tpl.php line 44
24. CM_RenderAdapter_Component->fetch() at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/SmartyPlugins/function.component.php line 21
25. CM_Frontend_Render->fetchViewResponse(CM_Frontend_ViewResponse) at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/RenderAdapter/Component.php line 23
26. CM_Frontend_Render->fetchViewTemplate(Admin_Component_LogList, 'default', []) at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Frontend/Render.php line 473
27. CM_Frontend_Render->fetchTemplate('vendor/cargomedia/cm/layout/de...', [], []) at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Frontend/Render.php line 465
28. Smarty_Internal_TemplateBase->fetch() at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Frontend/Render.php line 85
29. content_576bee5236fd93_70368084(Smarty_Internal_Template) at /home/example/releases/20160623140811/vendor/smarty/smarty/libs/sysplugins/smarty_internal_templatebase.php line 182
30. CM_Paging_Abstract->rewind() at /home/example/releases/20160623140811/tmp/smarty/Admin_Component_LogList_101_en^cdd46377373a65d5f43337183e6200ad3f0689f2.file.default.tpl.php line 82
31. CM_Paging_Abstract->getItems() at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Paging/Abstract.php line 485
32. CM_Paging_Abstract->_getItemsRaw() at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Paging/Abstract.php line 31
33. CM_PagingSource_MongoDb->getItems(0, 51) at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/Paging/Abstract.php line 362
34. MongoCursor->rewind() at /home/example/releases/20160623140811/vendor/cargomedia/cm/library/CM/PagingSource/MongoDb.php line 89
```

@fvovan @tomaszdurka could you have a look?
cc @alexispeter 