### PR TITLE
Use Logger instead of handleException()

### DIFF
--- a/library/CM/Action/Email.php
+++ b/library/CM/Action/Email.php
@@ -17,7 +17,7 @@ class CM_Action_Email extends CM_Action_Abstract {
             $className = CM_Mail::_getClassName($typeEmail);
             $this->_nameEmail = ucwords(CM_Util::uncamelize(str_replace('_', '', preg_replace('#\\A[^_]++_[^_]++_#', '', $className)), ' '));
         } catch (CM_Class_Exception_TypeNotConfiguredException $exception) {
-            CM_Service_Manager::getInstance()->getLogger()->logException($exception, CM_Log_Logger::WARNING);
+            CM_Service_Manager::getInstance()->getLogger()->logException($exception, CM_Log_Logger::WARNING, 'Unrecognized mail type when creating mail action');
             $this->_nameEmail = (string) $typeEmail;
         }
     }

--- a/library/CM/Action/Email.php
+++ b/library/CM/Action/Email.php
@@ -17,8 +17,7 @@ class CM_Action_Email extends CM_Action_Abstract {
             $className = CM_Mail::_getClassName($typeEmail);
             $this->_nameEmail = ucwords(CM_Util::uncamelize(str_replace('_', '', preg_replace('#\\A[^_]++_[^_]++_#', '', $className)), ' '));
         } catch (CM_Class_Exception_TypeNotConfiguredException $exception) {
-            $exception->setSeverity(CM_Exception::WARN);
-            CM_Bootloader::getInstance()->getExceptionHandler()->handleException($exception);
+            CM_Service_Manager::getInstance()->getLogger()->logException($exception, CM_Log_Logger::WARNING);
             $this->_nameEmail = (string) $typeEmail;
         }
     }

--- a/library/CM/Action/Email.php
+++ b/library/CM/Action/Email.php
@@ -17,7 +17,7 @@ class CM_Action_Email extends CM_Action_Abstract {
             $className = CM_Mail::_getClassName($typeEmail);
             $this->_nameEmail = ucwords(CM_Util::uncamelize(str_replace('_', '', preg_replace('#\\A[^_]++_[^_]++_#', '', $className)), ' '));
         } catch (CM_Class_Exception_TypeNotConfiguredException $exception) {
-            CM_Service_Manager::getInstance()->getLogger()->logException($exception, CM_Log_Logger::WARNING, 'Unrecognized mail type when creating mail action');
+            CM_Service_Manager::getInstance()->getLogger()->warning('Unrecognized mail type when creating mail action', (new CM_Log_Context())->setException($exception));
             $this->_nameEmail = (string) $typeEmail;
         }
     }

--- a/library/CM/Bootloader.php
+++ b/library/CM/Bootloader.php
@@ -163,7 +163,7 @@ class CM_Bootloader {
             $code();
             return 0;
         } catch (Exception $e) {
-            self::getExceptionHandler()->handleException($e);
+            $this->getExceptionHandler()->handleException($e);
             return 1;
         }
     }

--- a/library/CM/ExceptionHandling/Handler/Abstract.php
+++ b/library/CM/ExceptionHandling/Handler/Abstract.php
@@ -82,7 +82,7 @@ abstract class CM_ExceptionHandling_Handler_Abstract implements CM_Service_Manag
             $this->_printException($exception);
         }
         $logLevel = CM_Log_Logger::severityToLevel($severity);
-        $this->_logException($exception, $logLevel);
+        $this->getServiceManager()->getLogger()->logException($exception, $logLevel);
     }
 
     /**
@@ -102,16 +102,5 @@ abstract class CM_ExceptionHandling_Handler_Abstract implements CM_Service_Manag
      */
     private function _getPrintSeverityMin() {
         return $this->_printSeverityMin;
-    }
-
-    /**
-     * @param Exception $exception
-     * @param  int      $logLevel
-     * @throws CM_Exception_Invalid
-     */
-    protected function _logException(Exception $exception, $logLevel) {
-        $context = new CM_Log_Context();
-        $context->setException($exception);
-        $this->getServiceManager()->getLogger()->addMessage('Application error', $logLevel, $context);
     }
 }

--- a/library/CM/ExceptionHandling/Handler/Abstract.php
+++ b/library/CM/ExceptionHandling/Handler/Abstract.php
@@ -82,7 +82,7 @@ abstract class CM_ExceptionHandling_Handler_Abstract implements CM_Service_Manag
             $this->_printException($exception);
         }
         $logLevel = CM_Log_Logger::severityToLevel($severity);
-        $this->getServiceManager()->getLogger()->logException($exception, $logLevel);
+        $this->getServiceManager()->getLogger()->addMessage('Application error', $logLevel, (new CM_Log_Context())->setException($exception));
     }
 
     /**

--- a/library/CM/Jobdistribution/Cli.php
+++ b/library/CM/Jobdistribution/Cli.php
@@ -7,6 +7,7 @@ class CM_Jobdistribution_Cli extends CM_Cli_Runnable_Abstract {
      */
     public function startWorker() {
         $worker = new CM_Jobdistribution_JobWorker();
+        $worker->setServiceManager($this->getServiceManager());
         foreach (CM_Jobdistribution_Job_Abstract::getClassChildren() as $jobClassName) {
             /** @var CM_Jobdistribution_Job_Abstract $job */
             $job = new $jobClassName();

--- a/library/CM/Jobdistribution/JobWorker.php
+++ b/library/CM/Jobdistribution/JobWorker.php
@@ -1,6 +1,8 @@
 <?php
 
-class CM_Jobdistribution_JobWorker extends CM_Class_Abstract {
+class CM_Jobdistribution_JobWorker extends CM_Class_Abstract implements CM_Service_ManagerAwareInterface {
+
+    use CM_Service_ManagerAwareTrait;
 
     /** @var GearmanWorker */
     private $_gearmanWorker;
@@ -27,7 +29,7 @@ class CM_Jobdistribution_JobWorker extends CM_Class_Abstract {
                 CM_Cache_Storage_Runtime::getInstance()->flush();
                 $workFailed = !$this->_getGearmanWorker()->work();
             } catch (Exception $ex) {
-                CM_Service_Manager::getInstance()->getLogger()->logException($ex);
+                $this->getServiceManager()->getLogger()->logException($ex);
             }
             if ($workFailed) {
                 throw new CM_Exception_Invalid('Worker failed');

--- a/library/CM/Jobdistribution/JobWorker.php
+++ b/library/CM/Jobdistribution/JobWorker.php
@@ -27,19 +27,12 @@ class CM_Jobdistribution_JobWorker extends CM_Class_Abstract {
                 CM_Cache_Storage_Runtime::getInstance()->flush();
                 $workFailed = !$this->_getGearmanWorker()->work();
             } catch (Exception $ex) {
-                $this->_handleException($ex);
+                CM_Service_Manager::getInstance()->getLogger()->logException($ex);
             }
             if ($workFailed) {
                 throw new CM_Exception_Invalid('Worker failed');
             }
         }
-    }
-
-    /**
-     * @param Exception $exception
-     */
-    protected function _handleException(Exception $exception) {
-        CM_Bootloader::getInstance()->getExceptionHandler()->handleException($exception);
     }
 
     /**

--- a/library/CM/Jobdistribution/JobWorker.php
+++ b/library/CM/Jobdistribution/JobWorker.php
@@ -29,7 +29,7 @@ class CM_Jobdistribution_JobWorker extends CM_Class_Abstract implements CM_Servi
                 CM_Cache_Storage_Runtime::getInstance()->flush();
                 $workFailed = !$this->_getGearmanWorker()->work();
             } catch (Exception $ex) {
-                $this->getServiceManager()->getLogger()->logException($ex);
+                $this->getServiceManager()->getLogger()->addMessage('Worker failed', CM_Log_Logger::exceptionToLevel($ex), (new CM_Log_Context())->setException($ex));
             }
             if ($workFailed) {
                 throw new CM_Exception_Invalid('Worker failed');

--- a/library/CM/Log/Context.php
+++ b/library/CM/Log/Context.php
@@ -89,13 +89,16 @@ class CM_Log_Context {
 
     /**
      * @param Exception|null $exception
+     * @return $this
      */
     public function setException($exception) {
         $this->_exception = $exception;
+        return $this;
     }
 
     /**
      * @param array $extra
+     * @return $this
      * @throws CM_Exception_Invalid
      */
     public function setExtra(array $extra) {
@@ -105,8 +108,8 @@ class CM_Log_Context {
         })) {
             throw new CM_Exception_Invalid('Object can not be passed to "Extra"');
         }
-
         $this->_extra = $extra;
+        return $this;
     }
 
     /**

--- a/library/CM/Log/Logger.php
+++ b/library/CM/Log/Logger.php
@@ -142,15 +142,27 @@ class CM_Log_Logger {
     }
 
     /**
-     * @param Exception $exception
-     * @param int|null  $level
+     * @param Exception   $exception
+     * @param int|null    $level
+     * @param string|null $message
      * @return CM_Log_Logger
      */
-    public function logException(Exception $exception, $level = null) {
+    public function logException(Exception $exception, $level = null, $message = null) {
         if (null === $level) {
             $level = self::exceptionToLevel($exception);
         }
-        return $this->addMessage('Application error', $level, (new CM_Log_Context())->setException($exception));
+        if (null === $message) {
+            if ($exception instanceof CM_Exception && '' !== $exception->getMessage()) {
+                $message = $exception->getMessage();
+            } else {
+                $message = 'Application error';
+            }
+        }
+        $context = (new CM_Log_Context())->setException($exception);
+        if ($exception instanceof CM_Exception) {
+            $context->setExtra($exception->getMetaInfo());
+        }
+        return $this->addMessage($message, $level, $context);
     }
 
     /**

--- a/library/CM/Log/Logger.php
+++ b/library/CM/Log/Logger.php
@@ -142,27 +142,16 @@ class CM_Log_Logger {
     }
 
     /**
-     * @param Exception   $exception
-     * @param int|null    $level
-     * @param string|null $message
+     * @param Exception $exception
+     * @param int|null  $level
      * @return CM_Log_Logger
      */
-    public function logException(Exception $exception, $level = null, $message = null) {
+    public function logException(Exception $exception, $level = null) {
         if (null === $level) {
             $level = self::exceptionToLevel($exception);
         }
-        if (null === $message) {
-            if ($exception instanceof CM_Exception && '' !== $exception->getMessage()) {
-                $message = $exception->getMessage();
-            } else {
-                $message = 'Application error';
-            }
-        }
         $context = (new CM_Log_Context())->setException($exception);
-        if ($exception instanceof CM_Exception) {
-            $context->setExtra($exception->getMetaInfo());
-        }
-        return $this->addMessage($message, $level, $context);
+        return $this->addMessage('Application error', $level, $context);
     }
 
     /**

--- a/library/CM/Log/Logger.php
+++ b/library/CM/Log/Logger.php
@@ -142,19 +142,6 @@ class CM_Log_Logger {
     }
 
     /**
-     * @param Exception $exception
-     * @param int|null  $level
-     * @return CM_Log_Logger
-     */
-    public function logException(Exception $exception, $level = null) {
-        if (null === $level) {
-            $level = self::exceptionToLevel($exception);
-        }
-        $context = (new CM_Log_Context())->setException($exception);
-        return $this->addMessage('Application error', $level, $context);
-    }
-
-    /**
      * @param CM_Log_Record $record
      * @return CM_Log_Logger
      */

--- a/library/CM/Log/Logger.php
+++ b/library/CM/Log/Logger.php
@@ -142,6 +142,18 @@ class CM_Log_Logger {
     }
 
     /**
+     * @param Exception $exception
+     * @param int|null  $level
+     * @return CM_Log_Logger
+     */
+    public function logException(Exception $exception, $level = null) {
+        if (null === $level) {
+            $level = self::exceptionToLevel($exception);
+        }
+        return $this->addMessage('Application error', $level, (new CM_Log_Context())->setException($exception));
+    }
+
+    /**
      * @param CM_Log_Record $record
      * @return CM_Log_Logger
      */

--- a/library/CM/Memcache/Client.php
+++ b/library/CM/Memcache/Client.php
@@ -13,8 +13,8 @@ class CM_Memcache_Client extends CM_Class_Abstract implements CM_Service_Manager
     public function __construct(array $servers) {
         $this->_memcache = new Memcache();
         foreach ($servers as $server) {
-            $this->_memcache->addServer($server['host'], $server['port'], true, 1, 1, 15, true, function ($host, $port) {
-                $this->getServiceManager()->getLogger()->warning('Cannot connect to memcached server', (new CM_Log_Context())->setExtra([
+            $this->_memcache->addServer($server['host'], $server['port'], true, 1, 1, 1, true, function ($host, $port) {
+                $this->getServiceManager()->getLogger()->error('Cannot connect to memcached server', (new CM_Log_Context())->setExtra([
                     'host' => $host,
                     'port' => $port,
                 ]));

--- a/library/CM/Memcache/Client.php
+++ b/library/CM/Memcache/Client.php
@@ -1,6 +1,8 @@
 <?php
 
-class CM_Memcache_Client extends CM_Class_Abstract {
+class CM_Memcache_Client extends CM_Class_Abstract implements CM_Service_ManagerAwareInterface {
+
+    use CM_Service_ManagerAwareTrait;
 
     /** @var \Memcache */
     private $_memcache;
@@ -12,11 +14,10 @@ class CM_Memcache_Client extends CM_Class_Abstract {
         $this->_memcache = new Memcache();
         foreach ($servers as $server) {
             $this->_memcache->addServer($server['host'], $server['port'], true, 1, 1, 15, true, function ($host, $port) {
-                $warning = new CM_Exception('Cannot connect to memcached server', CM_Exception::WARN, [
+                $this->getServiceManager()->getLogger()->warning('Cannot connect to memcached server', (new CM_Log_Context())->setExtra([
                     'host' => $host,
                     'port' => $port,
-                ]);
-                CM_Bootloader::getInstance()->getExceptionHandler()->handleException($warning);
+                ]));
             });
         }
     }

--- a/library/CM/MessageStream/Adapter/SocketRedis.php
+++ b/library/CM/MessageStream/Adapter/SocketRedis.php
@@ -120,7 +120,7 @@ class CM_MessageStream_Adapter_SocketRedis extends CM_MessageStream_Adapter_Abst
                             }
                         }
                     } catch (CM_Exception $e) {
-                        $this->getServiceManager()->getLogger()->logException($e, CM_Log_Logger::WARNING);
+                        $this->getServiceManager()->getLogger()->logException($e, CM_Log_Logger::WARNING, 'Cannot add socket redis subscriber when synchronizing status');
                     }
                 }
             } catch (CM_Exception $e) {

--- a/library/CM/MessageStream/Adapter/SocketRedis.php
+++ b/library/CM/MessageStream/Adapter/SocketRedis.php
@@ -118,13 +118,11 @@ class CM_MessageStream_Adapter_SocketRedis extends CM_MessageStream_Adapter_Abst
                             }
                         }
                     } catch (CM_Exception $e) {
-                        $e->setSeverity(CM_Exception::WARN);
-                        $this->_handleException($e);
+                        CM_Service_Manager::getInstance()->getLogger()->logException($e, CM_Log_Logger::WARNING);
                     }
                 }
             } catch (CM_Exception $e) {
-                $e->setSeverity(CM_Exception::WARN);
-                $this->_handleException($e);
+                CM_Service_Manager::getInstance()->getLogger()->logException($e, CM_Log_Logger::WARNING);
             }
         }
     }
@@ -229,13 +227,6 @@ class CM_MessageStream_Adapter_SocketRedis extends CM_MessageStream_Adapter_Abst
                 'http://' . $server['httpHost'] . ':' . $server['httpPort'])));
         }
         return $statusData;
-    }
-
-    /**
-     * @param CM_Exception $exception
-     */
-    protected function _handleException(CM_Exception $exception) {
-        CM_Bootloader::getInstance()->getExceptionHandler()->handleException($exception);
     }
 
     /**

--- a/library/CM/MessageStream/Adapter/SocketRedis.php
+++ b/library/CM/MessageStream/Adapter/SocketRedis.php
@@ -1,6 +1,8 @@
 <?php
 
-class CM_MessageStream_Adapter_SocketRedis extends CM_MessageStream_Adapter_Abstract {
+class CM_MessageStream_Adapter_SocketRedis extends CM_MessageStream_Adapter_Abstract implements CM_Service_ManagerAwareInterface {
+
+    use CM_Service_ManagerAwareTrait;
 
     const SYNCHRONIZE_DELAY = 10;
 
@@ -118,11 +120,11 @@ class CM_MessageStream_Adapter_SocketRedis extends CM_MessageStream_Adapter_Abst
                             }
                         }
                     } catch (CM_Exception $e) {
-                        CM_Service_Manager::getInstance()->getLogger()->logException($e, CM_Log_Logger::WARNING);
+                        $this->getServiceManager()->getLogger()->logException($e, CM_Log_Logger::WARNING);
                     }
                 }
             } catch (CM_Exception $e) {
-                CM_Service_Manager::getInstance()->getLogger()->logException($e, CM_Log_Logger::WARNING);
+                $this->getServiceManager()->getLogger()->logException($e, CM_Log_Logger::WARNING);
             }
         }
     }

--- a/library/CM/MessageStream/Adapter/SocketRedis.php
+++ b/library/CM/MessageStream/Adapter/SocketRedis.php
@@ -120,11 +120,11 @@ class CM_MessageStream_Adapter_SocketRedis extends CM_MessageStream_Adapter_Abst
                             }
                         }
                     } catch (CM_Exception $e) {
-                        $this->getServiceManager()->getLogger()->logException($e, CM_Log_Logger::WARNING, 'Cannot add socket redis subscriber when synchronizing status');
+                        $this->getServiceManager()->getLogger()->warning('Cannot add socket redis subscriber when synchronizing status', (new CM_Log_Context())->setException($e));
                     }
                 }
             } catch (CM_Exception $e) {
-                $this->getServiceManager()->getLogger()->logException($e, CM_Log_Logger::WARNING);
+                $this->getServiceManager()->getLogger()->warning('Error synchronizing socket redis status', (new CM_Log_Context())->setException($e));
             }
         }
     }

--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -228,7 +228,7 @@ class CM_Process {
                 $forkHandler->runAndSendWorkload();
                 $forkHandler->closeIpcStream();
             } catch (Exception $e) {
-                CM_Bootloader::getInstance()->getExceptionHandler()->handleException($e);
+                CM_Service_Manager::getInstance()->getLogger()->logException($e);
             }
             exit;
         }
@@ -279,8 +279,7 @@ class CM_Process {
                         $this->unbind('exit', [$this, 'killChildren']);
                     }
                     if ($keepAlive) {
-                        $warning = new CM_Exception('Respawning dead child.', CM_Exception::WARN, ['pid' => $pid]);
-                        CM_Bootloader::getInstance()->getExceptionHandler()->handleException($warning);
+                        CM_Service_Manager::getInstance()->getLogger()->warning('Respawning dead child.', (new CM_Log_Context())->setExtra(['pid' => $pid]));
                         usleep(self::RESPAWN_TIMEOUT * 1000000);
                         $this->_fork($forkHandler->getWorkload(), $forkHandler->getIdentifier());
                     }

--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -228,7 +228,7 @@ class CM_Process {
                 $forkHandler->runAndSendWorkload();
                 $forkHandler->closeIpcStream();
             } catch (Exception $e) {
-                CM_Service_Manager::getInstance()->getLogger()->logException($e);
+                CM_Service_Manager::getInstance()->getLogger()->addMessage('Forking workload failed', CM_Log_Logger::exceptionToLevel($e), (new CM_Log_Context())->setException($e));
             }
             exit;
         }

--- a/library/CM/Process/ForkHandler.php
+++ b/library/CM/Process/ForkHandler.php
@@ -76,7 +76,7 @@ class CM_Process_ForkHandler {
             $return = $workload($result);
             $result->setResult($return);
         } catch (Exception $e) {
-            CM_Service_Manager::getInstance()->getLogger()->logException($e);
+            CM_Service_Manager::getInstance()->getLogger()->logException($e, null, 'Cannot execute workload in forked child process');
             $result->setException($e);
         }
 

--- a/library/CM/Process/ForkHandler.php
+++ b/library/CM/Process/ForkHandler.php
@@ -76,7 +76,7 @@ class CM_Process_ForkHandler {
             $return = $workload($result);
             $result->setResult($return);
         } catch (Exception $e) {
-            CM_Bootloader::getInstance()->getExceptionHandler()->handleException($e);
+            CM_Service_Manager::getInstance()->getLogger()->logException($e);
             $result->setException($e);
         }
 

--- a/library/CM/Process/ForkHandler.php
+++ b/library/CM/Process/ForkHandler.php
@@ -76,7 +76,7 @@ class CM_Process_ForkHandler {
             $return = $workload($result);
             $result->setResult($return);
         } catch (Exception $e) {
-            CM_Service_Manager::getInstance()->getLogger()->logException($e, null, 'Cannot execute workload in forked child process');
+            CM_Service_Manager::getInstance()->getLogger()->logException($e);
             $result->setException($e);
         }
 

--- a/library/CM/Process/ForkHandler.php
+++ b/library/CM/Process/ForkHandler.php
@@ -76,7 +76,7 @@ class CM_Process_ForkHandler {
             $return = $workload($result);
             $result->setResult($return);
         } catch (Exception $e) {
-            CM_Service_Manager::getInstance()->getLogger()->logException($e);
+            CM_Service_Manager::getInstance()->getLogger()->addMessage('Forked workload failed', CM_Log_Logger::exceptionToLevel($e), (new CM_Log_Context())->setException($e));
             $result->setException($e);
         }
 

--- a/library/CM/Redis/Client.php
+++ b/library/CM/Redis/Client.php
@@ -347,7 +347,7 @@ class CM_Redis_Client extends CM_Class_Abstract {
                     $response = $callback($message->channel, $message->payload);
                 }
             } catch (Exception $e) {
-                CM_Bootloader::getInstance()->getExceptionHandler()->handleException($e);
+                CM_Service_Manager::getInstance()->getLogger()->logException($e);
             }
             if (!is_null($response)) {
                 break;

--- a/library/CM/Redis/Client.php
+++ b/library/CM/Redis/Client.php
@@ -349,7 +349,7 @@ class CM_Redis_Client extends CM_Class_Abstract implements CM_Service_ManagerAwa
                     $response = $callback($message->channel, $message->payload);
                 }
             } catch (Exception $e) {
-                $this->getServiceManager()->getLogger()->logException($e);
+                $this->getServiceManager()->getLogger()->logException($e, null, 'Cannot execute callback for redis message');
             }
             if (!is_null($response)) {
                 break;

--- a/library/CM/Redis/Client.php
+++ b/library/CM/Redis/Client.php
@@ -349,7 +349,7 @@ class CM_Redis_Client extends CM_Class_Abstract implements CM_Service_ManagerAwa
                     $response = $callback($message->channel, $message->payload);
                 }
             } catch (Exception $e) {
-                $this->getServiceManager()->getLogger()->logException($e, null, 'Cannot execute callback for redis message');
+                $this->getServiceManager()->getLogger()->logException($e);
             }
             if (!is_null($response)) {
                 break;

--- a/library/CM/Redis/Client.php
+++ b/library/CM/Redis/Client.php
@@ -1,6 +1,8 @@
 <?php
 
-class CM_Redis_Client extends CM_Class_Abstract {
+class CM_Redis_Client extends CM_Class_Abstract implements CM_Service_ManagerAwareInterface {
+
+    use CM_Service_ManagerAwareTrait;
 
     /** @var Predis\Client */
     private $_redis = null;
@@ -347,7 +349,7 @@ class CM_Redis_Client extends CM_Class_Abstract {
                     $response = $callback($message->channel, $message->payload);
                 }
             } catch (Exception $e) {
-                CM_Service_Manager::getInstance()->getLogger()->logException($e);
+                $this->getServiceManager()->getLogger()->logException($e);
             }
             if (!is_null($response)) {
                 break;

--- a/library/CM/Redis/Client.php
+++ b/library/CM/Redis/Client.php
@@ -349,7 +349,7 @@ class CM_Redis_Client extends CM_Class_Abstract implements CM_Service_ManagerAwa
                     $response = $callback($message->channel, $message->payload);
                 }
             } catch (Exception $e) {
-                $this->getServiceManager()->getLogger()->logException($e);
+                $this->getServiceManager()->getLogger()->addMessage('Redis message callback failed', CM_Log_Logger::exceptionToLevel($e), (new CM_Log_Context())->setException($e));
             }
             if (!is_null($response)) {
                 break;

--- a/library/CM/Service/Manager.php
+++ b/library/CM/Service/Manager.php
@@ -117,10 +117,12 @@ class CM_Service_Manager extends CM_Class_Abstract {
 
     /**
      * @param string $serviceName
+     * @return $this
      */
     public function unregister($serviceName) {
         unset($this->_serviceConfigList[$serviceName]);
         unset($this->_serviceInstanceList[$serviceName]);
+        return $this;
     }
 
     /**

--- a/tests/library/CM/ExceptionHandling/Handler/AbstractTest.php
+++ b/tests/library/CM/ExceptionHandling/Handler/AbstractTest.php
@@ -56,17 +56,21 @@ class CM_ExceptionHandling_Handler_AbstractTest extends CMTest_TestCase {
             ->at(2, function (Exception $ex) use ($fatalException) {
                 $this->assertEquals($fatalException, $ex);
             });
-        $logExceptionMock = $logger->mockMethod('logException')
-            ->at(0, function (Exception $exception, $level = null) use ($errorException) {
-                $this->assertEquals($errorException, $exception);
-                $this->assertEquals(CM_Log_Logger::ERROR, $level);
+        $addMessageMock = $logger->mockMethod('addMessage')
+            ->at(0, function ($message, $level, CM_Log_Context $context = null) use ($errorException) {
+                $this->assertSame('Application error', $message);
+                $this->assertSame(CM_Log_Logger::ERROR, $level);
+                $this->assertEquals($errorException, $context->getException());
             })
-            ->at(1, function (Exception $exception, $level = null) use ($nativeException) {
-                $this->assertEquals(CM_Log_Logger::ERROR, $level);
+            ->at(1, function ($message, $level, CM_Log_Context $context = null) use ($nativeException) {
+                $this->assertSame('Application error', $message);
+                $this->assertSame(CM_Log_Logger::ERROR, $level);
+                $this->assertEquals($nativeException, $context->getException());
             })
-            ->at(2, function (Exception $exception, $level = null) use ($fatalException) {
-                $this->assertEquals($fatalException, $exception);
-                $this->assertEquals(CM_Log_Logger::CRITICAL, $level);
+            ->at(2, function ($message, $level, CM_Log_Context $context = null) use ($fatalException) {
+                $this->assertSame('Application error', $message);
+                $this->assertSame(CM_Log_Logger::CRITICAL, $level);
+                $this->assertEquals($fatalException, $context->getException());
             });
 
         /** @var CM_ExceptionHandling_Handler_Abstract $exceptionHandler */
@@ -75,7 +79,7 @@ class CM_ExceptionHandling_Handler_AbstractTest extends CMTest_TestCase {
         $exceptionHandler->handleException($fatalException);
 
         $this->assertSame(3, $printExceptionMock->getCallCount());
-        $this->assertSame(3, $logExceptionMock->getCallCount());
+        $this->assertSame(3, $addMessageMock->getCallCount());
     }
 
     public function testPrintExceptionPrintSeverity() {
@@ -99,17 +103,21 @@ class CM_ExceptionHandling_Handler_AbstractTest extends CMTest_TestCase {
             ->at(1, function (Exception $ex) use ($fatalException) {
                 $this->assertEquals($fatalException, $ex);
             });
-        $logExceptionMock = $logger->mockMethod('logException')
-            ->at(0, function (Exception $exception, $level = null) use ($errorException) {
-                $this->assertEquals($errorException, $exception);
-                $this->assertEquals(CM_Log_Logger::ERROR, $level);
+        $addMessageMock = $logger->mockMethod('addMessage')
+            ->at(0, function ($message, $level, CM_Log_Context $context = null) use ($errorException) {
+                $this->assertSame('Application error', $message);
+                $this->assertSame(CM_Log_Logger::ERROR, $level);
+                $this->assertEquals($errorException, $context->getException());
             })
-            ->at(1, function (Exception $exception, $level = null) use ($nativeException) {
-                $this->assertEquals(CM_Log_Logger::ERROR, $level);
+            ->at(1, function ($message, $level, CM_Log_Context $context = null) use ($nativeException) {
+                $this->assertSame('Application error', $message);
+                $this->assertSame(CM_Log_Logger::ERROR, $level);
+                $this->assertEquals($nativeException, $context->getException());
             })
-            ->at(2, function (Exception $exception, $level = null) use ($fatalException) {
-                $this->assertEquals($fatalException, $exception);
-                $this->assertEquals(CM_Log_Logger::CRITICAL, $level);
+            ->at(2, function ($message, $level, CM_Log_Context $context = null) use ($fatalException) {
+                $this->assertSame('Application error', $message);
+                $this->assertSame(CM_Log_Logger::CRITICAL, $level);
+                $this->assertEquals($fatalException, $context->getException());
             });
 
         $exceptionHandler->setPrintSeverityMin(CM_Exception::FATAL);
@@ -119,6 +127,6 @@ class CM_ExceptionHandling_Handler_AbstractTest extends CMTest_TestCase {
         $exceptionHandler->handleException($fatalException);
 
         $this->assertSame(2, $printExceptionMock->getCallCount());
-        $this->assertSame(3, $logExceptionMock->getCallCount());
+        $this->assertSame(3, $addMessageMock->getCallCount());
     }
 }

--- a/tests/library/CM/ExceptionHandling/Handler/AbstractTest.php
+++ b/tests/library/CM/ExceptionHandling/Handler/AbstractTest.php
@@ -40,10 +40,11 @@ class CM_ExceptionHandling_Handler_AbstractTest extends CMTest_TestCase {
 
         /** @var CM_ExceptionHandling_Handler_Abstract|\Mocka\AbstractClassTrait $exceptionHandler */
         $exceptionHandler = $this->mockObject('CM_ExceptionHandling_Handler_Abstract');
-        $exceptionHandler->setServiceManager($this->getServiceManager());
+        $serviceManager = new CM_Service_Manager();
+        $exceptionHandler->setServiceManager($serviceManager);
         /** @var CM_Log_Logger|\Mocka\AbstractClassTrait $logger */
         $logger = $this->mockObject('CM_Log_Logger');
-        $this->getServiceManager()->unregister('logger')->registerInstance('logger', $logger);
+        $serviceManager->registerInstance('logger', $logger);
 
         $printExceptionMock = $exceptionHandler->mockMethod('_printException')
             ->at(0, function (Exception $ex) use ($errorException) {
@@ -84,10 +85,11 @@ class CM_ExceptionHandling_Handler_AbstractTest extends CMTest_TestCase {
 
         /** @var CM_ExceptionHandling_Handler_Abstract|\Mocka\AbstractClassTrait $exceptionHandler */
         $exceptionHandler = $this->mockObject('CM_ExceptionHandling_Handler_Abstract');
-        $exceptionHandler->setServiceManager($this->getServiceManager());
+        $serviceManager = new CM_Service_Manager();
+        $exceptionHandler->setServiceManager($serviceManager);
         /** @var CM_Log_Logger|\Mocka\AbstractClassTrait $logger */
         $logger = $this->mockObject('CM_Log_Logger');
-        $this->getServiceManager()->unregister('logger')->registerInstance('logger', $logger);
+        $serviceManager->registerInstance('logger', $logger);
 
         $printExceptionMock = $exceptionHandler->mockMethod('_printException');
         $printExceptionMock

--- a/tests/library/CM/Jobdistribution/JobWorkerTest.php
+++ b/tests/library/CM/Jobdistribution/JobWorkerTest.php
@@ -22,16 +22,19 @@ class CM_JobDistribution_JobWorkerTest extends CMTest_TestCase {
         /** @var CM_Log_Logger|\Mocka\AbstractClassTrait $logger */
         $logger = $this->mockObject('CM_Log_Logger');
         $serviceManager->registerInstance('logger', $logger);
-        $logExceptionMock = $logger->mockMethod('logException')->set(function (Exception $exception, $level = null) {
+        $addMessageMock = $logger->mockMethod('addMessage')->set(function ($message, $level, CM_Log_Context $context = null) {
+            $this->assertSame('Worker failed', $message);
+            $this->assertEquals(CM_Log_Logger::ERROR, $level);
+            $exception = $context->getException();
+            $this->assertInstanceOf('Exception', $exception);
             $this->assertEquals('foo-bar', $exception->getMessage());
-            $this->assertEquals(null, $level);
         });
         try {
             $jobWorkerMock->run();
         } catch (CM_Exception_Invalid $ex) {
             $this->assertContains('Worker failed', $ex->getMessage());
             $this->assertSame(2, $counter);
-            $this->assertSame(1, $logExceptionMock->getCallCount());
+            $this->assertSame(1, $addMessageMock->getCallCount());
         } catch (Exception $ex) {
             $this->fail('Exception not caught.');
         }

--- a/tests/library/CM/Jobdistribution/JobWorkerTest.php
+++ b/tests/library/CM/Jobdistribution/JobWorkerTest.php
@@ -16,11 +16,12 @@ class CM_JobDistribution_JobWorkerTest extends CMTest_TestCase {
         }));
         $jobWorkerMock = $this->getMock('CM_Jobdistribution_JobWorker', array('_getGearmanWorker', '_handleException'), array(), '', false);
         $jobWorkerMock->expects($this->any())->method('_getGearmanWorker')->will($this->returnValue($gearmanWorkerMock));
+        /** @var CM_JobDistribution_JobWorker $jobWorkerMock */
+        $serviceManager = new CM_Service_Manager();
+        $jobWorkerMock->setServiceManager($serviceManager);
         /** @var CM_Log_Logger|\Mocka\AbstractClassTrait $logger */
         $logger = $this->mockObject('CM_Log_Logger');
-        $this->getServiceManager()->unregister('logger')->registerInstance('logger', $logger);
-        /** @var CM_JobDistribution_JobWorker $jobWorkerMock */
-        $jobWorkerMock->setServiceManager($this->getServiceManager());
+        $serviceManager->unregister('logger')->registerInstance('logger', $logger);
         $logExceptionMock = $logger->mockMethod('logException')->set(function (Exception $exception, $level = null) {
             $this->assertEquals('foo-bar', $exception->getMessage());
             $this->assertEquals(null, $level);

--- a/tests/library/CM/Jobdistribution/JobWorkerTest.php
+++ b/tests/library/CM/Jobdistribution/JobWorkerTest.php
@@ -21,7 +21,7 @@ class CM_JobDistribution_JobWorkerTest extends CMTest_TestCase {
         $jobWorkerMock->setServiceManager($serviceManager);
         /** @var CM_Log_Logger|\Mocka\AbstractClassTrait $logger */
         $logger = $this->mockObject('CM_Log_Logger');
-        $serviceManager->unregister('logger')->registerInstance('logger', $logger);
+        $serviceManager->registerInstance('logger', $logger);
         $logExceptionMock = $logger->mockMethod('logException')->set(function (Exception $exception, $level = null) {
             $this->assertEquals('foo-bar', $exception->getMessage());
             $this->assertEquals(null, $level);

--- a/tests/library/CM/Jobdistribution/JobWorkerTest.php
+++ b/tests/library/CM/Jobdistribution/JobWorkerTest.php
@@ -16,13 +16,21 @@ class CM_JobDistribution_JobWorkerTest extends CMTest_TestCase {
         }));
         $jobWorkerMock = $this->getMock('CM_Jobdistribution_JobWorker', array('_getGearmanWorker', '_handleException'), array(), '', false);
         $jobWorkerMock->expects($this->any())->method('_getGearmanWorker')->will($this->returnValue($gearmanWorkerMock));
-        $jobWorkerMock->expects($this->once())->method('_handleException')->with(new PHPUnit_Framework_Constraint_ExceptionMessage('foo-bar'));
+        /** @var CM_Log_Logger|\Mocka\AbstractClassTrait $logger */
+        $logger = $this->mockObject('CM_Log_Logger');
+        $this->getServiceManager()->unregister('logger')->registerInstance('logger', $logger);
         /** @var CM_JobDistribution_JobWorker $jobWorkerMock */
+        $jobWorkerMock->setServiceManager($this->getServiceManager());
+        $logExceptionMock = $logger->mockMethod('logException')->set(function (Exception $exception, $level = null) {
+            $this->assertEquals('foo-bar', $exception->getMessage());
+            $this->assertEquals(null, $level);
+        });
         try {
             $jobWorkerMock->run();
         } catch (CM_Exception_Invalid $ex) {
             $this->assertContains('Worker failed', $ex->getMessage());
             $this->assertSame(2, $counter);
+            $this->assertSame(1, $logExceptionMock->getCallCount());
         } catch (Exception $ex) {
             $this->fail('Exception not caught.');
         }

--- a/tests/library/CM/MessageStream/Adapter/SocketRedisTest.php
+++ b/tests/library/CM/MessageStream/Adapter/SocketRedisTest.php
@@ -141,9 +141,12 @@ class CM_MessageStream_Adapter_SocketRedisTest extends CMTest_TestCase {
 
         $adapter = $this->mockClass('CM_MessageStream_Adapter_SocketRedis')->newInstanceWithoutConstructor();
         $adapter->mockMethod('_fetchStatus')->set($status);
+        /** @var CM_MessageStream_Adapter_SocketRedis $adapter */
+        $serviceManager = new CM_Service_Manager();
+        $adapter->setServiceManager($serviceManager);
         /** @var CM_Log_Logger|\Mocka\AbstractClassTrait $logger */
         $logger = $this->mockObject('CM_Log_Logger');
-        $this->getServiceManager()->unregister('logger')->registerInstance('logger', $logger);
+        $serviceManager->registerInstance('logger', $logger);
         $logExceptionMock = $logger->mockMethod('logException')->set(function (Exception $exception, $level = null) {
             $this->assertSame('Type is not configured for class.', $exception->getMessage());
             $this->assertInstanceOf('CM_Exception', $exception);
@@ -156,8 +159,6 @@ class CM_MessageStream_Adapter_SocketRedisTest extends CMTest_TestCase {
                 $exception->getMetaInfo()
             );
         });
-        /** @var CM_MessageStream_Adapter_SocketRedis $adapter */
-        $adapter->setServiceManager($this->getServiceManager());
         $adapter->synchronize();
         $this->assertSame(1, $logExceptionMock->getCallCount());
     }

--- a/tests/library/CM/MessageStream/Adapter/SocketRedisTest.php
+++ b/tests/library/CM/MessageStream/Adapter/SocketRedisTest.php
@@ -147,9 +147,11 @@ class CM_MessageStream_Adapter_SocketRedisTest extends CMTest_TestCase {
         /** @var CM_Log_Logger|\Mocka\AbstractClassTrait $logger */
         $logger = $this->mockObject('CM_Log_Logger');
         $serviceManager->registerInstance('logger', $logger);
-        $logExceptionMock = $logger->mockMethod('logException')->set(function (Exception $exception, $level = null) {
-            $this->assertSame('Type is not configured for class.', $exception->getMessage());
+        $warningMock = $logger->mockMethod('warning')->set(function ($message, CM_Log_Context $context = null) {
+            $this->assertSame('Error synchronizing socket redis status', $message);
+            $exception = $context->getException();
             $this->assertInstanceOf('CM_Exception', $exception);
+            $this->assertSame('Type is not configured for class.', $exception->getMessage());
             /** @var CM_Exception $exception */
             $this->assertSame(
                 [
@@ -160,7 +162,7 @@ class CM_MessageStream_Adapter_SocketRedisTest extends CMTest_TestCase {
             );
         });
         $adapter->synchronize();
-        $this->assertSame(1, $logExceptionMock->getCallCount());
+        $this->assertSame(1, $warningMock->getCallCount());
     }
 
     /**


### PR DESCRIPTION
We're often using `handleException()` when we want to log an exception using the following pattern:
```php
} catch (CM_Exception_Nonexistent $e) {
    $e->setSeverity(CM_Exception::WARN);
    CM_Bootloader::getInstance()->getExceptionHandler()->handleException($e);
}
```

Now that we have a proper Logger service we can instead just log a message:
```php
$serviceManager->getLogger()->warning('Something bad happened');
```

The difference will be:
- No stack trace available. Usually that's fine.
- Error will not be printed (stdout in CLI, and status 500 code in HTTP)
 - Printing happens only if the exception's severity is above the "printSeverityMin" (error or fatal). In most cases it's probably unexpected behaviour to print it (at least for HTTP).

Let's check all usages, also in SK and decide case to case.
Do we even still need `handleException()`?

cc @zazabe @fvovan