### PR TITLE
CM_Paging_ModelAbstract cache misses 

### DIFF
--- a/library/CM/Paging/Abstract.php
+++ b/library/CM/Paging/Abstract.php
@@ -295,12 +295,19 @@ abstract class CM_Paging_Abstract extends CM_Class_Abstract implements Iterator,
         $this->_flattenItems = (bool) $state;
     }
 
-
     /**
      * @return bool
      */
     protected function _canContainUnprocessableItems() {
         return ($this->_getStalenessChance() != 0);
+    }
+
+    protected function _clearItems() {
+        $this->_items = array();
+        $this->_itemsRaw = null;
+        $this->_itemsRawTree = null;
+        $this->_iteratorPosition = 0;
+        $this->_iteratorItems = null;
     }
 
     /**
@@ -379,14 +386,6 @@ abstract class CM_Paging_Abstract extends CM_Class_Abstract implements Iterator,
             return null;
         }
         return (int) $this->_pageOffset * $this->_pageSize;
-    }
-
-    private function _clearItems() {
-        $this->_items = array();
-        $this->_itemsRaw = null;
-        $this->_itemsRawTree = null;
-        $this->_iteratorPosition = 0;
-        $this->_iteratorItems = null;
     }
 
     private function _clearCount() {

--- a/library/CM/Paging/ModelAbstract.php
+++ b/library/CM/Paging/ModelAbstract.php
@@ -44,9 +44,7 @@ abstract class CM_Paging_ModelAbstract extends CM_Paging_Abstract {
             $this->_populateModelList($this->getItemsRaw());
         }
         $index = serialize($itemRaw);
-        if (/*!array_key_exists($index, $this->_modelList) ||*/
-            null === ($model = $this->_modelList[$index])
-        ) {
+        if (null === ($model = $this->_modelList[$index])) {
             throw new CM_Exception_Nonexistent('Model itemRaw has no data', null, ['itemRaw' => CM_Util::var_line($itemRaw)]);
         }
         return $model;

--- a/library/CM/Paging/ModelAbstract.php
+++ b/library/CM/Paging/ModelAbstract.php
@@ -10,14 +10,8 @@ abstract class CM_Paging_ModelAbstract extends CM_Paging_Abstract {
         $this->_modelList = null;
     }
 
-    public function setPage($page, $size) {
-        parent::setPage($page, $size);
-        $this->_modelList = null;
-        return $this;
-    }
-
-    public function filter(Closure $filter) {
-        parent::filter($filter);
+    protected function _clearItems() {
+        parent::_clearItems();
         $this->_modelList = null;
     }
 

--- a/library/CM/Paging/ModelAbstract.php
+++ b/library/CM/Paging/ModelAbstract.php
@@ -10,6 +10,17 @@ abstract class CM_Paging_ModelAbstract extends CM_Paging_Abstract {
         $this->_modelList = null;
     }
 
+    public function setPage($page, $size) {
+        parent::setPage($page, $size);
+        $this->_modelList = null;
+        return $this;
+    }
+
+    public function filter(Closure $filter) {
+        parent::filter($filter);
+        $this->_modelList = null;
+    }
+
     /**
      * @return int|null
      *
@@ -33,7 +44,9 @@ abstract class CM_Paging_ModelAbstract extends CM_Paging_Abstract {
             $this->_populateModelList($this->getItemsRaw());
         }
         $index = serialize($itemRaw);
-        if (null === ($model = $this->_modelList[$index])) {
+        if (/*!array_key_exists($index, $this->_modelList) ||*/
+            null === ($model = $this->_modelList[$index])
+        ) {
             throw new CM_Exception_Nonexistent('Model itemRaw has no data', null, ['itemRaw' => CM_Util::var_line($itemRaw)]);
         }
         return $model;

--- a/tests/library/CM/Paging/ModelAbstractTest.php
+++ b/tests/library/CM/Paging/ModelAbstractTest.php
@@ -61,7 +61,7 @@ class CM_Paging_ModelAbstractTest extends CMTest_TestCase {
         }
     }
 
-    public function testPagedPaging() {
+    public function testModelListInvalidation() {
         CM_Config::get()->CM_Model_Abstract->types[CM_Paging_ModelAbstractTest_ModelMock::getTypeStatic()] = 'CM_Paging_ModelAbstractTest_ModelMock';
         CM_Config::get()->CM_Model_Abstract->types[CM_Paging_ModelAbstractTest_ModelMock2::getTypeStatic()] = 'CM_Paging_ModelAbstractTest_ModelMock2';
         $model1 = CM_Paging_ModelAbstractTest_ModelMock::create('foo');

--- a/tests/library/CM/Paging/ModelAbstractTest.php
+++ b/tests/library/CM/Paging/ModelAbstractTest.php
@@ -60,6 +60,35 @@ class CM_Paging_ModelAbstractTest extends CMTest_TestCase {
             $this->assertContains('Array (', $ex->getMetaInfo()['itemRaw']);
         }
     }
+
+    public function testPagedPaging() {
+        CM_Config::get()->CM_Model_Abstract->types[CM_Paging_ModelAbstractTest_ModelMock::getTypeStatic()] = 'CM_Paging_ModelAbstractTest_ModelMock';
+        CM_Config::get()->CM_Model_Abstract->types[CM_Paging_ModelAbstractTest_ModelMock2::getTypeStatic()] = 'CM_Paging_ModelAbstractTest_ModelMock2';
+        $model1 = CM_Paging_ModelAbstractTest_ModelMock::create('foo');
+        $model2 = CM_Paging_ModelAbstractTest_ModelMock2::create('bar');
+        $model3 = CM_Paging_ModelAbstractTest_ModelMock::create('baz');
+        $model4 = CM_Paging_ModelAbstractTest_ModelMock::create('quux');
+        $model5 = CM_Paging_ModelAbstractTest_ModelMock::create('foobar');
+
+        $source = new CM_PagingSource_Array(array(
+            array('type' => $model1->getType(), 'id' => $model1->getId()),
+            array('type' => $model2->getType(), 'id' => $model2->getId()),
+            array('type' => $model3->getType(), 'id' => $model3->getId()),
+            array('type' => $model4->getType(), 'id' => $model4->getId()),
+            array('type' => $model5->getType(), 'id' => $model5->getId()),
+            array('type' => $model1->getType(), 'id' => 9999)
+        ));
+        $modelPaging = $this->getMockBuilder('CM_Paging_ModelAbstract')->setConstructorArgs(array($source))
+            ->getMockForAbstractClass();
+        /** @var CM_Paging_ModelAbstract $modelPaging */
+
+        $modelPaging->setPage(1, 2);
+        $this->assertEquals($model1, $modelPaging->getItem(0));
+        $this->assertEquals($model2, $modelPaging->getItem(1));
+        $modelPaging->setPage(2, 2);
+        $this->assertEquals($model3, $modelPaging->getItem(0));
+        $this->assertEquals($model4, $modelPaging->getItem(1));
+    }
 }
 
 class CM_Paging_ModelAbstractTest_ModelMock extends CM_Model_Abstract {


### PR DESCRIPTION
ErrorException: E_NOTICE: Undefined index: a:2:{s:2:"id";s:8:"16771914";s:4:"type";s:1:"2";} in .../CM/Paging/ModelAbstract.php on line 36

Most likely caused by https://github.com/cargomedia/cm/pull/2279