### PR TITLE
Include "deployVersion" in RPC responses

### DIFF
--- a/library/CM/Http/Response/RPC.php
+++ b/library/CM/Http/Response/RPC.php
@@ -20,6 +20,7 @@ class CM_Http_Response_RPC extends CM_Http_Response_Abstract {
             $output['error'] = array('type' => get_class($e), 'msg' => $e->getMessagePublic($this->getRender()), 'isPublic' => $e->isPublic());
         });
 
+        $output['deployVersion'] = CM_App::getInstance()->getDeployVersion();
         $this->setHeader('Content-Type', 'application/json');
         $this->_setContent(json_encode($output));
     }

--- a/tests/library/CM/Http/Response/RPCTest.php
+++ b/tests/library/CM/Http/Response/RPCTest.php
@@ -17,11 +17,7 @@ class CM_Http_Response_RPCTest extends CMTest_TestCase {
         $response->process();
 
         $responseData = CM_Params::jsonDecode($response->getContent());
-        $this->assertSame([
-            'success' => [
-                'result' => 5
-            ]
-        ], $responseData);
+        $this->assertSame(['result' => 5], $responseData['success']);
     }
 
     public function testProcessExceptionCatching() {
@@ -41,12 +37,10 @@ class CM_Http_Response_RPCTest extends CMTest_TestCase {
         $responseData = CM_Params::jsonDecode($response->getContent());
 
         $this->assertSame([
-            'error' => [
-                'type'     => 'CM_Exception_Invalid',
-                'msg'      => 'bar',
-                'isPublic' => true,
-            ]
-        ], $responseData);
+            'type'     => 'CM_Exception_Invalid',
+            'msg'      => 'bar',
+            'isPublic' => true,
+        ], $responseData['error']);
 
         $request->mockMethod('getQuery')->set(function () {
             throw new CM_Exception_Nonexistent('foo');
@@ -56,13 +50,11 @@ class CM_Http_Response_RPCTest extends CMTest_TestCase {
         $response->process();
         $responseData = CM_Params::jsonDecode($response->getContent());
 
-        $this->assertSame(
-            ['error' =>
-                 ['type'     => 'CM_Exception_Nonexistent',
-                  'msg'      => 'Internal server error',
-                  'isPublic' => false
-                 ]
-            ], $responseData);
+        $this->assertSame([
+            'type'     => 'CM_Exception_Nonexistent',
+            'msg'      => 'Internal server error',
+            'isPublic' => false
+        ], $responseData['error']);
     }
 
     public function testProcessingWithoutMethod() {
@@ -74,12 +66,10 @@ class CM_Http_Response_RPCTest extends CMTest_TestCase {
 
         $responseData = CM_Params::jsonDecode($response->getContent());
         $this->assertSame([
-            'error' => [
-                'type'     => 'CM_Exception_InvalidParam',
-                'msg'      => 'Internal server error',
-                'isPublic' => false,
-            ]
-        ], $responseData);
+            'type'     => 'CM_Exception_InvalidParam',
+            'msg'      => 'Internal server error',
+            'isPublic' => false,
+        ], $responseData['error']);
     }
 
     public function testProcessingInvalidMethod() {
@@ -91,12 +81,10 @@ class CM_Http_Response_RPCTest extends CMTest_TestCase {
 
         $responseData = CM_Params::jsonDecode($response->getContent());
         $this->assertSame([
-            'error' => [
-                'type'     => 'CM_Exception_InvalidParam',
-                'msg'      => 'Internal server error',
-                'isPublic' => false,
-            ]
-        ], $responseData);
+            'type'     => 'CM_Exception_InvalidParam',
+            'msg'      => 'Internal server error',
+            'isPublic' => false,
+        ], $responseData['error']);
     }
 
     public function testProcessReturnDeployVersion() {

--- a/tests/library/CM/Http/Response/RPCTest.php
+++ b/tests/library/CM/Http/Response/RPCTest.php
@@ -99,6 +99,21 @@ class CM_Http_Response_RPCTest extends CMTest_TestCase {
         ], $responseData);
     }
 
+    public function testProcessReturnDeployVersion() {
+        $body = CM_Params::jsonEncode([
+            'method' => 'CM_Http_Response_RPCTest.add',
+            'params' => [2, 3],
+        ]);
+        $site = $this->getMockSite();
+        $request = new CM_Http_Request_Post('/rpc', null, null, $body);
+        $response = CM_Http_Response_RPC::createFromRequest($request, $site, $this->getServiceManager());
+        $response->process();
+
+        $responseDecoded = CM_Params::jsonDecode($response->getContent());
+        $this->assertArrayHasKey('deployVersion', $responseDecoded);
+        $this->assertSame(CM_App::getInstance()->getDeployVersion(), $responseDecoded['deployVersion']);
+    }
+
     public static function rpc_add($foo, $bar) {
         return $foo + $bar;
     }


### PR DESCRIPTION
On the client side `cm.rpc()` calls `cm.ajax()` which expects a `deployVersion` key present in the response.

Currently that key is only available in the *ajax* response, but not in the *RPC* response.
