### PR TITLE
MongoDB based model constructor calls with invalid id

### DIFF
--- a/library/CM/Model/StorageAdapter/MongoDb.php
+++ b/library/CM/Model/StorageAdapter/MongoDb.php
@@ -15,7 +15,7 @@ class CM_Model_StorageAdapter_MongoDb extends CM_Model_StorageAdapter_AbstractAd
         $type = (int) $type;
         $id = (string) $id['id'];
         $collectionName = $this->_getCollectionName($type);
-        if (!$this->_checkIdFormat($id)) {
+        if (!$this->_isValidId($id)) {
             return false;
         }
         $mongoId = new MongoId($id);
@@ -79,7 +79,7 @@ class CM_Model_StorageAdapter_MongoDb extends CM_Model_StorageAdapter_AbstractAd
      * @param string $id
      * @return bool
      */
-    protected function _checkIdFormat($id) {
+    protected function _isValidId($id) {
         return (bool) preg_match('/^[0-9a-fA-F]{24}$/', (string) $id);
     }
 

--- a/library/CM/Model/StorageAdapter/MongoDb.php
+++ b/library/CM/Model/StorageAdapter/MongoDb.php
@@ -15,7 +15,7 @@ class CM_Model_StorageAdapter_MongoDb extends CM_Model_StorageAdapter_AbstractAd
         $type = (int) $type;
         $id = (string) $id['id'];
         $collectionName = $this->_getCollectionName($type);
-        if (!$this->_isValidId($id)) {
+        if (!MongoId::isValid($id)) {
             return false;
         }
         $mongoId = new MongoId($id);
@@ -73,14 +73,6 @@ class CM_Model_StorageAdapter_MongoDb extends CM_Model_StorageAdapter_AbstractAd
         $collectionName = $this->_getCollectionName($type);
         $mongoId = new MongoId($id);
         $this->_getMongoDb()->remove($collectionName, ['_id' => $mongoId]);
-    }
-
-    /**
-     * @param string $id
-     * @return bool
-     */
-    protected function _isValidId($id) {
-        return (bool) preg_match('/^[0-9a-fA-F]{24}$/', (string) $id);
     }
 
     /**

--- a/library/CM/Model/StorageAdapter/MongoDb.php
+++ b/library/CM/Model/StorageAdapter/MongoDb.php
@@ -15,6 +15,9 @@ class CM_Model_StorageAdapter_MongoDb extends CM_Model_StorageAdapter_AbstractAd
         $type = (int) $type;
         $id = (string) $id['id'];
         $collectionName = $this->_getCollectionName($type);
+        if (!$this->_checkIdFormat($id)) {
+            return false;
+        }
         $mongoId = new MongoId($id);
         $data = $this->_getMongoDb()->findOne($collectionName, ['_id' => $mongoId]);
         if (null === $data) {
@@ -70,6 +73,14 @@ class CM_Model_StorageAdapter_MongoDb extends CM_Model_StorageAdapter_AbstractAd
         $collectionName = $this->_getCollectionName($type);
         $mongoId = new MongoId($id);
         $this->_getMongoDb()->remove($collectionName, ['_id' => $mongoId]);
+    }
+
+    /**
+     * @param string $id
+     * @return bool
+     */
+    protected function _checkIdFormat($id) {
+        return (bool) preg_match('/^[0-9a-fA-F]{24}$/', (string) $id);
     }
 
     /**

--- a/tests/library/CM/Model/StorageAdapter/MongoDbTest.php
+++ b/tests/library/CM/Model/StorageAdapter/MongoDbTest.php
@@ -36,6 +36,8 @@ class CM_Model_StorageAdapter_MongoDbTest extends CMTest_TestCase {
 
         $this->assertEquals(['_id' => $id1['id'], '_type' => 99, 'foo' => 'foo1', 'bar' => 1], $adapter->load($type, $id1));
         $this->assertEquals(['_id' => $id2['id'], '_type' => 99, 'foo' => 'foo2', 'bar' => 2], $adapter->load($type, $id2));
+
+        $this->assertSame(false, $adapter->load($type, ['id' => '234']));
     }
 
     public function testLoad_nonExistent() {


### PR DESCRIPTION
If we pass malformed `$id` to model's based on mongo constructor we get 
`MongoException`. 
It's not handly to catch both that and `CM_Exception_Nonexistent`
How it would be better?
- to validate it (and throw `CM_Exception_Nonexistent` ) here https://github.com/cargomedia/cm/blob/6cdeb6109ee2b848c47aca119dce8301988e2fca/library/CM/Model/StorageAdapter/MongoDb.php#L18
- to create abstract `CM_Model_MongoBased` (or something) like that, overriding the constructor and implementing some mongo specific method.  Maybe it even should be a trait...

@njam wdyt?