### PR TITLE
Add deprecation note to ServiceManager::getInstance()

### DIFF
--- a/library/CM/Service/Manager.php
+++ b/library/CM/Service/Manager.php
@@ -294,6 +294,8 @@ class CM_Service_Manager extends CM_Class_Abstract {
     }
 
     /**
+     * @deprecated Instead make your class manager-aware (`CM_Service_ManagerAwareInterface`) and pass the manager.
+     *
      * @return CM_Service_Manager
      */
     public static function getInstance() {


### PR DESCRIPTION
Just to act as a reminder to not use the singleton access everywhere.
Instead we should find ways how to pass the manager whenever we use it.

@tomaszdurka @alexispeter please review