### PR TITLE
Logger: pass "httpRequest.query" to Loggly

### DIFF
--- a/library/CM/Http/Request/Abstract.php
+++ b/library/CM/Http/Request/Abstract.php
@@ -278,6 +278,17 @@ abstract class CM_Http_Request_Abstract {
     }
 
     /**
+     * @return array
+     */
+    public function findQuery() {
+        try {
+            return $this->getQuery();
+        } catch (CM_Exception_Invalid $e) {
+            return [];
+        }
+    }
+
+    /**
      * @param array $query
      */
     public function setQuery(array $query) {

--- a/library/CM/Log/ContextFormatter/Cargomedia.php
+++ b/library/CM/Log/ContextFormatter/Cargomedia.php
@@ -40,6 +40,11 @@ class CM_Log_ContextFormatter_Cargomedia implements CM_Log_ContextFormatter_Inte
                 'uri'    => $request->getUri(),
                 'method' => $request->getMethodName(),
             ];
+            try {
+                $formattedRequest['query'] = $request->getQuery();
+            } catch (CM_Exception_Invalid $e) {
+                //CM_Http_Request_Post can throw.
+            }
             if (array_key_exists('http_referer', $serverArray)) {
                 $formattedRequest['referer'] = (string) $serverArray['http_referer'];
             }

--- a/library/CM/Log/ContextFormatter/Cargomedia.php
+++ b/library/CM/Log/ContextFormatter/Cargomedia.php
@@ -40,11 +40,7 @@ class CM_Log_ContextFormatter_Cargomedia implements CM_Log_ContextFormatter_Inte
                 'uri'    => $request->getUri(),
                 'method' => $request->getMethodName(),
             ];
-            try {
-                $formattedRequest['query'] = $request->getQuery();
-            } catch (CM_Exception_Invalid $e) {
-                //CM_Http_Request_Post can throw.
-            }
+            $formattedRequest['query'] = $request->findQuery();
             if (array_key_exists('http_referer', $serverArray)) {
                 $formattedRequest['referer'] = (string) $serverArray['http_referer'];
             }

--- a/library/CM/Log/Handler/MongoDb.php
+++ b/library/CM/Log/Handler/MongoDb.php
@@ -83,12 +83,8 @@ class CM_Log_Handler_MongoDb extends CM_Log_Handler_Abstract {
                 'headers' => $request->getHeaders(),
             ];
 
-            try {
-                $formattedContext['httpRequest']['query'] = $request->getQuery();
-            } catch (CM_Exception_Invalid $e) {
-                //CM_Http_Request_Post can throw.
-            }
-
+            $formattedContext['httpRequest']['query'] = $request->findQuery();
+            
             if ($request instanceof CM_Http_Request_Post) {
                 $formattedContext['httpRequest']['body'] = $request->getBody();
             }

--- a/tests/library/CM/Http/Request/AbstractTest.php
+++ b/tests/library/CM/Http/Request/AbstractTest.php
@@ -112,6 +112,21 @@ class CM_Http_Request_AbstractTest extends CMTest_TestCase {
         $this->assertSame('/foo1/bar1?foo=bar', $mock->getUri());
     }
 
+    public function testFindQuery() {
+        $uri = '/foo/bar?foo1=bar1';
+        $headers = array('Host' => 'example.ch', 'Connection' => 'keep-alive');
+        /** @var CM_Http_Request_Abstract $mock */
+        $requestMockClass = $this->mockClass('CM_Http_Request_Abstract');
+        /** @var \Mocka\AbstractClassTrait|CM_Http_Request_Abstract $requestMock */
+        $requestMock = $requestMockClass->newInstance([$uri, $headers]);
+
+        $this->assertSame(['foo1' => 'bar1'], $requestMock->findQuery());
+        $requestMock->mockMethod('getQuery')->set(function () {
+            throw new CM_Exception_Invalid('error');
+        });
+        $this->assertSame([], $requestMock->findQuery());
+    }
+
     public function testSetUriNonUtf() {
         $uri = '/foo/bar?%%aff%%=quux&bar=%%AFF%%&baz[]=%%aff%%&baz[]=%%aff%%';
         $headers = array('Host' => 'example.ch', 'Connection' => 'keep-alive');
@@ -127,8 +142,8 @@ class CM_Http_Request_AbstractTest extends CMTest_TestCase {
                 'baz'   => [
                     '%?f%%',
                     '%?f%%',
-                ] 
-             ),
+                ]
+            ),
             $mock->getQuery()
         );
         $this->assertSame($uri, $mock->getUri());

--- a/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
+++ b/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
@@ -41,12 +41,13 @@ class CM_Log_ContextFormatter_CargomediaTest extends CMTest_TestCase {
         $this->assertSame('www.example.com', $formattedRecord['computerInfo']['fqdn']);
         $this->assertSame('v7.0.1', $formattedRecord['computerInfo']['phpVersion']);
         $this->assertSame('/foo?bar=1&baz=quux', $formattedRecord['httpRequest']['uri']);
-        $this->assertSame([
-            'bar' => '1',
-            'baz' => 'quux',
-            'foo' => 'bar',
-            'quux' => 'baz',
-        ],
+        $this->assertSame(
+            [
+                'bar'  => '1',
+                'baz'  => 'quux',
+                'foo'  => 'bar',
+                'quux' => 'baz',
+            ],
             $formattedRecord['httpRequest']['query']
         );
 

--- a/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
+++ b/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
@@ -17,7 +17,8 @@ class CM_Log_ContextFormatter_CargomediaTest extends CMTest_TestCase {
                 'http_referer'    => 'http://bar/baz',
                 'http_user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_10)',
                 'foo'             => 'quux',
-            ]
+            ],
+            '{"foo" : "bar", "quux" : "baz"}'
         );
         $clientId = $httpRequest->getClientId();
         $computerInfo = new CM_Log_Context_ComputerInfo('www.example.com', 'v7.0.1');
@@ -40,6 +41,14 @@ class CM_Log_ContextFormatter_CargomediaTest extends CMTest_TestCase {
         $this->assertSame('www.example.com', $formattedRecord['computerInfo']['fqdn']);
         $this->assertSame('v7.0.1', $formattedRecord['computerInfo']['phpVersion']);
         $this->assertSame('/foo?bar=1&baz=quux', $formattedRecord['httpRequest']['uri']);
+        $this->assertSame([
+            'bar' => '1',
+            'baz' => 'quux',
+            'foo' => 'bar',
+            'quux' => 'baz',
+        ],
+            $formattedRecord['httpRequest']['query']
+        );
 
         $this->assertSame('POST', $formattedRecord['httpRequest']['method']);
         $this->assertSame('http://bar/baz', $formattedRecord['httpRequest']['referer']);


### PR DESCRIPTION
Currently in Loggly we have the following keys in `httpRequest`: ip, hostname, uri, referer, useragent, method.

It would be good to also have `query`, which allows to identify for example what ajax request was sent. This information is available in mongodb/admin.

@fvovan @tomaszdurka  wdyt? If you agree, could you also open a PR on *guides*?