### PR TITLE
Unit tests: restore service-manager

### DIFF
--- a/library/CM/Service/Manager.php
+++ b/library/CM/Service/Manager.php
@@ -117,6 +117,17 @@ class CM_Service_Manager extends CM_Class_Abstract {
 
     /**
      * @param string $serviceName
+     * @param mixed  $instance
+     */
+    public function replaceInstance($serviceName, $instance) {
+        if ($this->has($serviceName)) {
+            $this->unregister($serviceName);
+        }
+        $this->registerInstance($serviceName, $instance);
+    }
+
+    /**
+     * @param string $serviceName
      */
     public function unregister($serviceName) {
         unset($this->_serviceConfigList[$serviceName]);
@@ -300,8 +311,16 @@ class CM_Service_Manager extends CM_Class_Abstract {
      */
     public static function getInstance() {
         if (null === self::$instance) {
-            self::$instance = new self();
+            self::setInstance(new self());
         }
         return self::$instance;
     }
+
+    /**
+     * @param CM_Service_Manager $serviceManager
+     */
+    public static function setInstance(CM_Service_Manager $serviceManager) {
+        self::$instance = $serviceManager;
+    }
+
 }

--- a/library/CM/Service/Manager.php
+++ b/library/CM/Service/Manager.php
@@ -323,4 +323,10 @@ class CM_Service_Manager extends CM_Class_Abstract {
         self::$instance = $serviceManager;
     }
 
+    function __clone() {
+        foreach ($this->_serviceInstanceList as &$instance) {
+            $instance = clone $instance;
+        }
+    }
+
 }

--- a/tests/helpers/CMTest/library/CMTest/TH.php
+++ b/tests/helpers/CMTest/library/CMTest/TH.php
@@ -24,12 +24,12 @@ class CMTest_TH {
     }
 
     public static function clearEnv() {
+        CM_Service_Manager::setInstance(clone self::$_serviceManagerBackup);
         self::clearDb();
         self::clearCache();
         self::timeReset();
         self::clearFilesystem();
         CM_Config::set(unserialize(self::$_configBackup));
-        CM_Service_Manager::setInstance(clone self::$_serviceManagerBackup);
     }
 
     public static function clearFilesystem() {

--- a/tests/helpers/CMTest/library/CMTest/TH.php
+++ b/tests/helpers/CMTest/library/CMTest/TH.php
@@ -14,7 +14,9 @@ class CMTest_TH {
         $loader->load($output);
 
         self::$_configBackup = serialize(CM_Config::get());
-        self::$_serviceManagerBackup = clone (CM_Service_Manager::getInstance());
+        $serviceManager = CM_Service_Manager::getInstance();
+        $serviceManager->resetServiceInstances();
+        self::$_serviceManagerBackup = clone $serviceManager;
 
         // Reset environment
         self::clearEnv();

--- a/tests/helpers/CMTest/library/CMTest/TH.php
+++ b/tests/helpers/CMTest/library/CMTest/TH.php
@@ -15,7 +15,7 @@ class CMTest_TH {
 
         self::$_configBackup = serialize(CM_Config::get());
         $serviceManager = CM_Service_Manager::getInstance();
-        $serviceManager->resetServiceInstances();
+        
         self::$_serviceManagerBackup = clone $serviceManager;
 
         // Reset environment

--- a/tests/helpers/CMTest/library/CMTest/TH.php
+++ b/tests/helpers/CMTest/library/CMTest/TH.php
@@ -5,6 +5,7 @@ class CMTest_TH {
     private static $_timeStart;
     private static $timeDelta = 0;
     private static $_configBackup;
+    private static $_serviceManagerBackup;
 
     public static function init() {
         $output = new CM_OutputStream_Null();
@@ -13,6 +14,7 @@ class CMTest_TH {
         $loader->load($output);
 
         self::$_configBackup = serialize(CM_Config::get());
+        self::$_serviceManagerBackup = clone (CM_Service_Manager::getInstance());
 
         // Reset environment
         self::clearEnv();
@@ -25,8 +27,8 @@ class CMTest_TH {
         self::clearCache();
         self::timeReset();
         self::clearFilesystem();
-        CM_Service_Manager::getInstance()->resetServiceInstances();
         CM_Config::set(unserialize(self::$_configBackup));
+        CM_Service_Manager::setInstance(clone self::$_serviceManagerBackup);
     }
 
     public static function clearFilesystem() {

--- a/tests/helpers/CMTest/library/CMTest/TH.php
+++ b/tests/helpers/CMTest/library/CMTest/TH.php
@@ -15,7 +15,6 @@ class CMTest_TH {
 
         self::$_configBackup = serialize(CM_Config::get());
         $serviceManager = CM_Service_Manager::getInstance();
-        
         self::$_serviceManagerBackup = clone $serviceManager;
 
         // Reset environment

--- a/tests/library/CM/Service/ManagerTest.php
+++ b/tests/library/CM/Service/ManagerTest.php
@@ -135,6 +135,17 @@ class CM_Service_ManagerTest extends CMTest_TestCase {
         $serviceManager->unregister('foo');
         $this->assertSame(false, $serviceManager->has('foo'));
     }
+
+    public function testReplaceInstance() {
+        $serviceManager = new CM_Service_Manager();
+        $this->assertSame(false, $serviceManager->has('foo'));
+
+        $serviceManager->replaceInstance('foo', 12.3);
+        $this->assertSame(12.3, $serviceManager->get('foo'));
+
+        $serviceManager->replaceInstance('foo', 12.4);
+        $this->assertSame(12.4, $serviceManager->get('foo'));
+    }
 }
 
 class DummyService implements CM_Service_ManagerAwareInterface {


### PR DESCRIPTION
- In `TH::clearEnv()` restore the service-manager that was backed up in `init()`.
- Introduce `SM::setInstance()`
- Introduce `SM::replaceInstance()`
