### PR TITLE
CM_Params::encode: Include "_class" also for JsonSerializable

### DIFF
--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -542,11 +542,9 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
         if (is_array($value)) {
             $result = array_map('self::encode', $value);
         } elseif ($value instanceof CM_ArrayConvertible || $value instanceof JsonSerializable) {
-            $class = get_class($value);
-            $result = [];
+            $result = ['_class' => get_class($value)];
             if ($value instanceof CM_ArrayConvertible) {
                 $array = $value->toArray();
-                $array = array_merge($array, array('_class' => $class));
                 $result = array_merge($result, $array);
             }
             if ($value instanceof JsonSerializable) {

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -170,7 +170,7 @@ EOL;
 
         $expected = <<<EOL
 cm.window.appendHidden("<div id=\\"$newAutoId\\" class=\\"CM_Component_Mock CM_Component_Notfound CM_Component_Abstract CM_View_Abstract\\">Sorry, this page was not found. It has been removed or never existed.\\n<\/div>");
-cm.views["$newAutoId"] = new CM_Component_Mock({el:$("#$newAutoId").get(0),params:{"entity":{"_type":123,"_id":{"id":"1"},"_class":"CM_Model_Entity_Mock2","id":1,"path":null}}});
+cm.views["$newAutoId"] = new CM_Component_Mock({el:$("#$newAutoId").get(0),params:{"entity":{"_class":"CM_Model_Entity_Mock2","_type":123,"_id":{"id":"1"},"id":1,"path":null}}});
 cm.views["$oldAutoId"].getParent().registerChild(cm.views["$newAutoId"]);
 cm.views["$oldAutoId"].replaceWithHtml(cm.views["$newAutoId"].\$el);
 cm.views["$newAutoId"]._ready();

--- a/tests/library/CM/ParamsTest.php
+++ b/tests/library/CM/ParamsTest.php
@@ -247,6 +247,7 @@ class CM_ParamsTest extends CMTest_TestCase {
         ]);
         $expectedEncoded = array(
             'foo' => 1,
+            '_class' => get_class($object),
         );
         $this->assertEquals($expectedEncoded, CM_Params::encode($object));
         $this->assertSame(1, $toArrayMethod->getCallCount());


### PR DESCRIPTION
Currently only added for ArrayConvertible