### PR TITLE
Janus RPC: invalid session should be warning

### DIFF
--- a/library/CM/Exception/UnknownSessionId.php
+++ b/library/CM/Exception/UnknownSessionId.php
@@ -1,0 +1,5 @@
+<?php
+
+class CM_Exception_UnknownSessionId extends CM_Exception {
+
+}

--- a/library/CM/Janus/RpcEndpoints.php
+++ b/library/CM/Janus/RpcEndpoints.php
@@ -21,7 +21,7 @@ class CM_Janus_RpcEndpoints {
 
         $server = $janus->getServerList()->findByKey($serverKey);
         $sessionParams = CM_Params::factory(CM_Params::jsonDecode($sessionData), true);
-        $session = self::_getSession($sessionParams);
+        $session = self::_getSession($sessionParams->getString('sessionId'));
         $user = $session->getUser(true);
 
         $channelKey = (string) $channelKey;
@@ -89,7 +89,7 @@ class CM_Janus_RpcEndpoints {
 
         $server = $janus->getServerList()->findByKey($serverKey);
         $sessionParams = CM_Params::factory(CM_Params::jsonDecode($sessionData), true);
-        $session = self::_getSession($sessionParams);
+        $session = self::_getSession($sessionParams->getString('sessionId'));
         $user = $session->getUser(true);
 
         $channelKey = (string) $channelKey;
@@ -210,14 +210,14 @@ class CM_Janus_RpcEndpoints {
     }
 
     /**
-     * @param CM_Params $sessionParams
+     * @param string $sessionId
      * @return CM_Session
-     * @throws CM_Exception_Nonexistent
+     * @throws CM_Exception_UnknownSessionId
      */
-    protected static function _getSession(CM_Params $sessionParams) {
+    protected static function _getSession($sessionId) {
         try {
-            return new CM_Session($sessionParams->getString('sessionId'));
-        } catch (CM_Exception_Nonexistent $e) {
+            return new CM_Session((string) $sessionId);
+        } catch (CM_Exception_UnknownSessionId $e) {
             $e->setSeverity(CM_Exception::WARN);
             throw $e;
         }

--- a/library/CM/Janus/RpcEndpoints.php
+++ b/library/CM/Janus/RpcEndpoints.php
@@ -21,7 +21,7 @@ class CM_Janus_RpcEndpoints {
 
         $server = $janus->getServerList()->findByKey($serverKey);
         $sessionParams = CM_Params::factory(CM_Params::jsonDecode($sessionData), true);
-        $session = self::_getSession($sessionParams->getString('sessionId'));
+        $session = $sessionParams->getSession('sessionId');
         $user = $session->getUser(true);
 
         $channelKey = (string) $channelKey;
@@ -89,7 +89,7 @@ class CM_Janus_RpcEndpoints {
 
         $server = $janus->getServerList()->findByKey($serverKey);
         $sessionParams = CM_Params::factory(CM_Params::jsonDecode($sessionData), true);
-        $session = self::_getSession($sessionParams->getString('sessionId'));
+        $session = $sessionParams->getSession('sessionId');
         $user = $session->getUser(true);
 
         $channelKey = (string) $channelKey;
@@ -206,20 +206,6 @@ class CM_Janus_RpcEndpoints {
     protected static function _authenticate(CM_Janus_Service $janus, $serverKey) {
         if (!$janus->getServerList()->findByKey($serverKey)) {
             throw new CM_Exception_AuthFailed('Invalid serverKey');
-        }
-    }
-
-    /**
-     * @param string $sessionId
-     * @return CM_Session
-     * @throws CM_Exception_UnknownSessionId
-     */
-    protected static function _getSession($sessionId) {
-        try {
-            return new CM_Session((string) $sessionId);
-        } catch (CM_Exception_UnknownSessionId $e) {
-            $e->setSeverity(CM_Exception::WARN);
-            throw $e;
         }
     }
 }

--- a/library/CM/Janus/RpcEndpoints.php
+++ b/library/CM/Janus/RpcEndpoints.php
@@ -21,7 +21,7 @@ class CM_Janus_RpcEndpoints {
 
         $server = $janus->getServerList()->findByKey($serverKey);
         $sessionParams = CM_Params::factory(CM_Params::jsonDecode($sessionData), true);
-        $session = new CM_Session($sessionParams->getString('sessionId'));
+        $session = self::_getSession($sessionParams);
         $user = $session->getUser(true);
 
         $channelKey = (string) $channelKey;
@@ -89,7 +89,7 @@ class CM_Janus_RpcEndpoints {
 
         $server = $janus->getServerList()->findByKey($serverKey);
         $sessionParams = CM_Params::factory(CM_Params::jsonDecode($sessionData), true);
-        $session = new CM_Session($sessionParams->getString('sessionId'));
+        $session = self::_getSession($sessionParams);
         $user = $session->getUser(true);
 
         $channelKey = (string) $channelKey;
@@ -206,6 +206,20 @@ class CM_Janus_RpcEndpoints {
     protected static function _authenticate(CM_Janus_Service $janus, $serverKey) {
         if (!$janus->getServerList()->findByKey($serverKey)) {
             throw new CM_Exception_AuthFailed('Invalid serverKey');
+        }
+    }
+
+    /**
+     * @param CM_Params $sessionParams
+     * @return CM_Session
+     * @throws CM_Exception_Nonexistent
+     */
+    protected static function _getSession(CM_Params $sessionParams) {
+        try {
+            return new CM_Session($sessionParams->getString('sessionId'));
+        } catch (CM_Exception_Nonexistent $e) {
+            $e->setSeverity(CM_Exception::WARN);
+            throw $e;
         }
     }
 }

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -497,6 +497,21 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
 
     /**
      * @param string $key
+     * @return CM_Session
+     * @throws CM_Exception_InvalidParam
+     */
+    public function getSession($key) {
+        $key = (string) $key;
+        $sessionId = $this->getString($key);
+        try {
+            return new CM_Session($sessionId);
+        } catch (CM_Exception_UnknownSessionId $e) {
+            throw new CM_Exception_InvalidParam('Session is not found', null, ['key' => $key]);
+        }
+    }
+
+    /**
+     * @param string $key
      * @param mixed  $default
      * @throws CM_Exception_InvalidParam
      * @return mixed

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -502,12 +502,16 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
      */
     public function getSession($key) {
         $key = (string) $key;
-        $sessionId = $this->getString($key);
-        try {
-            return new CM_Session($sessionId);
-        } catch (CM_Exception_UnknownSessionId $e) {
-            throw new CM_Exception_InvalidParam('Session is not found', null, ['key' => $key]);
-        }
+        return $this->getObject($key, 'CM_Session', null, function ($className, $param) use ($key) {
+            if (is_string($param)) {
+                try {
+                    return new CM_Session($param);
+                } catch (CM_Exception_UnknownSessionId $e) {
+                    throw new CM_Exception_InvalidParam('Session is not found', null, ['key' => $key]);
+                }
+            }
+            throw new CM_Exception_InvalidParam('Invalid param type for session', null, ['key' => $key]);
+        });
     }
 
     /**

--- a/library/CM/Session.php
+++ b/library/CM/Session.php
@@ -25,14 +25,14 @@ class CM_Session implements CM_Comparable {
     /**
      * @param string|null                   $id
      * @param CM_Http_Request_Abstract|null $request
-     * @throws CM_Exception_Nonexistent
+     * @throws CM_Exception_UnknownSessionId
      */
     public function __construct($id = null, CM_Http_Request_Abstract $request = null) {
         if (null !== $id) {
             $this->_id = (string) $id;
             $data = self::_findDataById($this->getId());
             if (null === $data) {
-                throw new CM_Exception_Nonexistent('Session `' . $this->getId() . '` does not exist.');
+                throw new CM_Exception_UnknownSessionId('Session `' . $this->getId() . '` does not exist.');
             }
             $this->_isPersistent = true;
             $expires = (int) $data['expires'];

--- a/library/CM/Session.php
+++ b/library/CM/Session.php
@@ -32,7 +32,7 @@ class CM_Session implements CM_Comparable {
             $this->_id = (string) $id;
             $data = self::_findDataById($this->getId());
             if (null === $data) {
-                throw new CM_Exception_UnknownSessionId('Session `' . $this->getId() . '` does not exist.');
+                throw new CM_Exception_UnknownSessionId('Session does not exist.', null, ['sessionId' => $this->getId()]);
             }
             $this->_isPersistent = true;
             $expires = (int) $data['expires'];

--- a/tests/library/CM/ParamsTest.php
+++ b/tests/library/CM/ParamsTest.php
@@ -246,7 +246,7 @@ class CM_ParamsTest extends CMTest_TestCase {
             'foo' => 1
         ]);
         $expectedEncoded = array(
-            'foo' => 1,
+            'foo'    => 1,
             '_class' => get_class($object),
         );
         $this->assertEquals($expectedEncoded, CM_Params::encode($object));
@@ -467,5 +467,22 @@ class CM_ParamsTest extends CMTest_TestCase {
         });
         $this->assertInstanceOf('CM_Exception_InvalidParam', $exception);
         $this->assertSame('Not enough parameters', $exception->getMessage());
+    }
+
+    public function testGetSession() {
+        $session = CMTest_TH::createSession();
+        $sessionId = $session->getId();
+        $params = new CM_Params(['foo' => $sessionId, 'bar' => 'baz']);
+
+        $session = $params->getSession('foo');
+        $this->assertInstanceOf('CM_Session', $session);
+        $this->assertSame($sessionId, $session->getId());
+
+        $exception = $this->catchException(function () use ($params) {
+            $params->getSession('bar');
+        });
+
+        $this->assertInstanceOf('CM_Exception_InvalidParam', $exception);
+        $this->assertSame('Session is not found', $exception->getMessage());
     }
 }

--- a/tests/library/CM/ParamsTest.php
+++ b/tests/library/CM/ParamsTest.php
@@ -470,19 +470,31 @@ class CM_ParamsTest extends CMTest_TestCase {
     }
 
     public function testGetSession() {
-        $session = CMTest_TH::createSession();
-        $sessionId = $session->getId();
-        $params = new CM_Params(['foo' => $sessionId, 'bar' => 'baz']);
+        $session1 = CMTest_TH::createSession();
+        $sessionId1 = $session1->getId();
+        $session2 = CMTest_TH::createSession();
+        $sessionId2 = $session2->getId();
 
-        $session = $params->getSession('foo');
-        $this->assertInstanceOf('CM_Session', $session);
-        $this->assertSame($sessionId, $session->getId());
+        $params = new CM_Params(['foo' => $sessionId1, 'bar' => 'baz', 'baz' => $session2, 'quux' => 5]);
+
+        $session1 = $params->getSession('foo');
+        $this->assertInstanceOf('CM_Session', $session1);
+        $this->assertSame($sessionId1, $session1->getId());
 
         $exception = $this->catchException(function () use ($params) {
             $params->getSession('bar');
         });
-
         $this->assertInstanceOf('CM_Exception_InvalidParam', $exception);
         $this->assertSame('Session is not found', $exception->getMessage());
+
+        $session2 = $params->getSession('baz');
+        $this->assertInstanceOf('CM_Session', $session2);
+        $this->assertSame($sessionId2, $session2->getId());
+
+        $exception = $this->catchException(function () use ($params) {
+            $params->getSession('quux');
+        });
+        $this->assertInstanceOf('CM_Exception_InvalidParam', $exception);
+        $this->assertSame('Invalid param type for session', $exception->getMessage());
     }
 }

--- a/tests/library/CM/SessionTest.php
+++ b/tests/library/CM/SessionTest.php
@@ -9,7 +9,7 @@ class CM_SessionTest extends CMTest_TestCase {
         try {
             new CM_Session('nonexistent');
             $this->fail('Can instantiate nonexistent session.');
-        } catch (CM_Exception_Nonexistent $ex) {
+        } catch (CM_Exception_UnknownSessionId $ex) {
             $this->assertTrue(true);
         }
     }
@@ -35,7 +35,7 @@ class CM_SessionTest extends CMTest_TestCase {
         try {
             new CM_Session($sessionId);
             $this->fail('Empty Session stored in db.');
-        } catch (CM_Exception_Nonexistent $ex) {
+        } catch (CM_Exception_UnknownSessionId $ex) {
             $this->assertTrue(true);
         }
         $session = new CM_Session();
@@ -54,7 +54,7 @@ class CM_SessionTest extends CMTest_TestCase {
         try {
             $session = new CM_Session($sessionId);
             $this->assertTrue(true);
-        } catch (CM_Exception_Nonexistent $ex) {
+        } catch (CM_Exception_UnknownSessionId $ex) {
             $this->fail('Session not persistent.');
         }
         $this->assertEquals('bar', $session->get('foo'));
@@ -91,7 +91,7 @@ class CM_SessionTest extends CMTest_TestCase {
         try {
             $session = new CM_Session($sessionId);
             $this->fail('Session not deleted.');
-        } catch (CM_Exception_Nonexistent $ex) {
+        } catch (CM_Exception_UnknownSessionId $ex) {
             $this->assertTrue(true);
         }
     }
@@ -109,7 +109,7 @@ class CM_SessionTest extends CMTest_TestCase {
         try {
             new CM_Session($oldSessionId);
             $this->fail('Db entry not updated.');
-        } catch (CM_Exception_Nonexistent $ex) {
+        } catch (CM_Exception_UnknownSessionId $ex) {
             $this->assertTrue(true);
         }
         try {
@@ -130,7 +130,7 @@ class CM_SessionTest extends CMTest_TestCase {
         try {
             new CM_Session($sessionId);
             $this->fail('Expired Session was not deleted.');
-        } catch (CM_Exception_Nonexistent $ex) {
+        } catch (CM_Exception_UnknownSessionId $ex) {
             $this->assertTrue(true);
         }
     }


### PR DESCRIPTION
Currently when we receive RPC calls with invalid session information we get this exception:
```php
CM_Exception_Nonexistent: Session `e443d82711136b1668032a1e680cd2ba` does not exist. in /home/example/releases/20160707172200/vendor/cargomedia/cm/library/CM/Session.php on line 35
0. {main} at /home/example/serve/public/index.php line 0
1. CM_Http_Handler->processRequest(CM_Http_Request_Post) at /home/example/releases/20160707172200/public/index.php line 8
2. CM_Http_Response_Abstract->process() at /home/example/releases/20160707172200/vendor/cargomedia/cm/library/CM/Http/Handler.php line 28
3. CM_Http_Response_RPC->_process() at /home/example/releases/20160707172200/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php line 48
4. CM_Http_Response_Abstract->_runWithCatching(Closure, Closure) at /home/example/releases/20160707172200/vendor/cargomedia/cm/library/CM/Http/Response/RPC.php line 21
5. CM_Http_Response_RPC->{closure}() at /home/example/releases/20160707172200/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php line 273
6. call_user_func_array([], []) at /home/example/releases/20160707172200/vendor/cargomedia/cm/library/CM/Http/Response/RPC.php line 18
7. [internal function] at line
8. CM_Session->__construct('e443d82711136b1668032a1e680cd2...') at /home/example/releases/20160707172200/vendor/cargomedia/cm/library/CM/Janus/RpcEndpoints.php line 92
```

This should be a warning only, as it's based on user input.

I see two ways to accomplish that:
- A: Catch the exception in the RPC functions, and handle it locally
- B: Add it to the config's `$config->CM_Http_Response_RPC->exceptionsToCatch`

Either way we should probably introduce a specific exception `CM_Session_UnknownSessionIdException`?

@tomaszdurka @fvovan wdyt?