### PR TITLE
Set user online on CM_Model_StreamChannel_Message_User subscription

### DIFF
--- a/library/CM/Model/StreamChannel/Message/User.php
+++ b/library/CM/Model/StreamChannel/Message/User.php
@@ -8,8 +8,11 @@ class CM_Model_StreamChannel_Message_User extends CM_Model_StreamChannel_Message
     }
 
     public function onSubscribe(CM_Model_Stream_Subscribe $streamSubscribe) {
-        if (!$streamSubscribe->getUser()->getOnline()) {
-            $streamSubscribe->getUser()->setOnline(true);
+        if ($this->hasUser()) {
+            $user = $streamSubscribe->getUser();
+            if ($user && !$user->getOnline()) {
+                $user->setOnline(true);
+            }
         }
     }
 
@@ -19,7 +22,7 @@ class CM_Model_StreamChannel_Message_User extends CM_Model_StreamChannel_Message
     public function onUnsubscribe(CM_Model_Stream_Subscribe $streamSubscribe) {
         if ($this->hasUser()) {
             $user = $streamSubscribe->getUser();
-            if ($user && $user->getOnline() && !$this->isSubscriber($user, $streamSubscribe)) {
+            if ($user && !$this->isSubscriber($user, $streamSubscribe)) {
                 $offlineJob = new CM_User_OfflineJob();
                 $offlineJob->queueDelayed(CM_Model_User::OFFLINE_DELAY, ['user' => $user]);
             }

--- a/library/CM/Model/StreamChannel/Message/User.php
+++ b/library/CM/Model/StreamChannel/Message/User.php
@@ -19,7 +19,7 @@ class CM_Model_StreamChannel_Message_User extends CM_Model_StreamChannel_Message
     public function onUnsubscribe(CM_Model_Stream_Subscribe $streamSubscribe) {
         if ($this->hasUser()) {
             $user = $streamSubscribe->getUser();
-            if ($user && !$this->isSubscriber($user, $streamSubscribe)) {
+            if ($user && $user->getOnline() && !$this->isSubscriber($user, $streamSubscribe)) {
                 $offlineJob = new CM_User_OfflineJob();
                 $offlineJob->queueDelayed(CM_Model_User::OFFLINE_DELAY, ['user' => $user]);
             }

--- a/library/CM/Model/StreamChannel/Message/User.php
+++ b/library/CM/Model/StreamChannel/Message/User.php
@@ -8,6 +8,9 @@ class CM_Model_StreamChannel_Message_User extends CM_Model_StreamChannel_Message
     }
 
     public function onSubscribe(CM_Model_Stream_Subscribe $streamSubscribe) {
+        if (!$streamSubscribe->getUser()->getOnline()) {
+            $streamSubscribe->getUser()->setOnline(true);
+        }
     }
 
     public function onUnpublish(CM_Model_Stream_Publish $streamPublish) {

--- a/tests/library/CM/Model/StreamChannel/Message/UserTest.php
+++ b/tests/library/CM/Model/StreamChannel/Message/UserTest.php
@@ -28,4 +28,33 @@ class CM_Model_StreamChannel_Message_UserTest extends CMTest_TestCase {
         CMTest_TH::reinstantiateModel($user);
         $this->assertSame(false, $user->getOnline());
     }
+
+    public function testOnSubscribe() {
+        $user = CMTest_TH::createUser();
+        /** @var CM_Model_StreamChannel_Message_User $channel */
+        $channel = CM_Model_StreamChannel_Message_User::createStatic([
+            'key'         => CM_Model_StreamChannel_Message_User::getKeyByUser($user),
+            'adapterType' => CM_MessageStream_Adapter_SocketRedis::getTypeStatic(),
+        ]);
+        $subscribe = CMTest_TH::createStreamSubscribe($user, $channel);
+        $delayedQueue = new CM_Jobdistribution_DelayedQueue($this->getServiceManager());
+
+        $subscribe->delete();
+        $channel->delete();
+        $user->setOnline(true);
+
+        CMTest_TH::timeForward(CM_Model_User::OFFLINE_DELAY);
+        $delayedQueue->queueOutstanding();
+        CMTest_TH::reinstantiateModel($user);
+        $this->assertSame(false, $user->getOnline());
+
+        /** @var CM_Model_StreamChannel_Message_User $channel */
+        $channel = CM_Model_StreamChannel_Message_User::createStatic([
+            'key'         => CM_Model_StreamChannel_Message_User::getKeyByUser($user),
+            'adapterType' => CM_MessageStream_Adapter_SocketRedis::getTypeStatic(),
+        ]);
+        $subscribe = CMTest_TH::createStreamSubscribe($user, $channel);
+        CMTest_TH::reinstantiateModel($user);
+        $this->assertSame(true, $user->getOnline());
+    }
 }

--- a/tests/library/CM/Model/StreamChannel/Message/UserTest.php
+++ b/tests/library/CM/Model/StreamChannel/Message/UserTest.php
@@ -36,23 +36,8 @@ class CM_Model_StreamChannel_Message_UserTest extends CMTest_TestCase {
             'key'         => CM_Model_StreamChannel_Message_User::getKeyByUser($user),
             'adapterType' => CM_MessageStream_Adapter_SocketRedis::getTypeStatic(),
         ]);
-        $subscribe = CMTest_TH::createStreamSubscribe($user, $channel);
-        $delayedQueue = new CM_Jobdistribution_DelayedQueue($this->getServiceManager());
 
-        $subscribe->delete();
-        $channel->delete();
-        $user->setOnline(true);
-
-        CMTest_TH::timeForward(CM_Model_User::OFFLINE_DELAY);
-        $delayedQueue->queueOutstanding();
-        CMTest_TH::reinstantiateModel($user);
         $this->assertSame(false, $user->getOnline());
-
-        /** @var CM_Model_StreamChannel_Message_User $channel */
-        $channel = CM_Model_StreamChannel_Message_User::createStatic([
-            'key'         => CM_Model_StreamChannel_Message_User::getKeyByUser($user),
-            'adapterType' => CM_MessageStream_Adapter_SocketRedis::getTypeStatic(),
-        ]);
         $subscribe = CMTest_TH::createStreamSubscribe($user, $channel);
         CMTest_TH::reinstantiateModel($user);
         $this->assertSame(true, $user->getOnline());


### PR DESCRIPTION
`CM_User_OfflineJob` could be executed just before the user subscription when the page is reloaded. Then, the user will be considered as offline and he will not receive any published events from the `CM_Model_StreamChannel_Message_User`...

Let's consider that when a user subscribes to the stream channel, he is actually online!