### PR TITLE
Unpublish streamchannel AFTER publisher is deleted

### DIFF
--- a/library/CM/Model/Stream/Publish.php
+++ b/library/CM/Model/Stream/Publish.php
@@ -23,12 +23,12 @@ class CM_Model_Stream_Publish extends CM_Model_Stream_Abstract {
         return CM_Db_Db::select('cm_stream_publish', '*', array('id' => $this->getId()))->fetch();
     }
 
-    protected function _onDeleteBefore() {
-        $this->getStreamChannel()->onUnpublish($this);
-    }
-
     protected function _onDelete() {
         CM_Db_Db::delete('cm_stream_publish', array('id' => $this->getId()));
+    }
+
+    protected function _onDeleteAfter() {
+        $this->getStreamChannel()->onUnpublish($this);
     }
 
     /**

--- a/tests/library/CM/Model/Stream/PublishTest.php
+++ b/tests/library/CM/Model/Stream/PublishTest.php
@@ -158,10 +158,8 @@ class CM_Model_Stream_PublishTest extends CMTest_TestCase {
         /** @var CM_Model_StreamChannel_Media $streamChannel */
         /** @var CM_Model_Stream_Publish $streamPublish */
 
-        $onDeleteBefore = CMTest_TH::getProtectedMethod('CM_Model_Stream_Publish', '_onDeleteBefore');
+        $onDeleteBefore = CMTest_TH::getProtectedMethod('CM_Model_Stream_Publish', '_onDeleteAfter');
         $onDeleteBefore->invoke($streamPublish);
-        $onDelete = CMTest_TH::getProtectedMethod('CM_Model_Stream_Publish', '_onDelete');
-        $onDelete->invoke($streamPublish);
     }
 
     public function testDeleteOnUnpublishInvalid() {

--- a/tests/library/CM/Model/Stream/PublishTest.php
+++ b/tests/library/CM/Model/Stream/PublishTest.php
@@ -158,8 +158,8 @@ class CM_Model_Stream_PublishTest extends CMTest_TestCase {
         /** @var CM_Model_StreamChannel_Media $streamChannel */
         /** @var CM_Model_Stream_Publish $streamPublish */
 
-        $onDeleteBefore = CMTest_TH::getProtectedMethod('CM_Model_Stream_Publish', '_onDeleteAfter');
-        $onDeleteBefore->invoke($streamPublish);
+        $onDeleteAfter = CMTest_TH::getProtectedMethod('CM_Model_Stream_Publish', '_onDeleteAfter');
+        $onDeleteAfter->invoke($streamPublish);
     }
 
     public function testDeleteOnUnpublishInvalid() {


### PR DESCRIPTION
Because it shouldn't exist anymore when onUnpublish() is called.