### PR TITLE
Ensure that users always subscribe to CM_Model_StreamChannel_Message_User

### DIFF
--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -985,6 +985,12 @@ var CM_App = CM_Class_Abstract.extend({
     _channelDispatchers: {},
 
     ready: function() {
+      if (!cm.options.stream.enabled) {
+        return;
+      }
+      if (!cm.options.stream.channel) {
+        return;
+      }
       if (cm.options.stream.channel.key && cm.options.stream.channel.type) {
         var channel = cm.options.stream.channel.key + ':' + cm.options.stream.channel.type;
         this._subscribe(channel);

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -23,6 +23,7 @@ var CM_App = CM_Class_Abstract.extend({
     this.date.ready();
     this.template.ready();
     this.router.ready();
+    this.stream.ready();
   },
 
   /**
@@ -982,6 +983,13 @@ var CM_App = CM_Class_Abstract.extend({
 
     /** @type {Object} */
     _channelDispatchers: {},
+
+    ready: function() {
+      if (cm.options.stream.channel.key && cm.options.stream.channel.type) {
+        var channel = cm.options.stream.channel.key + ':' + cm.options.stream.channel.type;
+        this._subscribe(channel);
+      }
+    },
 
     /**
      * @param {String} channelKey


### PR DESCRIPTION
`CM_Model_StreamChannel_Message_User` is used to [detect the presence of users](https://github.com/cargomedia/cm/blob/master/library/CM/Model/StreamChannel/Message/User.php#L10), so we should always subscribe to it.
On the other hand, user subscribes to [channels on demand](https://github.com/cargomedia/cm/blob/master/library/CM/App.js#L994), when they need to listen to some events.

We should enforce the `CM_Model_StreamChannel_Message_User` subscription, maybe at the `CM_App` level, wdyt @vogdb @njam ?
