### PR TITLE
remove mongoDB log collection validation.

### DIFF
--- a/library/CM/Log/Handler/MongoDb.php
+++ b/library/CM/Log/Handler/MongoDb.php
@@ -33,7 +33,6 @@ class CM_Log_Handler_MongoDb extends CM_Log_Handler_Abstract {
         };
 
         $this->_insertOptions = null !== $insertOptions ? $insertOptions : ['w' => 0];
-        $this->_validateCollection($this->_collection);
     }
 
     /**
@@ -149,22 +148,5 @@ class CM_Log_Handler_MongoDb extends CM_Log_Handler_Abstract {
         }
 
         return $formattedRecord;
-    }
-
-    /**
-     * @param string $collection
-     * @throws CM_Exception_Invalid
-     */
-    protected function _validateCollection($collection) {
-        if (null !== $this->_recordTtl) {
-            $indexInfo = $this->_mongoDb->getIndexInfo($collection);
-            $foundIndex = \Functional\some($indexInfo, function ($el) {
-                return isset($el['key']['expireAt']) && isset($el['expireAfterSeconds']) && $el['expireAfterSeconds'] == 0;
-            });
-
-            if (!$foundIndex) {
-                throw new CM_Exception_Invalid('MongoDb Collection `' . $collection . '` does not contain valid TTL index');
-            };
-        }
     }
 }

--- a/tests/library/CM/Log/Handler/MongoDbTest.php
+++ b/tests/library/CM/Log/Handler/MongoDbTest.php
@@ -11,15 +11,6 @@ class CM_Log_Handler_MongoDbTest extends CMTest_TestCase {
         $this->assertInstanceOf('CM_Log_Handler_MongoDb', $handler);
     }
 
-    public function testFailWithWrongCollection() {
-        $exception = $this->catchException(function () {
-            new CM_Log_Handler_MongoDb('badCollection', 1000);
-        });
-
-        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
-        $this->assertSame('MongoDb Collection `badCollection` does not contain valid TTL index', $exception->getMessage());
-    }
-
     public function testFailWithWrongTtl() {
         $collection = 'cm_event_log';
         $mongoClient = $this->getServiceManager()->getMongoDb();


### PR DESCRIPTION
Index is not always properly recreated after reloading app and it's not so important for development env.