### PR TITLE
'Undefined index' in CM_Paging_ModelAbstract

### DIFF
--- a/library/CM/Paging/ModelAbstract.php
+++ b/library/CM/Paging/ModelAbstract.php
@@ -38,10 +38,6 @@ abstract class CM_Paging_ModelAbstract extends CM_Paging_Abstract {
             $this->_populateModelList($this->_getItemsRaw());
         }
         $index = serialize($itemRaw);
-        $model = isset($this->_modelList[$index]) ? $this->_modelList[$index] : null;
-        if (null === $model) {
-            throw new CM_Exception_Nonexistent('Model itemRaw has no data', null, ['itemRaw' => CM_Util::var_line($itemRaw)]);
-        }
-        return $model;
+        return isset($this->_modelList[$index]) ? $this->_modelList[$index] : null;
     }
 }

--- a/library/CM/Paging/ModelAbstract.php
+++ b/library/CM/Paging/ModelAbstract.php
@@ -38,7 +38,8 @@ abstract class CM_Paging_ModelAbstract extends CM_Paging_Abstract {
             $this->_populateModelList($this->_getItemsRaw());
         }
         $index = serialize($itemRaw);
-        if (!array_key_exists($index, $this->_modelList) || null === ($model = $this->_modelList[$index])) {
+        $model = isset($this->_modelList[$index]) ? $this->_modelList[$index] : null;
+        if (null === $model) {
             throw new CM_Exception_Nonexistent('Model itemRaw has no data', null, ['itemRaw' => CM_Util::var_line($itemRaw)]);
         }
         return $model;

--- a/library/CM/Paging/ModelAbstract.php
+++ b/library/CM/Paging/ModelAbstract.php
@@ -38,7 +38,7 @@ abstract class CM_Paging_ModelAbstract extends CM_Paging_Abstract {
             $this->_populateModelList($this->_getItemsRaw());
         }
         $index = serialize($itemRaw);
-        if (null === ($model = $this->_modelList[$index])) {
+        if (!array_key_exists($index, $this->_modelList) || null === ($model = $this->_modelList[$index])) {
             throw new CM_Exception_Nonexistent('Model itemRaw has no data', null, ['itemRaw' => CM_Util::var_line($itemRaw)]);
         }
         return $model;

--- a/tests/library/CM/Paging/ModelAbstractTest.php
+++ b/tests/library/CM/Paging/ModelAbstractTest.php
@@ -27,13 +27,7 @@ class CM_Paging_ModelAbstractTest extends CMTest_TestCase {
         $this->assertCount(3, $modelPaging);
         $this->assertEquals($model2, $modelPaging->getItem(0));
         $this->assertEquals($model1, $modelPaging->getItem(1));
-        try {
-            $modelPaging->getItem(2);
-            $this->fail('Can access nonexistent item.');
-        } catch (CM_Exception_Nonexistent $ex) {
-            $this->assertSame('Model itemRaw has no data', $ex->getMessage());
-            $this->assertSame(['itemRaw' => '2000'], $ex->getMetaInfo());
-        }
+        $this->assertNull($modelPaging->getItem(2));
     }
 
     public function testPagingVariableType() {
@@ -52,13 +46,7 @@ class CM_Paging_ModelAbstractTest extends CMTest_TestCase {
         $this->assertCount(3, $modelPaging);
         $this->assertEquals($model1, $modelPaging->getItem(0));
         $this->assertEquals($model2, $modelPaging->getItem(1));
-        try {
-            $modelPaging->getItem(2);
-            $this->fail('Can access nonexistent item.');
-        } catch (CM_Exception_Nonexistent $ex) {
-            $this->assertSame('Model itemRaw has no data', $ex->getMessage());
-            $this->assertContains('Array (', $ex->getMetaInfo()['itemRaw']);
-        }
+        $this->assertNull($modelPaging->getItem(2));
     }
 
     public function testModelListInvalidation() {


### PR DESCRIPTION
There are still some problems  with model paging 

ErrorException: E_NOTICE: Undefined index: a:2:{s:2:"id";s:7:"5927208";s:4:"type";s:1:"1";} in /home/{appDir}/vendor/cargomedia/cm/library/CM/Paging/ModelAbstract.php on line 41

https://github.com/cargomedia/cm/pull/2295
https://github.com/cargomedia/cm/pull/2279