### PR TITLE
ESC key doesn't close floatbox

### DIFF
--- a/client-vendor/after-body/jquery.floatbox/jquery.floatbox.js
+++ b/client-vendor/after-body/jquery.floatbox/jquery.floatbox.js
@@ -20,7 +20,7 @@
   $document.on('keydown.floatbox', function(e) {
     if (e.which == 27) { // Escape
       if ($viewport && $viewport.children().length) {
-        $viewport.children('.floatbox-layer:last').floatIn();
+        $viewport.children('.floatbox-layer:last').find('.floatbox-body > *').floatIn();
       }
     }
   });


### PR DESCRIPTION
As reported by @NicolasSchmutz 

Probably a regression via https://github.com/cargomedia/cm/pull/2301 ?

If we can't find a quick fix, let's revert that change because we don't need it yet.
