### PR TITLE
smarty_function_date_time: allow to pass timeZone param as string

### DIFF
--- a/library/CM/SmartyPlugins/function.date.php
+++ b/library/CM/SmartyPlugins/function.date.php
@@ -9,6 +9,10 @@ function smarty_function_date($params, Smarty_Internal_Template $template) {
     $showTime = !empty($params['showTime']);
     $showWeekday = !empty($params['showWeekday']);
 
+    if (is_string($timeZone)) {
+        $timeZone = new \DateTimeZone($timeZone);
+    }
+
     if ($showTime) {
         $formatter = $render->getFormatterDate(IntlDateFormatter::SHORT, IntlDateFormatter::SHORT, null, $timeZone);
     } else {
@@ -18,7 +22,7 @@ function smarty_function_date($params, Smarty_Internal_Template $template) {
 
     if ($showWeekday) {
         $formatterWeekday = $render->getFormatterDate(IntlDateFormatter::NONE, IntlDateFormatter::NONE, 'eee', $timeZone);
-        $stringDate = $formatterWeekday->format($time) . ' ' .$stringDate;
+        $stringDate = $formatterWeekday->format($time) . ' ' . $stringDate;
     }
 
     return $stringDate;

--- a/library/CM/SmartyPlugins/function.date_time.php
+++ b/library/CM/SmartyPlugins/function.date_time.php
@@ -11,6 +11,9 @@ function smarty_function_date_time(array $params, Smarty_Internal_Template $temp
         $timeStamp = (int) $params['time'];
     }
     $timeZone = isset($params['timeZone']) ? $params['timeZone'] : null;
+    if (is_string($timeZone)) {
+        $timeZone = new \DateTimeZone($timeZone);
+    }
     $pattern = !empty($params['showSeconds']) ? 'H:mm:ss' : 'H:mm';
 
     $formatter = $render->getFormatterDate(IntlDateFormatter::NONE, IntlDateFormatter::NONE, $pattern, $timeZone);

--- a/tests/library/CM/SmartyPlugins/function.dateTest.php
+++ b/tests/library/CM/SmartyPlugins/function.dateTest.php
@@ -1,0 +1,49 @@
+<?php
+
+require_once CM_Util::getModulePath('CM') . 'library/CM/SmartyPlugins/function.date.php';
+
+class smarty_function_dateTest extends CMTest_TestCase {
+
+    /** @var CM_Frontend_Render */
+    private $_render;
+
+    /** @var Smarty_Internal_Template */
+    private $_template;
+
+    public function setUp() {
+        $smarty = new Smarty();
+        $this->_render = new CM_Frontend_Render();
+        $this->_template = $smarty->createTemplate('string:');
+        $this->_template->assignGlobal('render', $this->_render);
+    }
+
+    public function testRender() {
+        $time = strtotime('2003-02-01 12:34');
+        foreach ([[
+            'params'   => ['time' => $time],
+            'expected' => '2/1/03',
+        ], [
+            'params'   => ['time' => $time, 'showTime' => true],
+            'expected' => '2/1/03 12:34 PM',
+        ], [
+            'params'   => ['time' => $time, 'showTime' => true, 'timeZone' => new DateTimeZone('US/Eastern')],
+            'expected' => '2/1/03 7:34 AM',
+        ], [
+            'params'   => ['time' => $time, 'showTime' => true, 'timeZone' => 'US/Eastern'],
+            'expected' => '2/1/03 7:34 AM',
+        ], [
+            'params'   => ['time' => $time, 'showWeekday' => true],
+            'expected' => 'Sat 2/1/03',
+        ]] as $testData) {
+            $this->_assertSame($testData['expected'], $testData['params']);
+        }
+    }
+
+    /**
+     * @param string $expected
+     * @param array  $params
+     */
+    private function _assertSame($expected, array $params) {
+        $this->assertSame($expected, smarty_function_date($params, $this->_template));
+    }
+}

--- a/tests/library/CM/SmartyPlugins/function.dateTimeTest.php
+++ b/tests/library/CM/SmartyPlugins/function.dateTimeTest.php
@@ -35,6 +35,9 @@ class smarty_function_date_timeTest extends CMTest_TestCase {
         ], [
             'params'   => ['time' => $time, 'timeZone' => new DateTimeZone('US/Eastern')],
             'expected' => '7:34',
+        ], [
+            'params'   => ['time' => $time, 'timeZone' => 'US/Eastern'],
+            'expected' => '7:34',
         ]] as $testData) {
             $this->_assertSame($testData['expected'], $testData['params']);
         }


### PR DESCRIPTION
At the moment in `smarty_function_date_time` timeZone param must be a `DateTimeZone` or null (because used in CM_Frontend_Render::getFormatterDate()). Usage is quite painful as requires to create the object in a component or page, pass it to a template and then use it.

I'd allow timeZone param as a string using one of the [PHP supported timezones](http://php.net/manual/en/timezones.php) in order to create the `DateTimeZone` based on that. Of course w/o BC break because passing an object would still be allowed.

@njam wdyt?