### PR TITLE
Send mail via SMTP with concurrency support

### DIFF
--- a/library/CM/Mail/Mailer.php
+++ b/library/CM/Mail/Mailer.php
@@ -17,13 +17,11 @@ class CM_Mail_Mailer extends Swift_Mailer implements CM_Service_ManagerAwareInte
         }
 
         $numSent = 0;
-        $failedRecipients = null;
         $context = new CM_Log_Context();
         try {
             $numSent = parent::send($message, $failedRecipients);
         } catch (Exception $e) {
             $context->setException($e);
-            throw $e;
         }
 
         $this->getTransport()->stop();

--- a/library/CM/Mail/MailerFactory.php
+++ b/library/CM/Mail/MailerFactory.php
@@ -16,15 +16,18 @@ class CM_Mail_MailerFactory implements CM_Service_ManagerAwareInterface {
     /**
      * @param string|null $host
      * @param int|null    $port
+     * @param array|null  $headers
      * @param string|null $username
      * @param string|null $password
      * @param string|null $security
      * @return CM_Mail_Mailer
      */
-    public function createSmtpMailer($host = null, $port = null, $username = null, $password = null, $security = null) {
+    public function createSmtpMailer($host = null, $port = null, array $headers = null, $username = null, $password = null, $security = null) {
         $host = null !== $host ? (string) $host : 'localhost';
         $port = null !== $port ? (int) $port : 25;
+        $headers = null !== $headers ? (array) $headers : [];
         $security = null !== $security ? (string) $security : null;
+
         $transport = new Swift_SmtpTransport($host, $port, $security);
         if (null !== $username) {
             $transport->setUsername((string) $username);
@@ -32,7 +35,7 @@ class CM_Mail_MailerFactory implements CM_Service_ManagerAwareInterface {
         if (null !== $password) {
             $transport->setPassword((string) $password);
         }
-        return new CM_Mail_Mailer($transport);
+        return new CM_Mail_Mailer($transport, $headers);
     }
 
     /**

--- a/tests/library/CM/Mail/MailerTest.php
+++ b/tests/library/CM/Mail/MailerTest.php
@@ -37,6 +37,46 @@ class CM_Mail_MailerTest extends CMTest_TestCase {
         $this->assertSame(0, $sendMethod->getCallCount());
     }
 
+    public function testSendThrows() {
+        $serviceManager = new CM_Service_Manager();
+        $logger = $this->mockObject('CM_Log_Logger');
+        $serviceManager->registerInstance('logger', $logger);
+        $transport = $this->mockInterface('Swift_Transport')->newInstance();
+        $transport->mockMethod('isStarted')->set(true);
+        $message = new Swift_Message('foo', 'content');
+        $message->setFrom('foobar@example.com', 'Foobar');
+        $message->setTo('foo@example.com');
+        $message->setCc('bar@example.com', 'bar');
+
+        $client = new CM_Mail_Mailer($transport);
+        $client->setServiceManager($serviceManager);
+
+        $sendMethod = $transport->mockMethod('send')->set(function () {
+            throw new Exception('Failed');
+        });
+        $errorMethod = $logger->mockMethod('error')->set(function ($message, CM_Log_Context $context = null) {
+            $exception = $context->getException();
+            $this->assertSame('Failed to send email', $message);
+            $this->assertSame([
+                'message'          => [
+                    'subject' => 'foo',
+                    'from'    => ['foobar@example.com' => 'Foobar'],
+                    'to'      => ['foo@example.com' => null],
+                    'cc'      => ['bar@example.com' => 'bar'],
+                    'bcc'     => null,
+                ],
+                'failedRecipients' => [],
+            ], $context->getExtra());
+            $this->assertInstanceOf('Exception', $exception);
+            $this->assertSame('Failed', $exception->getMessage());
+        });
+
+        $client->send($message);
+        /** @var CM_Exception_Invalid $exception */
+        $this->assertSame(1, $sendMethod->getCallCount());
+        $this->assertSame(1, $errorMethod->getCallCount());
+    }
+
     public function testSendFailed() {
         $serviceManager = new CM_Service_Manager();
         $logger = $this->mockObject('CM_Log_Logger');
@@ -44,7 +84,7 @@ class CM_Mail_MailerTest extends CMTest_TestCase {
         $transport = $this->mockInterface('Swift_Transport')->newInstance();
         $transport->mockMethod('isStarted')->set(true);
         $message = new Swift_Message('foo', 'content');
-        $message->setSender('foobar@example.com', 'Foobar');
+        $message->setFrom('foobar@example.com', 'Foobar');
         $message->setTo('foo@example.com');
         $message->setCc('bar@example.com', 'bar');
 
@@ -52,9 +92,8 @@ class CM_Mail_MailerTest extends CMTest_TestCase {
         $client->setServiceManager($serviceManager);
 
         $sendMethod = $transport->mockMethod('send')->set(0);
-        $warningMethod = $logger->mockMethod('warning');
         $errorMethod = $logger->mockMethod('error')->set(function ($message, CM_Log_Context $context = null) {
-            $this->assertSame('Failed to send email to all recipients', $message);
+            $this->assertSame('Failed to send email', $message);
             $this->assertSame([
                 'message'          => [
                     'subject' => 'foo',
@@ -72,7 +111,6 @@ class CM_Mail_MailerTest extends CMTest_TestCase {
 
         /** @var CM_Exception_Invalid $exception */
         $this->assertSame(1, $sendMethod->getCallCount());
-        $this->assertSame(0, $warningMethod->getCallCount());
         $this->assertSame(1, $errorMethod->getCallCount());
     }
 }


### PR DESCRIPTION
`Swift_SmtpTransport` seems to have some concurrency issues...

Actually, the connection is [open with `stream_socket_client`](https://github.com/swiftmailer/swiftmailer/blob/5.x/lib/classes/Swift/Transport/StreamBuffer.php#L249) and those params:
```php
// https://github.com/swiftmailer/swiftmailer/blob/5.x/lib/classes/Swift/Transport/EsmtpTransport.php#L37
[
    'protocol'               => 'tcp',
    'host'                   => 'localhost',
    'port'                   => 25,
    'timeout'                => 30,
    'blocking'               => 1,
    'tls'                    => false,
    'type'                   => Swift_Transport_IoBuffer::TYPE_SOCKET,
    'stream_context_options' => [],
]
```

So the connection is blocking by default, but I could imagine that multiple connections from different threads to the same host, even in blocking mode, could produce some issues...

Similar issues have been reported:
```
- https://github.com/swiftmailer/swiftmailer/issues/490
- https://github.com/swiftmailer/swiftmailer/issues/788
```