### PR TITLE
ES location index gets emptied

### DIFF
--- a/library/CM/Db/Db.php
+++ b/library/CM/Db/Db.php
@@ -178,6 +178,19 @@ class CM_Db_Db extends CM_Class_Abstract {
     }
 
     /**
+     * @param string $table
+     * @param string $replacement
+     */
+    public static function replaceTable($table, $replacement) {
+        $client = self::getClient();
+        $tableQuoted = $client->quoteIdentifier($table);
+        $replacementQuoted = $client->quoteIdentifier($replacement);
+        $temporaryTableQuoted = $client->quoteIdentifier(uniqid($table . '_'));
+        self::exec("RENAME TABLE {$tableQuoted} TO {$temporaryTableQuoted}, {$replacementQuoted} TO {$tableQuoted}");
+        self::exec("DROP TABLE {$temporaryTableQuoted}");
+    }
+
+    /**
      * @param string            $table
      * @param string|array      $fields Column-name OR Column-names array
      * @param string|array|null $where  Associative array field=>value OR string

--- a/library/CM/Model/Location.php
+++ b/library/CM/Model/Location.php
@@ -334,6 +334,24 @@ class CM_Model_Location extends CM_Model_Abstract {
         return 'CM_Model_StorageAdapter_CacheLocal';
     }
 
+    /**
+     * @param CM_Db_Client $db
+     * @return bool
+     */
+    public static function getCreateAggregationInProgress(CM_Db_Client $db) {
+        foreach ([
+                     'cm_tmp_location_new',
+                     'cm_tmp_location_coordinates_new',
+                     'cm_tmp_location_old',
+                     'cm_tmp_location_coordinates_old',
+                 ] as $table) {
+            if (CM_Db_Db::exec('SHOW TABLES LIKE ?', [$table], null, $db)->getAffectedRows()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static function createAggregation() {
         CM_Db_Db::exec('DROP TABLE IF EXISTS `cm_tmp_location_new`');
         CM_Db_Db::exec('CREATE TABLE `cm_tmp_location_new` LIKE `cm_tmp_location`');
@@ -375,11 +393,6 @@ class CM_Model_Location extends CM_Model_Abstract {
         CM_Db_Db::exec('DROP TABLE `cm_tmp_location_old`');
         CM_Db_Db::exec('RENAME TABLE `cm_tmp_location_coordinates` TO `cm_tmp_location_coordinates_old`, `cm_tmp_location_coordinates_new` TO `cm_tmp_location_coordinates`');
         CM_Db_Db::exec('DROP TABLE `cm_tmp_location_coordinates_old`');
-
-        $client = CM_Service_Manager::getInstance()->getDatabases()->getReadMaintenance();
-        while (CM_Db_Db::exec('SHOW TABLES LIKE ?', ['cm_tmp_location_coordinates_old'], null, $client)->getAffectedRows()) {
-            sleep(1);
-        }
     }
 
     /**

--- a/library/CM/Model/Location.php
+++ b/library/CM/Model/Location.php
@@ -392,6 +392,9 @@ class CM_Model_Location extends CM_Model_Abstract {
         CM_Db_Db::exec('RENAME TABLE `cm_tmp_location` TO `cm_tmp_location_old`, `cm_tmp_location_new` TO `cm_tmp_location`');
         CM_Db_Db::exec('DROP TABLE `cm_tmp_location_old`');
         CM_Db_Db::exec('RENAME TABLE `cm_tmp_location_coordinates` TO `cm_tmp_location_coordinates_old`, `cm_tmp_location_coordinates_new` TO `cm_tmp_location_coordinates`');
+        while (!CM_Model_Location::getCreateAggregationInProgress(CM_Service_Manager::getInstance()->getDatabases()->getReadMaintenance())) {
+            sleep(1);
+        }
         CM_Db_Db::exec('DROP TABLE `cm_tmp_location_coordinates_old`');
     }
 

--- a/library/CM/Model/Location.php
+++ b/library/CM/Model/Location.php
@@ -352,7 +352,10 @@ class CM_Model_Location extends CM_Model_Abstract {
         return false;
     }
 
-    public static function createAggregation() {
+    /**
+     * @param CM_Db_Client|null $waitForDb
+     */
+    public static function createAggregation(CM_Db_Client $waitForDb = null) {
         CM_Db_Db::exec('DROP TABLE IF EXISTS `cm_tmp_location_new`');
         CM_Db_Db::exec('CREATE TABLE `cm_tmp_location_new` LIKE `cm_tmp_location`');
         CM_Db_Db::exec('INSERT INTO `cm_tmp_location_new` (`level`,`id`,`1Id`,`2Id`,`3Id`,`4Id`,`name`, `abbreviation`, `nameFull`, `lat`,`lon`)
@@ -392,10 +395,17 @@ class CM_Model_Location extends CM_Model_Abstract {
         CM_Db_Db::exec('RENAME TABLE `cm_tmp_location` TO `cm_tmp_location_old`, `cm_tmp_location_new` TO `cm_tmp_location`');
         CM_Db_Db::exec('DROP TABLE `cm_tmp_location_old`');
         CM_Db_Db::exec('RENAME TABLE `cm_tmp_location_coordinates` TO `cm_tmp_location_coordinates_old`, `cm_tmp_location_coordinates_new` TO `cm_tmp_location_coordinates`');
-        while (!CM_Model_Location::getCreateAggregationInProgress(CM_Service_Manager::getInstance()->getDatabases()->getReadMaintenance())) {
-            sleep(1);
+        if ($waitForDb) {
+            while (!CM_Model_Location::getCreateAggregationInProgress($waitForDb)) {
+                sleep(1);
+            }
         }
         CM_Db_Db::exec('DROP TABLE `cm_tmp_location_coordinates_old`');
+        if ($waitForDb) {
+            while (CM_Model_Location::getCreateAggregationInProgress($waitForDb)) {
+                sleep(1);
+            }
+        }
     }
 
     /**

--- a/library/CM/Model/Location.php
+++ b/library/CM/Model/Location.php
@@ -375,6 +375,11 @@ class CM_Model_Location extends CM_Model_Abstract {
         CM_Db_Db::exec('DROP TABLE `cm_tmp_location_old`');
         CM_Db_Db::exec('RENAME TABLE `cm_tmp_location_coordinates` TO `cm_tmp_location_coordinates_old`, `cm_tmp_location_coordinates_new` TO `cm_tmp_location_coordinates`');
         CM_Db_Db::exec('DROP TABLE `cm_tmp_location_coordinates_old`');
+
+        $client = CM_Service_Manager::getInstance()->getDatabases()->getReadMaintenance();
+        while (CM_Db_Db::exec('SHOW TABLES LIKE ?', ['cm_tmp_location_coordinates_old'], null, $client)->getAffectedRows()) {
+            sleep(1);
+        }
     }
 
     /**

--- a/library/CM/Model/Location.php
+++ b/library/CM/Model/Location.php
@@ -335,8 +335,9 @@ class CM_Model_Location extends CM_Model_Abstract {
     }
 
     public static function createAggregation() {
-        CM_Db_Db::truncate('cm_tmp_location');
-        CM_Db_Db::exec('INSERT INTO `cm_tmp_location` (`level`,`id`,`1Id`,`2Id`,`3Id`,`4Id`,`name`, `abbreviation`, `nameFull`, `lat`,`lon`)
+        CM_Db_Db::exec('DROP TABLE IF EXISTS `cm_tmp_location_new`');
+        CM_Db_Db::exec('CREATE TABLE `cm_tmp_location_new` LIKE `cm_tmp_location`');
+        CM_Db_Db::exec('INSERT INTO `cm_tmp_location_new` (`level`,`id`,`1Id`,`2Id`,`3Id`,`4Id`,`name`, `abbreviation`, `nameFull`, `lat`,`lon`)
 			SELECT 1, `1`.`id`, `1`.`id`, NULL, NULL, NULL,
 					`1`.`name`, `1`.`abbreviation`, CONCAT_WS(" ", `1`.`name`, `1`.`abbreviation`), NULL, NULL
 			FROM `cm_model_location_country` AS `1`
@@ -359,8 +360,9 @@ class CM_Model_Location extends CM_Model_Abstract {
 			LEFT JOIN `cm_model_location_state` AS `2` ON(`3`.`stateId`=`2`.`id`)
 			LEFT JOIN `cm_model_location_country` AS `1` ON(`3`.`countryId`=`1`.`id`)');
 
-        CM_Db_Db::truncate('cm_tmp_location_coordinates');
-        CM_Db_Db::exec('INSERT INTO `cm_tmp_location_coordinates` (`level`,`id`,`coordinates`)
+        CM_Db_Db::exec('DROP TABLE IF EXISTS `cm_tmp_location_coordinates_new`');
+        CM_Db_Db::exec('CREATE TABLE `cm_tmp_location_coordinates_new` LIKE `cm_tmp_location_coordinates`');
+        CM_Db_Db::exec('INSERT INTO `cm_tmp_location_coordinates_new` (`level`,`id`,`coordinates`)
 			SELECT 3, `id`, POINT(lat, lon)
 			FROM `cm_model_location_city`
 			WHERE `lat` IS NOT NULL AND `lon` IS NOT NULL
@@ -368,6 +370,11 @@ class CM_Model_Location extends CM_Model_Abstract {
 			SELECT 4, `id`, POINT(lat, lon)
 			FROM `cm_model_location_zip`
 			WHERE `lat` IS NOT NULL AND `lon` IS NOT NULL');
+
+        CM_Db_Db::exec('RENAME TABLE `cm_tmp_location` TO `cm_tmp_location_old`, `cm_tmp_location_new` TO `cm_tmp_location`');
+        CM_Db_Db::exec('DROP TABLE `cm_tmp_location_old`');
+        CM_Db_Db::exec('RENAME TABLE `cm_tmp_location_coordinates` TO `cm_tmp_location_coordinates_old`, `cm_tmp_location_coordinates_new` TO `cm_tmp_location_coordinates`');
+        CM_Db_Db::exec('DROP TABLE `cm_tmp_location_coordinates_old`');
     }
 
     /**

--- a/library/CMService/MaxMind.php
+++ b/library/CMService/MaxMind.php
@@ -1,6 +1,8 @@
 <?php
 
-class CMService_MaxMind extends CM_Class_Abstract {
+class CMService_MaxMind extends CM_Class_Abstract implements CM_Service_ManagerAwareInterface {
+
+    use CM_Service_ManagerAwareTrait;
 
     const COUNTRY_URL = 'https://raw.githubusercontent.com/lukes/ISO-3166-Countries-with-Regional-Codes/56efb650f927eda08c18c2a077226104d0e41744/all/all.csv';
     const REGION_URL = 'http://www.maxmind.com/download/geoip/misc/region_codes.csv';
@@ -1368,10 +1370,10 @@ class CMService_MaxMind extends CM_Class_Abstract {
 
     protected function _updateSearchIndex() {
         CM_Model_Location::createAggregation();
-        while (CM_Model_Location::getCreateAggregationInProgress(CM_Service_Manager::getInstance()->getDatabases()->getReadMaintenance())) {
+        while (CM_Model_Location::getCreateAggregationInProgress($this->getServiceManager()->getDatabases()->getReadMaintenance())) {
             sleep(1);
         }
-        $client = CM_Service_Manager::getInstance()->getElasticsearch()->getClient();
+        $client = $this->getServiceManager()->getElasticsearch()->getClient();
         $type = new CM_Elasticsearch_Type_Location($client);
         $searchIndexCli = new CM_Elasticsearch_Index_Cli(null, $this->_streamOutput, $this->_streamError);
         $searchIndexCli->create($type->getIndexName());
@@ -1482,7 +1484,7 @@ class CMService_MaxMind extends CM_Class_Abstract {
      * @codeCoverageIgnore
      */
     private function _getFileTmp($name) {
-        return new CM_File($name, CM_Service_Manager::getInstance()->getFilesystems()->getTmp());
+        return new CM_File($name, $this->getServiceManager()->getFilesystems()->getTmp());
     }
 
     /**

--- a/library/CMService/MaxMind.php
+++ b/library/CMService/MaxMind.php
@@ -1367,11 +1367,8 @@ class CMService_MaxMind extends CM_Class_Abstract {
     }
 
     protected function _updateSearchIndex() {
-        CM_Model_Location::createAggregation();
-        $db = CM_Service_Manager::getInstance()->getDatabases()->getReadMaintenance();
-        while (CM_Model_Location::getCreateAggregationInProgress($db)) {
-            sleep(1);
-        }
+        $waitForDb = CM_Service_Manager::getInstance()->getDatabases()->getReadMaintenance();
+        CM_Model_Location::createAggregation($waitForDb);
         $client = CM_Service_Manager::getInstance()->getElasticsearch()->getClient();
         $type = new CM_Elasticsearch_Type_Location($client);
         $searchIndexCli = new CM_Elasticsearch_Index_Cli(null, $this->_streamOutput, $this->_streamError);

--- a/library/CMService/MaxMind.php
+++ b/library/CMService/MaxMind.php
@@ -1362,8 +1362,7 @@ class CMService_MaxMind extends CM_Class_Abstract implements CM_Service_ManagerA
             $this->_printProgressCounter(++$item, $count);
         }
 
-        CM_Db_Db::exec('RENAME TABLE `cm_model_location_ip` TO `cm_model_location_ip_old`, `cm_model_location_ip_new` TO `cm_model_location_ip`');
-        CM_Db_Db::exec('DROP TABLE `cm_model_location_ip_old`');
+        CM_Db_Db::replaceTable('cm_model_location_ip', 'cm_model_location_ip_new');
 
         $this->_printInfoList($infoListWarning, '!');
     }

--- a/library/CMService/MaxMind.php
+++ b/library/CMService/MaxMind.php
@@ -1367,8 +1367,10 @@ class CMService_MaxMind extends CM_Class_Abstract {
     }
 
     protected function _updateSearchIndex() {
-        $waitForDb = CM_Service_Manager::getInstance()->getDatabases()->getReadMaintenance();
-        CM_Model_Location::createAggregation($waitForDb);
+        CM_Model_Location::createAggregation();
+        while (CM_Model_Location::getCreateAggregationInProgress(CM_Service_Manager::getInstance()->getDatabases()->getReadMaintenance())) {
+            sleep(1);
+        }
         $client = CM_Service_Manager::getInstance()->getElasticsearch()->getClient();
         $type = new CM_Elasticsearch_Type_Location($client);
         $searchIndexCli = new CM_Elasticsearch_Index_Cli(null, $this->_streamOutput, $this->_streamError);

--- a/library/CMService/MaxMind.php
+++ b/library/CMService/MaxMind.php
@@ -1368,6 +1368,10 @@ class CMService_MaxMind extends CM_Class_Abstract {
 
     protected function _updateSearchIndex() {
         CM_Model_Location::createAggregation();
+        $db = CM_Service_Manager::getInstance()->getDatabases()->getReadMaintenance();
+        while (CM_Model_Location::getCreateAggregationInProgress($db)) {
+            sleep(1);
+        }
         $client = CM_Service_Manager::getInstance()->getElasticsearch()->getClient();
         $type = new CM_Elasticsearch_Type_Location($client);
         $searchIndexCli = new CM_Elasticsearch_Index_Cli(null, $this->_streamOutput, $this->_streamError);

--- a/tests/library/CM/Db/DbTest.php
+++ b/tests/library/CM/Db/DbTest.php
@@ -206,4 +206,15 @@ class CM_Db_DbTest extends CMTest_TestCase {
         $this->assertSame(3, $counter);
         $this->assertSame(3, (int) CM_Db_Db::select('test', array('foo'))->fetchColumn('foo'));
     }
+
+    public function testReplaceTable() {
+        $this->assertInstanceOf('CM_Db_Exception', $this->catchException(function () {
+            CM_Db_Db::replaceTable('test', 'test_new');
+        }));
+        CM_Db_Db::exec('CREATE TABLE `test_new` (`id` INT(10) UNSIGNED NOT NULL)');
+        CM_Db_Db::insert('test_new', ['id' => 123]);
+        CM_Db_Db::replaceTable('test', 'test_new');
+        $this->assertSame([['id' => '123']], CM_Db_Db::select('test', '*')->fetchAll());
+        $this->assertSame(false, CM_Db_Db::existsTable('test_new'));
+    }
 }


### PR DESCRIPTION
The "location" search index suddenly doesn't return any results.
It happened once before, and now again as reported in https://github.com/cargomedia/sk-support/issues/29.

Querying the index' status shows 0 documents:
```
curl -XGET 'http://localhost:9200/location/_status'
[…]
      "docs": {
        "num_docs": 0,
        "max_doc": 0,
        "deleted_docs": 0
      },
[…]
```
Full output: https://gist.github.com/njam/c99a516a903122054fd66ae2d7a2bf1f

I guess it happens after the weekly MaxMind upgrade.

@fauvel can you investigate?
It looks to me like the previous call to `CM_Model_Location::createAggregation()` probably truncates the table `cm_tmp_location`, and when the search index is created the mysql slave doesn't have the table yet?

Didn't we want to re-create that table with a different name, and then just rename it?
