### PR TITLE
CM_Params::encode() should recursively encode values returned by CM_ArrayConvertible::toArray()

### DIFF
--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -599,12 +599,12 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
             $result = ['_class' => get_class($value)];
             if ($value instanceof CM_ArrayConvertible) {
                 $array = $value->toArray();
-                $result = array_merge($result, array_map('self::encode', $array));
+                $result = array_merge($result, self::encode($array));
             }
             if ($value instanceof JsonSerializable) {
                 $array = $value->jsonSerialize();
                 if (is_array($array)) {
-                    $result = array_merge($result, array_map('self::encode', $array));
+                    $result = array_merge($result, self::encode($array));
                 }
             }
         } else {

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -599,7 +599,7 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
             $result = ['_class' => get_class($value)];
             if ($value instanceof CM_ArrayConvertible) {
                 $array = $value->toArray();
-                $result = array_merge($result, $array);
+                $result = array_merge($result, array_map('self::encode', $array));
             }
             if ($value instanceof JsonSerializable) {
                 $array = $value->jsonSerialize();


### PR DESCRIPTION
Seems that this functionality was removed in https://github.com/cargomedia/cm/pull/2187