### PR TITLE
URL encoded requests lead to json encoding error

### DIFF
--- a/library/CM/Http/Request/Abstract.php
+++ b/library/CM/Http/Request/Abstract.php
@@ -320,8 +320,7 @@ abstract class CM_Http_Request_Abstract {
         $querySanitized = [];
         foreach ($query as $key => $value) {
             $key = self::_sanitizeUtf($key);
-            $value = self::_sanitizeUtf($value);
-            $querySanitized[$key] = $value;
+            $querySanitized[$key] = self::_sanitizeUtf($value);
         }
 
         $this->setQuery($querySanitized);

--- a/library/CM/Http/Request/Abstract.php
+++ b/library/CM/Http/Request/Abstract.php
@@ -315,8 +315,16 @@ abstract class CM_Http_Request_Abstract {
         if (false === ($queryString = parse_url($uriWithHost, PHP_URL_QUERY))) {
             throw new CM_Exception_Invalid('Cannot detect query from `' . $uriWithHost . '`.');
         }
-        parse_str($queryString, $query);
-        $this->setQuery($query);
+        mb_parse_str($queryString, $query);
+
+        $querySanitized = [];
+        foreach ($query as $key => $value) {
+            $key = self::_sanitizeUtf($key);
+            $value = self::_sanitizeUtf($value);
+            $querySanitized[$key] = $value;
+        }
+
+        $this->setQuery($querySanitized);
 
         $this->setLanguageUrl(null);
 

--- a/tests/library/CM/Http/Request/AbstractTest.php
+++ b/tests/library/CM/Http/Request/AbstractTest.php
@@ -112,6 +112,24 @@ class CM_Http_Request_AbstractTest extends CMTest_TestCase {
         $this->assertSame('/foo1/bar1?foo=bar', $mock->getUri());
     }
 
+    public function testSetUriNonUtf() {
+        $uri = '/foo/bar?%%aff%%=quux&bar=%%AFF%%';
+        $headers = array('Host' => 'example.ch', 'Connection' => 'keep-alive');
+        /** @var CM_Http_Request_Abstract $mock */
+        $mock = $this->getMockForAbstractClass('CM_Http_Request_Abstract', array($uri, $headers));
+
+        $this->assertSame('/foo/bar', $mock->getPath());
+        $this->assertSame(array('foo', 'bar'), $mock->getPathParts());
+        $this->assertSame(
+            array(
+                '%?f%%' => 'quux',
+                'bar'   => '%?F%%',
+            ),
+            $mock->getQuery()
+        );
+        $this->assertSame($uri, $mock->getUri());
+    }
+
     public function testSetUriRelativeAndColon() {
         $uri = '/foo/bar?foo1=bar1:80';
         /** @var CM_Http_Request_Abstract $mock */


### PR DESCRIPTION
Related to https://github.com/cargomedia/cm/issues/2235

Example URL:
/campaign?redirectUnsupported=false&version=1&af=%%aff_id%%&af_source=offerit&oid=%%click_hash%%&utm_source=%%aff_id%%&utm_medium=dfsdf&utm_content=v1&utm_campaign=


> it is %af symbols  (twice) 
they are treated as hex urlencoded values being invalid utf sequences
the question is should we sanitize it?

> urldecoding happens here 
https://github.com/cargomedia/cm/blob/master/library/CM/Http/Request/Abstract.php#L318

```
Cannot json_encode value.
#0 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Params.php(626): CM_Util::jsonEncode(Array, NULL)
#1 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Frontend/GlobalResponse.php(194): CM_Params::jsonEncode(Array)
#2 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Frontend/GlobalResponse.php(151): CM_Frontend_GlobalResponse->_getTreeNodeInitJs(Object(CM_Frontend_TreeNode))
#3 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Frontend/GlobalResponse.php(138): CM_Frontend_GlobalResponse->_getJs()
#4 /home/example/releases/20160704104342/tmp/smarty/VR_Layout_Index_252_en^5218301f29f7b29cd9a7e5ec0e5146ab7ffa46f3.file.default.tpl.php(182): CM_Frontend_GlobalResponse->getHtml()
#5 /home/example/releases/20160704104342/vendor/smarty/smarty/libs/sysplugins/smarty_internal_templatebase.php(182): content_577a3ecda622d3_83527630(Object(Smarty_Internal_Template))
#6 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Frontend/Render.php(85): Smarty_Internal_TemplateBase->fetch()
#7 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Frontend/Render.php(472): CM_Frontend_Render->fetchTemplate('library/VR/layo...', Array, Array)
#8 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Frontend/Render.php(480): CM_Frontend_Render->fetchViewTemplate(Object(VR_Layout_Index), 'default', Array)
#9 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/RenderAdapter/Layout.php(72): CM_Frontend_Render->fetchViewResponse(Object(CM_Frontend_ViewResponse))
#10 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Http/Response/Page.php(58): CM_RenderAdapter_Layout->fetch()
#11 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Http/Response/Page.php(138): CM_Http_Response_Page->_renderPage(Object(VR_Page_Campaign))
#12 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php(273): CM_Http_Response_Page->{closure}()
#13 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Http/Response/Page.php(147): CM_Http_Response_Abstract->_runWithCatching(Object(Closure), Object(Closure))
#14 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Http/Response/Page.php(95): CM_Http_Response_Page->_processPage(Object(CM_Http_Request_Get), Object(CM_Http_Response_Page_ProcessingResult))
#15 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Http/Response/Page.php(82): CM_Http_Response_Page->_processPageLoop(Object(CM_Http_Request_Get))
#16 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Http/Response/Page.php(64): CM_Http_Response_Page->_processContentOrRedirect()
#17 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php(48): CM_Http_Response_Page->_process()
#18 /home/example/releases/20160704104342/vendor/cargomedia/cm/library/CM/Http/Handler.php(28): CM_Http_Response_Abstract->process()
#19 /home/example/releases/20160704104342/public/index.php(8): CM_Http_Handler->processRequest(Object(CM_Http_Request_Get))
```