### PR TITLE
No record logged if mongodb handler fails

### DIFF
--- a/library/CM/Log/Context.php
+++ b/library/CM/Log/Context.php
@@ -99,8 +99,8 @@ class CM_Log_Context {
      * @throws CM_Exception_Invalid
      */
     public function setExtra(array $extra) {
-        $flattenContext = Functional\flatten($extra);
-        if (Functional\some($flattenContext, function ($el) {
+        $flattenExtra = Functional\flatten($extra);
+        if (Functional\some($flattenExtra, function ($el) {
             return is_object($el);
         })) {
             throw new CM_Exception_Invalid('Object can not be passed to "Extra"');

--- a/library/CM/Log/Context.php
+++ b/library/CM/Log/Context.php
@@ -96,8 +96,16 @@ class CM_Log_Context {
 
     /**
      * @param array $extra
+     * @throws CM_Exception_Invalid
      */
     public function setExtra(array $extra) {
+        $flattenContext = Functional\flatten($extra);
+        if (Functional\some($flattenContext, function ($el) {
+            return is_object($el);
+        })) {
+            throw new CM_Exception_Invalid('Object can not be passed to "Extra"');
+        }
+
         $this->_extra = $extra;
     }
 

--- a/tests/library/CM/Log/ContextTest.php
+++ b/tests/library/CM/Log/ContextTest.php
@@ -13,4 +13,17 @@ class CM_Log_ContextTest extends CMTest_TestCase {
         $context->setHttpRequest($request);
         $this->assertSame($request, $context->getHttpRequest());
     }
+
+    public function testSetExtra() {
+        $extra = ['foo' => 'bar', 'baz' => ['quux' => 1, 'foo' => 0]];
+        $context = new CM_Log_Context();
+        $context->setExtra($extra);
+        $this->assertSame($extra, $context->getExtra());
+
+        $exception = $this->catchException(function () use ($context) {
+            $context->setExtra(['foo' => 'bar', 'fooBar' => ['1' => ['2' => new stdClass()]]]);
+        });
+        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
+        $this->assertSame('Object can not be passed to "Extra"', $exception->getMessage());
+    }
 }


### PR DESCRIPTION
Default config:
```
                'handlersLayerConfigList' => [
                    ['logger-handler-mongodb', 'logger-handler-newrelic'],
                    ['logger-handler-file-error']
                ],
```

If the mongodb handler fails, it seems there is no record logged.
Is this a bug, because if newrelic is disabled (on development), it should go to file, and additional log a logger error?

cc @tomaszdurka 