### PR TITLE
Introduce FormField "enum"

### DIFF
--- a/library/CM/FormField/Enum.js
+++ b/library/CM/FormField/Enum.js
@@ -1,0 +1,7 @@
+/**
+ * @class CM_FormField_Enum
+ * @extends CM_FormField_Set_Select
+ */
+var CM_FormField_Enum = CM_FormField_Set_Select.extend({
+  _class: 'CM_FormField_Enum'
+});

--- a/library/CM/FormField/Enum.php
+++ b/library/CM/FormField/Enum.php
@@ -1,0 +1,16 @@
+<?php
+
+class CM_FormField_Enum extends CM_FormField_Set_Select {
+
+    /**
+     * @throws CM_Exception_Invalid
+     */
+    protected function _initialize() {
+        $enumClassName = $this->_params->get('className');
+        if (!is_a($enumClassName, 'CM_Type_Enum', true)) {
+            throw new CM_Exception_Invalid('Invalid "className" parameter');
+        }
+        $this->_params->set('values', $enumClassName::getConstantList());
+        parent::_initialize();
+    }
+}

--- a/library/CM/FormField/Enum.php
+++ b/library/CM/FormField/Enum.php
@@ -10,6 +10,7 @@ class CM_FormField_Enum extends CM_FormField_Set_Select {
         if (!is_a($enumClassName, 'CM_Type_Enum', true)) {
             throw new CM_Exception_Invalid('Invalid "className" parameter');
         }
+        /** @type CM_Type_Enum $enumClassName */
         $this->_params->set('values', $enumClassName::getConstantList());
         parent::_initialize();
     }

--- a/library/CM/FormField/Set.php
+++ b/library/CM/FormField/Set.php
@@ -18,9 +18,16 @@ class CM_FormField_Set extends CM_FormField_Abstract {
         parent::_initialize();
     }
 
+    /**
+     * @return array
+     */
+    public function getValues() {
+        return array_keys($this->_getOptionList());
+    }
+
     public function validate(CM_Frontend_Environment $environment, $userInput) {
         foreach ($userInput as $key => $value) {
-            if (!in_array($value, $this->_getValues())) {
+            if (!in_array($value, $this->getValues())) {
                 unset($userInput[$key]);
             }
         }
@@ -43,12 +50,5 @@ class CM_FormField_Set extends CM_FormField_Abstract {
         } else {
             return array_combine($this->_values, $this->_values);
         }
-    }
-
-    /**
-     * @return array
-     */
-    protected function _getValues() {
-        return array_keys($this->_getOptionList());
     }
 }

--- a/library/CM/FormField/Set/Select.php
+++ b/library/CM/FormField/Set/Select.php
@@ -6,7 +6,7 @@ class CM_FormField_Set_Select extends CM_FormField_Set {
     const DISPLAY_RADIOS = 'radios';
 
     public function validate(CM_Frontend_Environment $environment, $userInput) {
-        if (!in_array($userInput, $this->_getValues())) {
+        if (!in_array($userInput, $this->getValues())) {
             throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid value'));
         }
         return $userInput;

--- a/tests/library/CM/FormField/EnumTest.php
+++ b/tests/library/CM/FormField/EnumTest.php
@@ -12,6 +12,11 @@ class CM_FormField_EnumTest extends CMTest_TestCase {
         $this->assertInstanceOf('CM_Exception_Invalid', $exception);
         $this->assertSame('Invalid "className" parameter', $exception->getMessage());
     }
+
+    public function testGetValues() {
+        $field = new CM_FormField_Enum(['name' => 'foo', 'className' => 'FormFieldEnumMock']);
+        $this->assertSame(['foo', 'bar'], $field->getValues());
+    }
 }
 
 class FormFieldEnumMock extends CM_Type_Enum {

--- a/tests/library/CM/FormField/EnumTest.php
+++ b/tests/library/CM/FormField/EnumTest.php
@@ -1,0 +1,21 @@
+<?php
+
+class CM_FormField_EnumTest extends CMTest_TestCase {
+
+    public function testInitialize() {
+        $field = new CM_FormField_Enum(['name' => 'foo', 'className' => 'FormFieldEnumMock']);
+        $this->assertInstanceOf('CM_FormField_Enum', $field);
+
+        $exception = $this->catchException(function () {
+            new CM_FormField_Enum(['name' => 'bar', 'className' => 'Bar']);
+        });
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertSame('Invalid "className" parameter', $exception->getMessage());
+    }
+}
+
+class FormFieldEnumMock extends CM_Type_Enum {
+
+    const FOO = 'foo';
+    const BAR = 'bar';
+}

--- a/tests/library/CM/FormField/SetTest.php
+++ b/tests/library/CM/FormField/SetTest.php
@@ -19,6 +19,12 @@ class CM_FormField_SetTest extends CMTest_TestCase {
         $this->assertSame($value, $field->getValue());
     }
 
+    public function testGetValues() {
+        $data = array(32 => 'apples', 64 => 'oranges', 128 => 'bananas');
+        $field = new CM_FormField_Set(['name' => 'foo', 'values' => $data, 'labelsInValues' => true]);
+        $this->assertSame(array_keys($data), $field->getValues());
+    }
+
     public function testValidate() {
         $data = array(32 => 'apples', 64 => 'oranges', 128 => 'bananas');
         $field = new CM_FormField_Set(['name' => 'foo', 'values' => $data, 'labelsInValues' => true]);


### PR DESCRIPTION
For `CM_Type_Enum`, extending `CM_FormField_Set_Select`.

Can be used for https://github.com/cargomedia/sk/pull/3403 and https://github.com/cargomedia/sk/issues/3446

@fvovan @alexispeter wdyt?