### PR TITLE
Make sure failing memcache connection leads to error

### DIFF
--- a/library/CM/Memcache/Client.php
+++ b/library/CM/Memcache/Client.php
@@ -15,7 +15,7 @@ class CM_Memcache_Client extends CM_Class_Abstract {
         }
         $this->_memcache = new Memcache();
         foreach ($servers as $server) {
-            $this->_memcache->addserver($server['host'], $server['port'], true, 1, 1, 15, true, function ($host, $port) use ($logger) {
+            $this->_memcache->addserver($server['host'], $server['port'], true, 1, 1, 1, true, function ($host, $port) use ($logger) {
                 $context = new CM_Log_Context();
                 $context->setExtra([
                     'host' => $host,

--- a/library/CM/Memcache/Client.php
+++ b/library/CM/Memcache/Client.php
@@ -6,17 +6,22 @@ class CM_Memcache_Client extends CM_Class_Abstract {
     private $_memcache;
 
     /**
-     * @param array[] $servers
+     * @param array[]            $servers
+     * @param CM_Log_Logger|null $logger
      */
-    public function __construct(array $servers) {
+    public function __construct(array $servers, CM_Log_Logger $logger = null) {
+        if (null === $logger) {
+            $logger = CM_Service_Manager::getInstance()->getLogger();
+        }
         $this->_memcache = new Memcache();
         foreach ($servers as $server) {
-            $this->_memcache->addServer($server['host'], $server['port'], true, 1, 1, 15, true, function ($host, $port) {
-                $warning = new CM_Exception('Cannot connect to memcached server', CM_Exception::WARN, [
+            $this->_memcache->addserver($server['host'], $server['port'], true, 1, 1, 15, true, function ($host, $port) use ($logger) {
+                $context = new CM_Log_Context();
+                $context->setExtra([
                     'host' => $host,
                     'port' => $port,
                 ]);
-                CM_Bootloader::getInstance()->getExceptionHandler()->handleException($warning);
+                $logger->error('Cannot connect to memcached server', $context);
             });
         }
     }

--- a/library/CM/Memcache/Client.php
+++ b/library/CM/Memcache/Client.php
@@ -1,18 +1,16 @@
 <?php
 
-class CM_Memcache_Client extends CM_Class_Abstract {
+class CM_Memcache_Client extends CM_Class_Abstract implements CM_Service_ManagerAwareInterface {
+
+    use CM_Service_ManagerAwareTrait;
 
     /** @var \Memcache */
     private $_memcache;
 
     /**
-     * @param array[]            $servers
-     * @param CM_Log_Logger|null $logger
+     * @param array[] $servers
      */
-    public function __construct(array $servers, CM_Log_Logger $logger = null) {
-        if (null === $logger) {
-            $logger = CM_Service_Manager::getInstance()->getLogger();
-        }
+    public function __construct(array $servers) {
         $this->_memcache = new Memcache();
         foreach ($servers as $server) {
             $this->_memcache->addserver($server['host'], $server['port'], true, 1, 1, 1, true, function ($host, $port) use ($logger) {
@@ -21,7 +19,7 @@ class CM_Memcache_Client extends CM_Class_Abstract {
                     'host' => $host,
                     'port' => $port,
                 ]);
-                $logger->error('Cannot connect to memcached server', $context);
+                $this->getServiceManager()->getLogger()->error('Cannot connect to memcached server', $context);
             });
         }
     }

--- a/library/CM/Memcache/Client.php
+++ b/library/CM/Memcache/Client.php
@@ -13,7 +13,7 @@ class CM_Memcache_Client extends CM_Class_Abstract implements CM_Service_Manager
     public function __construct(array $servers) {
         $this->_memcache = new Memcache();
         foreach ($servers as $server) {
-            $this->_memcache->addserver($server['host'], $server['port'], true, 1, 1, 1, true, function ($host, $port) use ($logger) {
+            $this->_memcache->addserver($server['host'], $server['port'], true, 1, 1, 1, true, function ($host, $port) {
                 $context = new CM_Log_Context();
                 $context->setExtra([
                     'host' => $host,


### PR DESCRIPTION
Currently the `CM_Memcache_Client` constructor is:
```php
    public function __construct(array $servers) {
        $this->_memcache = new Memcache();
        foreach ($servers as $server) {
            $this->_memcache->addServer($server['host'], $server['port'], true, 1, 1, 15, true, function ($host, $port) {
                $warning = new CM_Exception('Cannot connect to memcached server', CM_Exception::WARN, [
                    'host' => $host,
                    'port' => $port,
                ]);
                CM_Bootloader::getInstance()->getExceptionHandler()->handleException($warning);
            });
        }
    }
```

The problem is that if *no* server at all can be reached we only log a warning.
How it should work:
- If we can't connect to a single server, but can connect to another one we should log a warning.
- If we can't connect to any server we should throw and abort with an error

Docu: http://php.net/manual/en/memcache.addserver.php

Currently it aborts, but only logs a warning.
Example stack trace:
```
CM_Exception: Cannot connect to memcached server in /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Memcache/Client.php on line 15
0. {main} at /home/example/releases/20160824142623/bin/cm line 0
1. CM_Cli_CommandManager->run(CM_Cli_Arguments) at /home/example/releases/20160824142623/bin/cm line 18
2. CM_Process->fork(Closure) at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Cli/CommandManager.php line 175
3. CM_Process->_fork(Closure, 9) at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Process.php line 65
4. CM_Process_ForkHandler->runAndSendWorkload() at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Process.php line 228
5. CM_Cli_CommandManager->{closure}(CM_Process_WorkloadResult) at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Process/ForkHandler.php line 76
6. CM_Cli_Command->run([], CM_InputStream_Readline, CM_OutputStream_Stream_StandardOutput, CM_OutputStream_Stream_StandardError) at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Cli/CommandManager.php line 288
7. call_user_func_array([], []) at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Cli/Command.php line 27
8. [internal function] at line
9. CM_Jobdistribution_JobWorker->run() at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Jobdistribution/Cli.php line 19
10. GearmanWorker->work() at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Jobdistribution/JobWorker.php line 28
11. [internal function] at line
12. CM_Jobdistribution_Job_Abstract->_executeJob(['user' => SK_User(15502737)]) at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Jobdistribution/Job/Abstract.php line 128
13. SK_Elasticsearch_UpdateJob_UserActivity->_execute(['user' => SK_User(15502737)]) at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Jobdistribution/Job/Abstract.php line 19
14. SK_Params->getUser('user') at /home/example/releases/20160824142623/library/SK/library/SK/Elasticsearch/UpdateJob/UserActivity.php line 7
15. CM_Params->getUser('user', NULL) at /home/example/releases/20160824142623/library/SK/library/SK/Params.php line 370
16. CM_Params->_get('user', NULL) at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Params.php line 314
17. CM_Params->decode([]) at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Params.php line 535
18. CM_Model_Abstract->fromArray([]) at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Params.php line 646
19. CM_Model_Abstract->factoryGeneric(102, []) at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Model/Abstract.php line 706
20. unserialize('C:7:"SK_User":58:{a:2:{s:2:"id...') at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Model/Abstract.php line 598
21. [internal function] at line
22. CM_Model_Abstract->_construct([], NULL) at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Model/Abstract.php line 191
23. CM_Model_Abstract->_getData() at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Model/Abstract.php line 50
24. CM_Model_StorageAdapter_Cache->load(102, []) at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Model/Abstract.php line 289
25. CM_Cache_Abstract->get('CM_Model_StorageAdapter_Cache_...') at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Model/StorageAdapter/Cache.php line 6
26. CM_Cache_Storage_Abstract->get('CM_Model_StorageAdapter_Cache_...') at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Cache/Abstract.php line 51
27. CM_Cache_Storage_Memcache->_get('/home/example/releases/201608...') at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Cache/Storage/Abstract.php line 36
28. CM_Memcache_Client->get('/home/example/releases/201608...') at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Cache/Storage/Memcache.php line 23
29. MemcachePool->get('/home/example/releases/201608...') at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Memcache/Client.php line 38
30. [internal function] at line
31. {throw} at /home/example/releases/20160824142623/vendor/cargomedia/cm/library/CM/Memcache/Client.php line 15
```

@zazabe or @alexispeter maybe for you?
cc @cargomedia/devops 