### PR TITLE
Fluentd adapter sends incomplete stack-trace

### DIFF
--- a/library/CM/ExceptionHandling/SerializableException.php
+++ b/library/CM/ExceptionHandling/SerializableException.php
@@ -104,6 +104,11 @@ class CM_ExceptionHandling_SerializableException {
             foreach (array_reverse($exception->getTrace()) as $row) {
                 $trace[] = self::_extractTraceRow($row);
             }
+            $trace[] = [
+                'code' => '{throw}',
+                'line' => $this->line,
+                'file' => $this->file,
+            ];
             $this->trace = $trace;
         } catch (Exception $e) {
             $this->trace = null;

--- a/library/CM/Log/ContextFormatter/Cargomedia.php
+++ b/library/CM/Log/ContextFormatter/Cargomedia.php
@@ -60,10 +60,11 @@ class CM_Log_ContextFormatter_Cargomedia implements CM_Log_ContextFormatter_Inte
         if ($exception = $context->getException()) {
             $serializableException = new CM_ExceptionHandling_SerializableException($exception);
             $result['exception'] = [
-                'type'     => $serializableException->getClass(),
-                'message'  => $serializableException->getMessage(),
-                'stack'    => $serializableException->getTraceAsString(),
-                'metaInfo' => $serializableException->getMeta(),
+                'type'          => $serializableException->getClass(),
+                'message'       => $serializableException->getMessage(),
+                'stack'         => $serializableException->getTrace(),
+                'stackAsString' => $serializableException->getTraceAsString(),
+                'metaInfo'      => $serializableException->getMeta(),
             ];
         }
         return $result;

--- a/library/CM/Log/ContextFormatter/Cargomedia.php
+++ b/library/CM/Log/ContextFormatter/Cargomedia.php
@@ -59,12 +59,19 @@ class CM_Log_ContextFormatter_Cargomedia implements CM_Log_ContextFormatter_Inte
 
         if ($exception = $context->getException()) {
             $serializableException = new CM_ExceptionHandling_SerializableException($exception);
+            $stack = $serializableException->getTrace();
+            if (!empty($stack)) {
+                $stackAsString = trim(Functional\reduce_left(array_reverse($stack), function ($value, $index, $collection, $reduction) {
+                    return $reduction . '#' . $index . ' ' . $value['file'] . '(' . $value['line'] . '): ' . $value['code'] . PHP_EOL;
+                }, ''));
+            } else {
+                $stackAsString = $serializableException->getTraceAsString();
+            }
             $result['exception'] = [
-                'type'          => $serializableException->getClass(),
-                'message'       => $serializableException->getMessage(),
-                'stack'         => $serializableException->getTrace(),
-                'stackAsString' => $serializableException->getTraceAsString(),
-                'metaInfo'      => $serializableException->getMeta(),
+                'type'     => $serializableException->getClass(),
+                'message'  => $serializableException->getMessage(),
+                'stack'    => $stackAsString,
+                'metaInfo' => $serializableException->getMeta(),
             ];
         }
         return $result;

--- a/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
+++ b/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
@@ -63,8 +63,10 @@ class CM_Log_ContextFormatter_CargomediaTest extends CMTest_TestCase {
         $this->assertSame('CM_Exception_Invalid', $formattedRecord['exception']['type']);
         $this->assertSame('Bad', $formattedRecord['exception']['message']);
         $this->assertArrayHasKey('stack', $formattedRecord['exception']);
-        $this->assertInternalType('string', $formattedRecord['exception']['stack']);
+        $this->assertArrayHasKey('stackAsString', $formattedRecord['exception']);
+        $this->assertInternalType('array', $formattedRecord['exception']['stack']);
+        $this->assertInternalType('string', $formattedRecord['exception']['stackAsString']);
         $this->assertSame(['foo' => "'bar'"], $formattedRecord['exception']['metaInfo']);
-        $this->assertRegExp('/CM_Log_ContextFormatter_CargomediaTest->testGetRecordContext\(\)/', $formattedRecord['exception']['stack']);
+        $this->assertRegExp('/CM_Log_ContextFormatter_CargomediaTest->testGetRecordContext\(\)/', $formattedRecord['exception']['stackAsString']);
     }
 }

--- a/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
+++ b/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
@@ -63,10 +63,8 @@ class CM_Log_ContextFormatter_CargomediaTest extends CMTest_TestCase {
         $this->assertSame('CM_Exception_Invalid', $formattedRecord['exception']['type']);
         $this->assertSame('Bad', $formattedRecord['exception']['message']);
         $this->assertArrayHasKey('stack', $formattedRecord['exception']);
-        $this->assertArrayHasKey('stackAsString', $formattedRecord['exception']);
-        $this->assertInternalType('array', $formattedRecord['exception']['stack']);
-        $this->assertInternalType('string', $formattedRecord['exception']['stackAsString']);
+        $this->assertInternalType('string', $formattedRecord['exception']['stack']);
         $this->assertSame(['foo' => "'bar'"], $formattedRecord['exception']['metaInfo']);
-        $this->assertRegExp('/CM_Log_ContextFormatter_CargomediaTest->testGetRecordContext\(\)/', $formattedRecord['exception']['stackAsString']);
+        $this->assertRegExp('/library\/CM\/Log\/ContextFormatter\/CargomediaTest\.php\(\d+\)/', $formattedRecord['exception']['stack']);
     }
 }


### PR DESCRIPTION
More to the point, the file and line where an exception is instantiated is handled as separate information in exceptions and the adapter just sends the trace without this information.

For example, this is what our exception-handler prints to stdout.
```
CM_Exception_Invalid:  in /home/vagrant/sk/scripts/test.php on line 16
    0. {main} /home/vagrant/sk/scripts/test.php:0
    1. A->foo() /home/vagrant/sk/scripts/test.php:21
    2. A->bar() /home/vagrant/sk/scripts/test.php:12
```
and this is (part of) what the fluentd-logger sends to loggly. Note that `/home/vagrant/sk/scripts/test.php on line 16` is missing.
```php
array(1) {
  'exception' =>
  array(4) {
    'type' =>
    string(20) "CM_Exception_Invalid"
    'message' =>
    string(0) ""
    'stack' =>
    string(111) "#0 /home/vagrant/sk/scripts/test.php(12): A->bar()\n#1 /home/vagrant/sk/scripts/test.php(21): A->foo()\n#2 {main}"
    'metaInfo' =>
    array(0) {
    }
  }
}
```
The missing information could either be inserted into the trace, or sent as separate search-able fields. It wouldn't be bad to be able to search for filename and line, in case of non-unique error-messages.
Another related issue is that Exception::getTraceAsString() prints the trace in reverse order, which can be highly confusing.

fyi @tomaszdurka 