### PR TITLE
CM_Log_Logger::addMessage() fails if the logger has no global context

### DIFF
--- a/library/CM/Log/Logger.php
+++ b/library/CM/Log/Logger.php
@@ -85,7 +85,11 @@ class CM_Log_Logger {
         $message = (string) $message;
         $level = (int) $level;
 
-        $recordContext = clone $this->_context;
+        if (null !== $this->_context) {
+            $recordContext = clone $this->_context;
+        } else {
+            $recordContext = new CM_Log_Context();
+        }
         if ($context) {
             $recordContext->merge($context);
         }

--- a/library/CM/Log/Logger.php
+++ b/library/CM/Log/Logger.php
@@ -85,7 +85,7 @@ class CM_Log_Logger {
         $message = (string) $message;
         $level = (int) $level;
 
-        if (null !== $this->_context) {
+        if ($this->_context) {
             $recordContext = clone $this->_context;
         } else {
             $recordContext = new CM_Log_Context();

--- a/tests/library/CM/Log/LoggerTest.php
+++ b/tests/library/CM/Log/LoggerTest.php
@@ -57,19 +57,27 @@ class CM_Log_LoggerTest extends CMTest_TestCase {
         /** @var CM_Log_Context $loggerContext */
 
         $logger = $this->mockObject('CM_Log_Logger');
+
         $addRecord = $logger->mockMethod('_addRecord');
         /** @var CM_Log_Logger $logger */
-        $logger->setContext($loggerContext);
+        $message = 'messageFoo';
+        $level = CM_Log_Logger::INFO;
+        $context = new CM_Log_Context();
+        $logger->addMessage($message, $level, $context);
+        /** @var CM_Log_Record $record */
+        $record = $addRecord->getCall(0)->getArgument(0);
+        $this->assertSame($message, $record->getMessage());
+        $this->assertSame($level, $record->getLevel());
+        $this->assertSame(0, $merge->getCallCount());
 
+        $logger->setContext($loggerContext);
         $message = 'message';
         $level = CM_Log_Logger::DEBUG;
         $context = new CM_Log_Context();
-
         $logger->addMessage($message, $level, $context);
-
         $this->assertSame([$context], $merge->getCall(0)->getArguments());
         /** @var CM_Log_Record $record */
-        $record = $addRecord->getCall(0)->getArgument(0);
+        $record = $addRecord->getCall(1)->getArgument(0);
         $this->assertSame($message, $record->getMessage());
         $this->assertSame($level, $record->getLevel());
         $this->assertInstanceOf($loggerContextClass->getClassName(), $record->getContext());


### PR DESCRIPTION
If `CM_Log_Logger` is instantiated without any parameter, `CM_Log_Logger::addMessage()` fails with this error:
```
PHP Fatal error:  __clone method called on non-object in library/CM/Log/Logger.php on line 88
```

@fvovan ?