### PR TITLE
Load service worker from site URL

### DIFF
--- a/library/CM/Frontend/Render.php
+++ b/library/CM/Frontend/Render.php
@@ -279,20 +279,16 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
      * @return string
      */
     public function getUrlServiceWorker() {
-        $site = $this->getSite();
-        $url = $site->getUrlBase();
-
         $pathParts = [];
         $pathParts[] = 'serviceworker';
         if ($this->getLanguage()) {
             $pathParts[] = $this->getLanguage()->getAbbreviation();
         }
-        $pathParts[] = $site->getId();
         $pathParts[] = CM_App::getInstance()->getDeployVersion();
-        $pathParts[] = 'default.js';
-        $url .= '/' . implode('-', $pathParts);
 
-        return $url;
+        $path = '/' . implode('-', $pathParts) . '.js';
+
+        return $this->getUrl($path);
     }
 
     /**

--- a/library/CM/Http/Response/Resource/Javascript/ServiceWorker.php
+++ b/library/CM/Http/Response/Resource/Javascript/ServiceWorker.php
@@ -14,7 +14,6 @@ class CM_Http_Response_Resource_Javascript_ServiceWorker extends CM_Http_Respons
             $request->setPath(str_replace('-', '/', $request->getPath()));
             $request->popPathPart(0);
             $request->popPathLanguage();
-            $site = $request->popPathSite();
             $deployVersion = $request->popPathPart(0);
             return new self($request, $site, $serviceManager);
         }


### PR DESCRIPTION
Continuation of https://github.com/cargomedia/cm/pull/2213

Old URL:
https://denkmal.dev.cargomedia.ch/serviceworker-80-en-1471464755.js

New URL:
https://denkmal.dev.cargomedia.ch/basel/serviceworker-en-1471464755.js

The scope is `https://denkmal.dev.cargomedia.ch/basel/`. Seems to work better in Firefox.