### PR TITLE
Improve utf-8 sanitizing for logger handlers

### DIFF
--- a/layout/default/Component/LogList/default.tpl
+++ b/layout/default/Component/LogList/default.tpl
@@ -61,9 +61,14 @@
       {if !empty($log.context)}
         <div class="toggleNext">Context</div>
         <div class="toggleNext-content">
-          {if (!empty($log.context))}
-            <pre>{print_r($log.context, true)}</pre>
-          {/if}
+          <pre>{print_r($log.context, true)}</pre>
+        </div>
+      {/if}
+
+      {if !empty($log.loggerNotifications)}
+        <div class="toggleNext">Logger notifications</div>
+        <div class="toggleNext-content">
+          <pre>{print_r($log.loggerNotifications, true)}</pre>
         </div>
       {/if}
     </li>

--- a/library/CM/Http/Request/Abstract.php
+++ b/library/CM/Http/Request/Abstract.php
@@ -58,12 +58,12 @@ abstract class CM_Http_Request_Abstract {
         if (null !== $server) {
             foreach ($server as &$serverValue) {
                 if (is_string($serverValue)) {
-                    $serverValue = self::_sanitizeUtf($serverValue);
+                    $serverValue = CM_Util::sanitizeUtf($serverValue);
                 }
             }
             $this->_server = array_change_key_case($server);
         }
-        $uri = self::_sanitizeUtf((string) $uri);
+        $uri = CM_Util::sanitizeUtf((string) $uri);
         $this->setUri($uri);
 
         if ($sessionId = $this->getCookie('sessionId')) {
@@ -319,16 +319,16 @@ abstract class CM_Http_Request_Abstract {
 
         $querySanitized = [];
         foreach ($query as $key => $value) {
-            $key = self::_sanitizeUtf($key);
+            $key = CM_Util::sanitizeUtf($key);
 
             if (is_array($value)) {
                 array_walk_recursive($value, function (&$innerValue) {
                     if (is_string($innerValue)) {
-                        $innerValue = self::_sanitizeUtf($innerValue);
+                        $innerValue = CM_Util::sanitizeUtf($innerValue);
                     }
                 });
             } else {
-                $value = self::_sanitizeUtf($value);
+                $value = CM_Util::sanitizeUtf($value);
             }
 
             $querySanitized[$key] = $value;
@@ -687,13 +687,5 @@ abstract class CM_Http_Request_Abstract {
         }
 
         return self::factory($method, $uri, $headers, $server, $body);
-    }
-
-    /**
-     * @param string $value
-     * @return string
-     */
-    protected static function _sanitizeUtf($value) {
-        return mb_convert_encoding($value, 'UTF-8', 'UTF-8');
     }
 }

--- a/library/CM/Http/Request/Post.php
+++ b/library/CM/Http/Request/Post.php
@@ -40,7 +40,7 @@ class CM_Http_Request_Post extends CM_Http_Request_Abstract {
     public function getQuery() {
         if ($this->_bodyQuery === null) {
             if ($this->_bodyEncoding == self::ENCODING_JSON) {
-                $body = self::_sanitizeUtf($this->getBody());
+                $body = CM_Util::sanitizeUtf($this->getBody());
                 if (!is_array($this->_bodyQuery = json_decode($body, true))) {
                     throw new CM_Exception_Invalid('Cannot extract query from body', CM_Exception::WARN, ['body' => $body]);
                 }

--- a/library/CM/Log/Handler/MongoDb.php
+++ b/library/CM/Log/Handler/MongoDb.php
@@ -136,15 +136,15 @@ class CM_Log_Handler_MongoDb extends CM_Log_Handler_Abstract {
         array_walk_recursive($formattedRecord, function (&$value, $key) use (&$nonUtfBytesList) {
             if (is_string($value) && !mb_check_encoding($value)) {
                 $nonUtfBytesList[$key] = unpack('H*', $value)[1];
-                $value = 'SANITIZED: ' . mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+                $value = mb_convert_encoding($value, 'UTF-8', 'UTF-8');
             }
         });
 
         if (!empty($nonUtfBytesList)) {
-            $formattedRecord['context']['extra']['sanitized'] = true;
-        }
-        foreach ($nonUtfBytesList as $key => $nonUtfByte) {
-            $formattedRecord['context']['extra'][$key . '-UTF'] = $nonUtfByte;
+            $formattedRecord['loggerNotifications']['sanitizedFields'] = [];
+            foreach ($nonUtfBytesList as $key => $nonUtfByte) {
+                $formattedRecord['loggerNotifications']['sanitizedFields'][$key] = $nonUtfByte;
+            }
         }
 
         return $formattedRecord;

--- a/library/CM/Log/Handler/MongoDb.php
+++ b/library/CM/Log/Handler/MongoDb.php
@@ -132,11 +132,10 @@ class CM_Log_Handler_MongoDb extends CM_Log_Handler_Abstract {
      */
     protected function _sanitizeRecord(array $formattedRecord) {
         $nonUtfBytesList = [];
-
         array_walk_recursive($formattedRecord, function (&$value, $key) use (&$nonUtfBytesList) {
-            if (is_string($value) && !mb_check_encoding($value)) {
+            if (is_string($value) && !mb_check_encoding($value, 'UTF-8')) {
                 $nonUtfBytesList[$key] = unpack('H*', $value)[1];
-                $value = mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+                $value = CM_Util::sanitizeUtf($value);
             }
         });
 
@@ -146,7 +145,6 @@ class CM_Log_Handler_MongoDb extends CM_Log_Handler_Abstract {
                 $formattedRecord['loggerNotifications']['sanitizedFields'][$key] = $nonUtfByte;
             }
         }
-
         return $formattedRecord;
     }
 }

--- a/library/CM/Util.php
+++ b/library/CM/Util.php
@@ -581,4 +581,12 @@ class CM_Util {
         }
         return $result;
     }
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    public static function sanitizeUtf($value) {
+        return mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+    }
 }

--- a/tests/library/CM/Log/Handler/MongoDbTest.php
+++ b/tests/library/CM/Log/Handler/MongoDbTest.php
@@ -89,15 +89,14 @@ class CM_Log_Handler_MongoDbTest extends CMTest_TestCase {
         $sanitizedRecord = $this->callProtectedMethod($handler, '_sanitizeRecord', [$record]);
 
         $this->assertSame([
-            'foo'     => [
+            'foo'                 => [
                 'baz' => 'quux',
-                'bar' => 'SANITIZED: ?.',
+                'bar' => '?.',
             ],
-            'foo2'    => 2,
-            'context' => [
-                'extra' => [
-                    'sanitized' => true,
-                    'bar-UTF'   => 'c32e',
+            'foo2'                => 2,
+            'loggerNotifications' => [
+                'sanitizedFields' => [
+                    'bar' => 'c32e',
                 ]
             ],
         ], $sanitizedRecord);

--- a/tests/library/CM/UtilTest.php
+++ b/tests/library/CM/UtilTest.php
@@ -141,4 +141,8 @@ class CM_UtilTest extends CMTest_TestCase {
     public function testJsonDecodeInvalid() {
         CM_Util::jsonDecode('{[foo:bar)}');
     }
+    
+    public function testSanitizeUtf() {
+        $this->assertSame('?.', CM_Util::sanitizeUtf(pack("H*", 'c32e')));
+    }
 }


### PR DESCRIPTION
https://github.com/cargomedia/cm/issues/2235

>As discussed let's sanitize all the log entry values for all affected handlers (mongodb and fluentd and file?).
In mongodb for records that had values in invalid encoding we'll add a key sanitizedFields that contains a key/value hash of all sanitized values for debugging.
loggerNotifications: { sanitizedFields: {key1: value, key2: value} }
This should displayed next to the "context" in the admin.