### PR TITLE
Allow to open a floatbox in a floatbox

### DIFF
--- a/client-vendor/after-body/jquery.floatbox/jquery.floatbox.js
+++ b/client-vendor/after-body/jquery.floatbox/jquery.floatbox.js
@@ -86,7 +86,7 @@
       this._getFocusElement().focus();
       this.$floatbox.trap();
 
-      this.$layer.data('floatbox', this);
+      $element.data('floatbox', this);
       $element.trigger('floatbox-open');
     },
     close: function() {
@@ -97,7 +97,7 @@
       if (this.$parent.length) {
         this.$parent.append($element);
       }
-      this.$layer.removeData('floatbox');
+      $element.removeData('floatbox');
       this.$layer.remove();
       $viewport.children('.floatbox-layer:last').addClass('active');
       if (lastFocusedElement) {
@@ -141,7 +141,7 @@
 
   $.fn.floatOut = function(options) {
     return this.each(function() {
-      if (!$(this).parents('.floatbox-layer').addBack().data('floatbox')) {
+      if (!$(this).data('floatbox')) {
         var floatbox = new $.floatbox(options);
         floatbox.show($(this));
       }
@@ -149,7 +149,7 @@
   };
   $.fn.floatIn = function() {
     return this.each(function() {
-      var floatbox = $(this).parents('.floatbox-layer').addBack().data('floatbox');
+      var floatbox = $(this).data('floatbox');
       if (floatbox) {
         floatbox.close();
       }

--- a/layout/default/Component/Example/tabs/example.less
+++ b/layout/default/Component/Example/tabs/example.less
@@ -8,3 +8,7 @@
 .usertext {
   display: inline;
 }
+
+.innerPopup {
+  display: none;
+}

--- a/layout/default/Component/Example/tabs/example.tpl
+++ b/layout/default/Component/Example/tabs/example.tpl
@@ -43,7 +43,6 @@
     <div class="innerPopup">
       <h3>Popup Level 3</h3>
       {button_link class="innerPopinComponent" label="PopIn()"}
-      {button_link class="innerPopoutComponent" label="PopOut()"}
     </div>
   </div>
 </div>

--- a/layout/default/Component/Example/tabs/example.tpl
+++ b/layout/default/Component/Example/tabs/example.tpl
@@ -6,6 +6,7 @@
 {button_link class="reloadComponent" label="reload()" icon="refresh"}
 {button_link class="popoutComponent" label="popOut()"}
 {button_link class="popinComponent" label="popIn()"}
+{button_link class="multiLevelPopoutComponent" label="Multi-level PopOut()"}
 {button_link class="loadComponent" label="load()"}
 {button_link class="loadComponent_callback" label="load()+callback"}
 {button_link class="removeComponent" label="remove()"}
@@ -27,4 +28,22 @@
 <div class="stream">
   <div class="output"></div>
   {button_link class="callAjaxPing" label="ajax: ping()"}
+</div>
+
+<div class="innerPopup first">
+  <h3>Popup Level 1</h3>
+  {button_link class="innerPopinComponent" label="PopIn()"}
+  {button_link class="innerPopoutComponent" label="PopOut()"}
+
+  <div class="innerPopup">
+    <h3>Popup Level 2</h3>
+    {button_link class="innerPopinComponent" label="PopIn()"}
+    {button_link class="innerPopoutComponent" label="PopOut()"}
+
+    <div class="innerPopup">
+      <h3>Popup Level 3</h3>
+      {button_link class="innerPopinComponent" label="PopIn()"}
+      {button_link class="innerPopoutComponent" label="PopOut()"}
+    </div>
+  </div>
 </div>

--- a/library/CM/Component/Example.js
+++ b/library/CM/Component/Example.js
@@ -13,6 +13,7 @@ var CM_Component_Example = CM_Component_Abstract.extend({
     'click .reloadComponent': 'reloadChinese',
     'click .popoutComponent': 'popOut',
     'click .popinComponent': 'popIn',
+    'click .multiLevelPopoutComponent': 'multiLevelPopout',
     'click .loadComponent': 'loadExample',
     'click .loadComponent_callback': 'loadExampleInline',
     'click .removeComponent': 'myRemove',
@@ -42,6 +43,47 @@ var CM_Component_Example = CM_Component_Abstract.extend({
 
   ready: function() {
     this.message("Component ready, uname: " + this.uname);
+  },
+
+  multiLevelPopout: function() {
+    var applyFloatbox = function($el) {
+      var $popout = $el.children('.innerPopoutComponent');
+      var $popin = $el.children('.innerPopinComponent');
+      var $subpopup = $el.children('.innerPopup');
+
+      $el.hide();
+      $subpopup.hide();
+      $popout.hide();
+
+      if (0 !== $subpopup.length) {
+        $popout.show();
+        $popout.on('click', function() {
+          applyFloatbox($subpopup);
+          $subpopup.floatOut();
+        });
+      }
+
+      $popin.on('click', function() {
+        $el.floatIn();
+      });
+
+      $el.on('floatbox-open', function(event) {
+        event.stopPropagation();
+        $el.show();
+      });
+
+      $el.on('floatbox-close', function(event) {
+        event.stopPropagation();
+        $popout.off('click');
+        $popin.off('click');
+        $el.off('floatbox-open floatbox-close');
+        $el.hide();
+      });
+    };
+
+    var $popup = this.$('.innerPopup.first').clone();
+    applyFloatbox($popup);
+    $popup.floatOut();
   },
 
   /**

--- a/library/CM/Component/Example.js
+++ b/library/CM/Component/Example.js
@@ -53,16 +53,11 @@ var CM_Component_Example = CM_Component_Abstract.extend({
 
       $el.hide();
       $subpopup.hide();
-      $popout.hide();
 
-      if (0 !== $subpopup.length) {
-        $popout.show();
-        $popout.on('click', function() {
-          applyFloatbox($subpopup);
-          $subpopup.floatOut();
-        });
-      }
-
+      $popout.on('click', function() {
+        applyFloatbox($subpopup);
+        $subpopup.floatOut();
+      });
       $popin.on('click', function() {
         $el.floatIn();
       });
@@ -71,7 +66,6 @@ var CM_Component_Example = CM_Component_Abstract.extend({
         event.stopPropagation();
         $el.show();
       });
-
       $el.on('floatbox-close', function(event) {
         event.stopPropagation();
         $popout.off('click');


### PR DESCRIPTION
Currently disallowed in `jquery.floatbox.js`:
```js
  $.fn.floatOut = function(options) {
    return this.each(function() {
      if (!$(this).parents('.floatbox-layer').addBack().data('floatbox')) {
        var floatbox = new $.floatbox(options);
        floatbox.show($(this));
      }
    });
  };
```

I think the reason for this check is just to make sure we don't open the *same element* in a floatbox multiple times.
Can we instead store that data attribute on the `$element` that is actually floating?

@zazabe maybe for you?
cc @christopheschwyzer 