### PR TITLE
Introduce CM_Frontend_JsonSerializable

### DIFF
--- a/library/CM/Frontend/JsonSerializable.php
+++ b/library/CM/Frontend/JsonSerializable.php
@@ -1,0 +1,29 @@
+<?php
+
+class CM_Frontend_JsonSerializable implements JsonSerializable {
+
+    /** @var array */
+    protected $_data;
+
+    /**
+     * @return array
+     */
+    public function getData() {
+        return $this->_data;
+    }
+
+    /**
+     * @param array $data
+     */
+    public function setData($data) {
+        $this->_data = $data;
+    }
+
+    public function __construct(array $data) {
+        $this->setData($data);
+    }
+
+    function jsonSerialize() {
+        return $this->getData();
+    }
+}

--- a/library/CM/Frontend/JsonSerializable.php
+++ b/library/CM/Frontend/JsonSerializable.php
@@ -6,6 +6,13 @@ class CM_Frontend_JsonSerializable implements JsonSerializable {
     protected $_data;
 
     /**
+     * @param array|null $data
+     */
+    public function __construct(array $data = null) {
+        $this->setData(null === $data ? [] : $data);
+    }
+
+    /**
      * @return array
      */
     public function getData() {
@@ -15,12 +22,8 @@ class CM_Frontend_JsonSerializable implements JsonSerializable {
     /**
      * @param array $data
      */
-    public function setData($data) {
+    public function setData(array $data) {
         $this->_data = $data;
-    }
-
-    public function __construct(array $data) {
-        $this->setData($data);
     }
 
     function jsonSerialize() {

--- a/tests/library/CM/Frontend/JsonSerializableTest.php
+++ b/tests/library/CM/Frontend/JsonSerializableTest.php
@@ -1,0 +1,26 @@
+<?php
+
+class CM_Frontend_JsonSerializableTest extends CMTest_TestCase {
+
+    public function testJsonSerialize() {
+        $obj = new CM_Frontend_JsonSerializable();
+        $this->assertEquals('[]', json_encode($obj));
+        $this->assertSame(['_class' => 'CM_Frontend_JsonSerializable'], CM_Params::encode($obj));
+
+        $obj->setData(['foo' => 1]);
+        $this->assertEquals('{"foo":1}', json_encode($obj));
+        $this->assertSame(['_class' => 'CM_Frontend_JsonSerializable', 'foo' => 1], CM_Params::encode($obj));
+
+        $obj->setData([
+            'bar' => new CM_Frontend_JsonSerializable(['foo' => 1])
+        ]);
+        $this->assertEquals('{"bar":{"foo":1}}', json_encode($obj));
+        $this->assertSame([
+            '_class' => 'CM_Frontend_JsonSerializable',
+            'bar'    => [
+                '_class' => 'CM_Frontend_JsonSerializable',
+                'foo'    => 1
+            ]
+        ], CM_Params::encode($obj));
+    }
+}


### PR DESCRIPTION
Useful to pass auto-converted `CM_Frontend_JsonSerializable` JS model to the client.