### PR TITLE
Auto encode DateTime values in logger metaInfo

### DIFF
--- a/library/CM/Log/Context.php
+++ b/library/CM/Log/Context.php
@@ -99,15 +99,8 @@ class CM_Log_Context {
     /**
      * @param array $extra
      * @return $this
-     * @throws CM_Exception_Invalid
      */
     public function setExtra(array $extra) {
-        $flattenExtra = Functional\flatten($extra);
-        if (Functional\some($flattenExtra, function ($el) {
-            return is_object($el);
-        })) {
-            throw new CM_Exception_Invalid('Object can not be passed to "Extra"');
-        }
         $this->_extra = $extra;
         return $this;
     }

--- a/library/CM/Log/ContextFormatter/Cargomedia.php
+++ b/library/CM/Log/ContextFormatter/Cargomedia.php
@@ -12,19 +12,6 @@ class CM_Log_ContextFormatter_Cargomedia implements CM_Log_ContextFormatter_Inte
         $this->_appName = (string) $appName;
     }
 
-    public function formatRecordContext(CM_Log_Record $record) {
-        $levelsMapping = array_flip(CM_Log_Logger::getLevels());
-        $context = $record->getContext();
-
-        $result = [
-            'message'   => (string) $record->getMessage(),
-            'level'     => strtolower($levelsMapping[$record->getLevel()]),
-            'timestamp' => $record->getCreatedAt()->format(DateTime::ISO8601),
-        ];
-        $result = array_merge($result, $this->formatContext($context));
-        return $result;
-    }
-
     public function formatContext(CM_Log_Context $context) {
         $result = [];
         if ($computerInfo = $context->getComputerInfo()) {

--- a/library/CM/Log/ContextFormatter/Cargomedia.php
+++ b/library/CM/Log/ContextFormatter/Cargomedia.php
@@ -81,7 +81,7 @@ class CM_Log_ContextFormatter_Cargomedia implements CM_Log_ContextFormatter_Inte
 
     public function formatAppContext(CM_Log_Context $context) {
         $result = [];
-        $appAttributes = $context->getExtra();
+        $appAttributes = $this->_encodeExtra($context->getExtra());
         if ($user = $context->getUser()) {
             $appAttributes['user'] = $user->getId();
         }
@@ -91,6 +91,14 @@ class CM_Log_ContextFormatter_Cargomedia implements CM_Log_ContextFormatter_Inte
         }
         $result[$this->_appName] = $appAttributes;
         return $result;
+    }
+
+    /**
+     * @param array $extra
+     * @return array
+     */
+    protected function _encodeExtra(array $extra) {
+        return $extra;
     }
 
     /**

--- a/library/CM/Log/ContextFormatter/Fluentd.php
+++ b/library/CM/Log/ContextFormatter/Fluentd.php
@@ -1,0 +1,26 @@
+<?php
+
+class CM_Log_ContextFormatter_Fluentd extends CM_Log_ContextFormatter_Cargomedia {
+
+    /**
+     * @param array $extra
+     * @return array
+     */
+    protected function _encodeExtra(array $extra) {
+        array_walk_recursive($extra, function (&$value) {
+            $encoded = $value;
+            if ($value instanceof DateTime) {
+                $encoded = $value->format('c');
+            } elseif (is_object($value)) {
+                $encoded = '[';
+                $encoded .= get_class($value);
+                if ($value instanceof CM_Model_Abstract) {
+                    $encoded .= ':' . $value->getId();
+                }
+                $encoded .= ']';
+            }
+            $value = $encoded;
+        });
+        return $extra;
+    }
+}

--- a/library/CM/Log/ContextFormatter/Interface.php
+++ b/library/CM/Log/ContextFormatter/Interface.php
@@ -3,12 +3,6 @@
 interface CM_Log_ContextFormatter_Interface {
 
     /**
-     * @param CM_Log_Record $record
-     * @return array
-     */
-    public function formatRecordContext(CM_Log_Record $record);
-
-    /**
      * @param CM_Log_Context $context
      * @return array
      */

--- a/library/CM/Log/ContextFormatter/MongoDb.php
+++ b/library/CM/Log/ContextFormatter/MongoDb.php
@@ -2,6 +2,8 @@
 
 class CM_Log_ContextFormatter_MongoDb implements CM_Log_ContextFormatter_Interface {
 
+    const DEFAULT_TYPE = 0;
+
     public function formatContext(CM_Log_Context $context) {
         $computerInfo = $context->getComputerInfo();
         $user = $context->getUser();
@@ -15,9 +17,10 @@ class CM_Log_ContextFormatter_MongoDb implements CM_Log_ContextFormatter_Interfa
                 'phpVersion' => $computerInfo->getPhpVersion(),
             ];
         }
-        if ($extra) {
-            $formattedContext['extra'] = $this->_encodeExtra($extra);
+        if (!isset($extra['type'])) {
+            $extra['type'] = self::DEFAULT_TYPE;
         }
+        $formattedContext['extra'] = $this->_encodeExtra($extra);
         if (null !== $user) {
             $formattedContext['user'] = [
                 'id'   => $user->getId(),

--- a/library/CM/Log/ContextFormatter/MongoDb.php
+++ b/library/CM/Log/ContextFormatter/MongoDb.php
@@ -1,0 +1,88 @@
+<?php
+
+class CM_Log_ContextFormatter_MongoDb implements CM_Log_ContextFormatter_Interface {
+
+    public function formatContext(CM_Log_Context $context) {
+        $computerInfo = $context->getComputerInfo();
+        $user = $context->getUser();
+        $extra = $context->getExtra();
+        $request = $context->getHttpRequest();
+
+        $formattedContext = [];
+        if (null !== $computerInfo) {
+            $formattedContext['computerInfo'] = [
+                'fqdn'       => $computerInfo->getFullyQualifiedDomainName(),
+                'phpVersion' => $computerInfo->getPhpVersion(),
+            ];
+        }
+        if ($extra) {
+            $formattedContext['extra'] = $this->_encodeExtra($extra);
+        }
+        if (null !== $user) {
+            $formattedContext['user'] = [
+                'id'   => $user->getId(),
+                'name' => $user->getDisplayName(),
+            ];
+        }
+        if (null !== $request) {
+            $formattedContext['httpRequest'] = [
+                'method'  => $request->getMethodName(),
+                'uri'     => $request->getUri(),
+                'query'   => [],
+                'server'  => $request->getServer(),
+                'headers' => $request->getHeaders(),
+            ];
+
+            $formattedContext['httpRequest']['query'] = $request->findQuery();
+
+            if ($request instanceof CM_Http_Request_Post) {
+                $formattedContext['httpRequest']['body'] = $request->getBody();
+            }
+
+            $formattedContext['httpRequest']['clientId'] = $request->getClientId();
+        }
+
+        if ($exception = $context->getException()) {
+            $serializableException = new CM_ExceptionHandling_SerializableException($exception);
+            $formattedContext['exception'] = [
+                'class'       => $serializableException->getClass(),
+                'message'     => $serializableException->getMessage(),
+                'line'        => $serializableException->getLine(),
+                'file'        => $serializableException->getFile(),
+                'trace'       => $serializableException->getTrace(),
+                'traceString' => $serializableException->getTraceAsString(),
+                'meta'        => $serializableException->getMeta(),
+            ];
+        }
+
+        return $formattedContext;
+    }
+
+    public function formatAppContext(CM_Log_Context $context) {
+        throw new CM_Exception_NotImplemented();
+    }
+
+    /**
+     * @param array $extra
+     * @return array
+     */
+    protected function _encodeExtra(array $extra) {
+        array_walk_recursive($extra, function (&$value) {
+            $encoded = $value;
+            if ($value instanceof DateTime) {
+                $encoded = new MongoDate($value->getTimestamp());
+            } elseif ($value instanceof CM_Model_Abstract) {
+                $encoded = '[' . get_class($value) . ':' . $value->getId() . ']';
+            } elseif ($value instanceof JsonSerializable) {
+                $encoded = $value->jsonSerialize();
+                if (is_array($encoded)) {
+                    $encoded = $this->_encodeExtra($encoded);
+                }
+            } elseif (is_object($value)) {
+                $encoded = '[' . get_class($value) . ']';
+            }
+            $value = $encoded;
+        });
+        return $extra;
+    }
+}

--- a/library/CM/Log/Handler/Factory.php
+++ b/library/CM/Log/Handler/Factory.php
@@ -67,7 +67,7 @@ class CM_Log_Handler_Factory implements CM_Service_ManagerAwareInterface {
     public function createFluentdLogger($hostname, $port, $tag, $minLevel = null) {
         $fluentd = new \Fluent\Logger\FluentLogger($hostname, $port);
         $appName = CM_App::getInstance()->getName();
-        $contextFormatter = new CM_Log_ContextFormatter_Cargomedia($appName);
+        $contextFormatter = new CM_Log_ContextFormatter_Fluentd($appName);
         return new CM_Log_Handler_Fluentd($fluentd, $contextFormatter, $tag, $minLevel);
     }
 

--- a/library/CM/Log/Handler/Factory.php
+++ b/library/CM/Log/Handler/Factory.php
@@ -72,6 +72,19 @@ class CM_Log_Handler_Factory implements CM_Service_ManagerAwareInterface {
     }
 
     /**
+     * @param string     $collection
+     * @param int|null   $recordTtl Time To Live in seconds
+     * @param array|null $insertOptions
+     * @param int|null   $minLevel
+     * @return CM_Log_Handler_MongoDb
+     */
+    public function createMongoDbHandler($collection, $recordTtl = null, array $insertOptions = null, $minLevel = null) {
+        $client = $this->getServiceManager()->getMongoDb();
+        $contextFormatter = new CM_Log_ContextFormatter_MongoDb();
+        return new CM_Log_Handler_MongoDb($client, $contextFormatter, $collection, $recordTtl, $insertOptions, $minLevel);
+    }
+
+    /**
      * @param CM_OutputStream_Interface $stream
      * @param CM_Log_Formatter_Abstract $formatter
      * @param int|null                  $minLevel

--- a/library/CM/Log/Handler/Fluentd.php
+++ b/library/CM/Log/Handler/Fluentd.php
@@ -47,7 +47,16 @@ class CM_Log_Handler_Fluentd extends CM_Log_Handler_Abstract {
      * @return array
      */
     protected function _formatRecord(CM_Log_Record $record) {
-        return $this->_contextFormatter->formatRecordContext($record);
+        $levelsMapping = array_flip(CM_Log_Logger::getLevels());
+        $context = $record->getContext();
+
+        $result = [
+            'message'   => (string) $record->getMessage(),
+            'level'     => strtolower($levelsMapping[$record->getLevel()]),
+            'timestamp' => $record->getCreatedAt()->format(DateTime::ISO8601),
+        ];
+        $result = array_merge($result, $this->_contextFormatter->formatContext($context));
+        return $result;
     }
 
     /**

--- a/library/CM/Log/Handler/MongoDb.php
+++ b/library/CM/Log/Handler/MongoDb.php
@@ -2,8 +2,6 @@
 
 class CM_Log_Handler_MongoDb extends CM_Log_Handler_Abstract {
 
-    const DEFAULT_TYPE = 0;
-
     /** @var  string */
     protected $_collection;
 

--- a/library/CM/Log/Handler/MongoDb.php
+++ b/library/CM/Log/Handler/MongoDb.php
@@ -8,6 +8,9 @@ class CM_Log_Handler_MongoDb extends CM_Log_Handler_Abstract {
     /** @var int|null */
     protected $_recordTtl = null;
 
+    /** @var CM_Log_ContextFormatter_Interface */
+    protected $_contextFormatter;
+
     /** @var  CM_MongoDb_Client */
     protected $_mongoDb;
 
@@ -15,23 +18,27 @@ class CM_Log_Handler_MongoDb extends CM_Log_Handler_Abstract {
     protected $_insertOptions;
 
     /**
-     * @param string   $collection
-     * @param int|null $recordTtl Time To Live in seconds
-     * @param array    $insertOptions
-     * @param int|null $minLevel
+     * CM_Log_Handler_MongoDb constructor.
+     * @param CM_MongoDb_Client                 $client
+     * @param CM_Log_ContextFormatter_Interface $contextFormatter
+     * @param string                            $collection
+     * @param int|null                          $recordTtl Time To Live in seconds
+     * @param array|null                        $insertOptions
+     * @param int|null                          $minLevel
      * @throws CM_Exception_Invalid
      */
-    public function __construct($collection, $recordTtl = null, array $insertOptions = null, $minLevel = null) {
+    public function __construct(CM_MongoDb_Client $client, CM_Log_ContextFormatter_Interface $contextFormatter, $collection,
+                                $recordTtl = null, array $insertOptions = null, $minLevel = null) {
         parent::__construct($minLevel);
+        $this->_contextFormatter = $contextFormatter;
         $this->_collection = (string) $collection;
-        $this->_mongoDb = CM_Service_Manager::getInstance()->getMongoDb();
+        $this->_mongoDb = $client;
         if (null !== $recordTtl) {
             $this->_recordTtl = (int) $recordTtl;
             if ($this->_recordTtl <= 0) {
                 throw new CM_Exception_Invalid('TTL should be positive value');
             }
         };
-
         $this->_insertOptions = null !== $insertOptions ? $insertOptions : ['w' => 0];
     }
 
@@ -49,67 +56,12 @@ class CM_Log_Handler_MongoDb extends CM_Log_Handler_Abstract {
      * @return array
      */
     protected function _formatRecord(CM_Log_Record $record) {
-        $recordContext = $record->getContext();
-
-        $computerInfo = $recordContext->getComputerInfo();
-        $user = $recordContext->getUser();
-        $extra = $recordContext->getExtra();
-        $request = $recordContext->getHttpRequest();
-
         $createdAt = $record->getCreatedAt();
-
-        $formattedContext = [];
-        if (null !== $computerInfo) {
-            $formattedContext['computerInfo'] = [
-                'fqdn'       => $computerInfo->getFullyQualifiedDomainName(),
-                'phpVersion' => $computerInfo->getPhpVersion(),
-            ];
-        }
-        if ($extra) {
-            $formattedContext['extra'] = $extra;
-        }
-        if (null !== $user) {
-            $formattedContext['user'] = [
-                'id'   => $user->getId(),
-                'name' => $user->getDisplayName(),
-            ];
-        }
-        if (null !== $request) {
-            $formattedContext['httpRequest'] = [
-                'method'  => $request->getMethodName(),
-                'uri'     => $request->getUri(),
-                'query'   => [],
-                'server'  => $request->getServer(),
-                'headers' => $request->getHeaders(),
-            ];
-
-            $formattedContext['httpRequest']['query'] = $request->findQuery();
-            
-            if ($request instanceof CM_Http_Request_Post) {
-                $formattedContext['httpRequest']['body'] = $request->getBody();
-            }
-
-            $formattedContext['httpRequest']['clientId'] = $request->getClientId();
-        }
-
-        if ($exception = $recordContext->getException()) {
-            $serializableException = new CM_ExceptionHandling_SerializableException($exception);
-            $formattedContext['exception'] = [
-                'class'       => $serializableException->getClass(),
-                'message'     => $serializableException->getMessage(),
-                'line'        => $serializableException->getLine(),
-                'file'        => $serializableException->getFile(),
-                'trace'       => $serializableException->getTrace(),
-                'traceString' => $serializableException->getTraceAsString(),
-                'meta'        => $serializableException->getMeta(),
-            ];
-        }
-
         $formattedRecord = [
             'level'     => (int) $record->getLevel(),
             'message'   => (string) $record->getMessage(),
             'createdAt' => new MongoDate($createdAt->getTimestamp()),
-            'context'   => $formattedContext,
+            'context'   => $this->_contextFormatter->formatContext($record->getContext()),
         ];
 
         if (null !== $this->_recordTtl) {

--- a/resources/config/default.php
+++ b/resources/config/default.php
@@ -273,13 +273,16 @@ return function (CM_Config_Node $config) {
     ];
 
     $config->services['logger-handler-mongodb'] = [
-        'class'     => 'CM_Log_Handler_MongoDb',
-        'arguments' => [
+        'class'  => 'CM_Log_Handler_Factory',
+        'method' => [
+            'name'      => 'createMongoDbHandler',
+            'arguments' => [
             'collection'    => 'cm_log',
             'recordTtl'     => null,
             'insertOptions' => null,
             'minLevel'      => CM_Log_Logger::DEBUG,
-        ],
+            ],
+        ]
     ];
 
     $config->services['logger-handler-file-error'] = [

--- a/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
+++ b/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
@@ -3,8 +3,6 @@
 class CM_Log_ContextFormatter_CargomediaTest extends CMTest_TestCase {
 
     public function testGetRecordContext() {
-        $level = CM_Log_Logger::DEBUG;
-        $message = 'foo';
         $user = CMTest_TH::createUser();
         $httpRequest = CM_Http_Request_Abstract::factory(
             'post',
@@ -30,17 +28,13 @@ class CM_Log_ContextFormatter_CargomediaTest extends CMTest_TestCase {
         $context->setException($exception);
         $context->setComputerInfo($computerInfo);
         $context->setHttpRequest($httpRequest);
-        $record = new CM_Log_Record($level, $message, $context);
 
         $contextFormatter = new CM_Log_ContextFormatter_Cargomedia('appName');
-        $formattedRecord = $contextFormatter->formatRecordContext($record);
+        $formattedContext = $contextFormatter->formatContext($context);
 
-        $this->assertSame($message, $formattedRecord['message']);
-        $this->assertSame('debug', $formattedRecord['level']);
-        $this->assertArrayHasKey('timestamp', $formattedRecord);
-        $this->assertSame('www.example.com', $formattedRecord['computerInfo']['fqdn']);
-        $this->assertSame('v7.0.1', $formattedRecord['computerInfo']['phpVersion']);
-        $this->assertSame('/foo?bar=1&baz=quux&viewInfoList=fooBar', $formattedRecord['httpRequest']['uri']);
+        $this->assertSame('www.example.com', $formattedContext['computerInfo']['fqdn']);
+        $this->assertSame('v7.0.1', $formattedContext['computerInfo']['phpVersion']);
+        $this->assertSame('/foo?bar=1&baz=quux&viewInfoList=fooBar', $formattedContext['httpRequest']['uri']);
         $this->assertSame(
             [
                 ['key' => 'bar', 'value' => '1'],
@@ -48,24 +42,24 @@ class CM_Log_ContextFormatter_CargomediaTest extends CMTest_TestCase {
                 ['key' => 'foo', 'value' => 'bar'],
                 ['key' => 'quux', 'value' => 'baz'],
             ],
-            $formattedRecord['httpRequest']['query']
+            $formattedContext['httpRequest']['query']
         );
 
-        $this->assertSame('POST', $formattedRecord['httpRequest']['method']);
-        $this->assertSame('http://bar/baz', $formattedRecord['httpRequest']['referer']);
-        $this->assertSame('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_10)', $formattedRecord['httpRequest']['useragent']);
-        $this->assertSame('foo.bar', $formattedRecord['httpRequest']['hostname']);
-        $this->assertSame($user->getId(), $formattedRecord['appName']['user']);
-        $this->assertSame($clientId, $formattedRecord['appName']['clientId']);
-        $this->assertSame('baz', $formattedRecord['appName']['bar']);
-        $this->assertSame('quux', $formattedRecord['appName']['baz']);
+        $this->assertSame('POST', $formattedContext['httpRequest']['method']);
+        $this->assertSame('http://bar/baz', $formattedContext['httpRequest']['referer']);
+        $this->assertSame('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_10)', $formattedContext['httpRequest']['useragent']);
+        $this->assertSame('foo.bar', $formattedContext['httpRequest']['hostname']);
+        $this->assertSame($user->getId(), $formattedContext['appName']['user']);
+        $this->assertSame($clientId, $formattedContext['appName']['clientId']);
+        $this->assertSame('baz', $formattedContext['appName']['bar']);
+        $this->assertSame('quux', $formattedContext['appName']['baz']);
 
-        $this->assertSame('CM_Exception_Invalid', $formattedRecord['exception']['type']);
-        $this->assertSame('Bad', $formattedRecord['exception']['message']);
-        $this->assertArrayHasKey('stack', $formattedRecord['exception']);
-        $this->assertInternalType('string', $formattedRecord['exception']['stack']);
-        $this->assertSame(['foo' => "'bar'"], $formattedRecord['exception']['metaInfo']);
-        $this->assertRegExp('/library\/CM\/Log\/ContextFormatter\/CargomediaTest\.php\(\d+\)/', $formattedRecord['exception']['stack']);
+        $this->assertSame('CM_Exception_Invalid', $formattedContext['exception']['type']);
+        $this->assertSame('Bad', $formattedContext['exception']['message']);
+        $this->assertArrayHasKey('stack', $formattedContext['exception']);
+        $this->assertInternalType('string', $formattedContext['exception']['stack']);
+        $this->assertSame(['foo' => "'bar'"], $formattedContext['exception']['metaInfo']);
+        $this->assertRegExp('/library\/CM\/Log\/ContextFormatter\/CargomediaTest\.php\(\d+\)/', $formattedContext['exception']['stack']);
     }
 
     public function testArrayEncoding() {

--- a/tests/library/CM/Log/ContextFormatter/FluentdTest.php
+++ b/tests/library/CM/Log/ContextFormatter/FluentdTest.php
@@ -2,6 +2,59 @@
 
 class CM_Log_ContextFormatter_FluentdTest extends CMTest_TestCase {
 
+    public function testFormatContext() {
+        $user = CMTest_TH::createUser();
+        $httpRequest = CM_Http_Request_Abstract::factory('post', '/foo');
+        $computerInfo = new CM_Log_Context_ComputerInfo('www.example.com', 'v7.0.1');
+        $context = new CM_Log_Context();
+        $context->setExtra([
+            'bar' => 1,
+            'a'   => new DateTime('2000-01-01'),
+            'b'   => (object) ['foo' => 1],
+            'c'   => new CM_Model_ContextFormatter_Fluentd_Mock(123, ['foo' => 'bar1']),
+            'd'   => new CM_Frontend_JsonSerializable(['foo' => 'bar2']),
+            'foo' => [
+                'a' => new DateTime('2000-01-02'),
+                'b' => (object) ['foo' => 2],
+                'c' => new CM_Model_ContextFormatter_Fluentd_Mock(456, ['foo' => 'bar3']),
+                'd' => new CM_Frontend_JsonSerializable(['foo' => 'bar4']),
+            ]
+        ]);
+        $context->setUser($user);
+        $context->setComputerInfo($computerInfo);
+        $context->setHttpRequest($httpRequest);
+
+        $contextFormatter = new CM_Log_ContextFormatter_Fluentd('appName');
+        $formattedContext = $contextFormatter->formatContext($context);
+
+        $this->assertSame([
+            'computerInfo' => [
+                'fqdn'       => 'www.example.com',
+                'phpVersion' => 'v7.0.1',
+            ],
+            'httpRequest'  => [
+                'uri'    => '/foo',
+                'method' => 'POST',
+                'query'  => [],
+            ],
+            'appName'      => [
+                'bar'      => 1,
+                'a'        => '2000-01-01T00:00:00+00:00',
+                'b'        => '[stdClass]',
+                'c'        => '[CM_Model_ContextFormatter_Fluentd_Mock:123]',
+                'd'        => '[CM_Frontend_JsonSerializable]',
+                'foo'      => [
+                    'a' => '2000-01-02T00:00:00+00:00',
+                    'b' => '[stdClass]',
+                    'c' => '[CM_Model_ContextFormatter_Fluentd_Mock:456]',
+                    'd' => '[CM_Frontend_JsonSerializable]',
+                ],
+                'user'     => $user->getId(),
+                'clientId' => $httpRequest->getClientId(),
+            ]
+        ], $formattedContext);
+    }
+
     public function testFormatAppContext() {
         $user = CMTest_TH::createUser();
         $httpRequest = CM_Http_Request_Abstract::factory('post', '/foo');
@@ -11,12 +64,12 @@ class CM_Log_ContextFormatter_FluentdTest extends CMTest_TestCase {
             'bar' => 1,
             'a'   => new DateTime('2000-01-01'),
             'b'   => (object) ['foo' => 1],
-            'c'   => new CM_ModelMock(123, ['foo' => 'bar1']),
+            'c'   => new CM_Model_ContextFormatter_Fluentd_Mock(123, ['foo' => 'bar1']),
             'd'   => new CM_Frontend_JsonSerializable(['foo' => 'bar2']),
             'foo' => [
                 'a' => new DateTime('2000-01-02'),
                 'b' => (object) ['foo' => 2],
-                'c' => new CM_ModelMock(456, ['foo' => 'bar3']),
+                'c' => new CM_Model_ContextFormatter_Fluentd_Mock(456, ['foo' => 'bar3']),
                 'd' => new CM_Frontend_JsonSerializable(['foo' => 'bar4']),
             ]
         ]);
@@ -32,12 +85,12 @@ class CM_Log_ContextFormatter_FluentdTest extends CMTest_TestCase {
                 'bar'      => 1,
                 'a'        => '2000-01-01T00:00:00+00:00',
                 'b'        => '[stdClass]',
-                'c'        => '[CM_ModelMock:123]',
+                'c'        => '[CM_Model_ContextFormatter_Fluentd_Mock:123]',
                 'd'        => '[CM_Frontend_JsonSerializable]',
                 'foo'      => [
                     'a' => '2000-01-02T00:00:00+00:00',
                     'b' => '[stdClass]',
-                    'c' => '[CM_ModelMock:456]',
+                    'c' => '[CM_Model_ContextFormatter_Fluentd_Mock:456]',
                     'd' => '[CM_Frontend_JsonSerializable]',
                 ],
                 'user'     => $user->getId(),
@@ -47,7 +100,7 @@ class CM_Log_ContextFormatter_FluentdTest extends CMTest_TestCase {
     }
 }
 
-class CM_ModelMock extends CM_Model_Abstract {
+class CM_Model_ContextFormatter_Fluentd_Mock extends CM_Model_Abstract {
 
     protected function _getData() {
         return [];

--- a/tests/library/CM/Log/ContextFormatter/FluentdTest.php
+++ b/tests/library/CM/Log/ContextFormatter/FluentdTest.php
@@ -1,0 +1,59 @@
+<?php
+
+class CM_Log_ContextFormatter_FluentdTest extends CMTest_TestCase {
+
+    public function testFormatAppContext() {
+        $user = CMTest_TH::createUser();
+        $httpRequest = CM_Http_Request_Abstract::factory('post', '/foo');
+        $computerInfo = new CM_Log_Context_ComputerInfo('www.example.com', 'v7.0.1');
+        $context = new CM_Log_Context();
+        $context->setExtra([
+            'bar' => 1,
+            'a'   => new DateTime('2000-01-01'),
+            'b'   => (object) ['foo' => 1],
+            'c'   => new CM_ModelMock(123, ['foo' => 'bar1']),
+            'd'   => new CM_Frontend_JsonSerializable(['foo' => 'bar2']),
+            'foo' => [
+                'a' => new DateTime('2000-01-02'),
+                'b' => (object) ['foo' => 2],
+                'c' => new CM_ModelMock(456, ['foo' => 'bar3']),
+                'd' => new CM_Frontend_JsonSerializable(['foo' => 'bar4']),
+            ]
+        ]);
+        $context->setUser($user);
+        $context->setComputerInfo($computerInfo);
+        $context->setHttpRequest($httpRequest);
+
+        $contextFormatter = new CM_Log_ContextFormatter_Fluentd('appName');
+        $formattedContext = $contextFormatter->formatAppContext($context);
+
+        $this->assertSame([
+            'appName' => [
+                'bar'      => 1,
+                'a'        => '2000-01-01T00:00:00+00:00',
+                'b'        => '[stdClass]',
+                'c'        => '[CM_ModelMock:123]',
+                'd'        => '[CM_Frontend_JsonSerializable]',
+                'foo'      => [
+                    'a' => '2000-01-02T00:00:00+00:00',
+                    'b' => '[stdClass]',
+                    'c' => '[CM_ModelMock:456]',
+                    'd' => '[CM_Frontend_JsonSerializable]',
+                ],
+                'user'     => $user->getId(),
+                'clientId' => $httpRequest->getClientId(),
+            ]
+        ], $formattedContext);
+    }
+}
+
+class CM_ModelMock extends CM_Model_Abstract {
+
+    protected function _getData() {
+        return [];
+    }
+
+    public static function getTypeStatic() {
+        return 1;
+    }
+}

--- a/tests/library/CM/Log/ContextFormatter/MongoDbTest.php
+++ b/tests/library/CM/Log/ContextFormatter/MongoDbTest.php
@@ -1,0 +1,95 @@
+<?php
+
+class CM_Log_ContextFormatter_MongoDbTest extends CMTest_TestCase {
+
+    public function testFormatContext() {
+        $user = CMTest_TH::createUser();
+        $httpRequest = CM_Http_Request_Abstract::factory('post', '/foo');
+        $computerInfo = new CM_Log_Context_ComputerInfo('www.example.com', 'v7.0.1');
+        $context = new CM_Log_Context();
+        $context->setExtra([
+            'bar' => 1,
+            'a'   => new DateTime('2000-01-01'),
+            'b'   => (object) ['foo' => 1],
+            'c'   => new CM_Model_ContextFormatter_MongoDb_Mock(123, ['foo' => 'bar1']),
+            'd'   => new CM_Frontend_JsonSerializable(['foo' => 'bar2']),
+            'foo' => [
+                'a' => new DateTime('2000-01-02'),
+                'b' => (object) ['foo' => 2],
+                'c' => new CM_Model_ContextFormatter_MongoDb_Mock(456, ['foo' => 'bar3']),
+                'd' => new CM_Frontend_JsonSerializable([
+                    'foo' => 'bar4',
+                    'bar' => new DateTime('2000-01-03'),
+                    'baz' => new CM_Model_ContextFormatter_MongoDb_Mock(789, ['foo' => 'bar4']),
+                ]),
+            ]
+        ]);
+        $context->setUser($user);
+        $context->setComputerInfo($computerInfo);
+        $context->setHttpRequest($httpRequest);
+
+        $contextFormatter = new CM_Log_ContextFormatter_MongoDb();
+        $formattedContext = $contextFormatter->formatContext($context);
+
+        $this->assertSame([
+            'fqdn'       => 'www.example.com',
+            'phpVersion' => 'v7.0.1',
+        ], $formattedContext['computerInfo']);
+        $this->assertSame([
+            'method'   => 'POST',
+            'uri'      => '/foo',
+            'query'    => [],
+            'server'   => [],
+            'headers'  => [],
+            'body'     => '',
+            'clientId' => 1,
+        ], $formattedContext['httpRequest']);
+        $this->assertSame([
+            'id'   => $user->getId(),
+            'name' => $user->getDisplayName(),
+        ], $formattedContext['user']);
+
+        $extra = $formattedContext['extra'];
+        $this->assertInstanceOf('MongoDate', $extra['a']);
+        $this->assertInstanceOf('MongoDate', $extra['foo']['a']);
+        $this->assertInstanceOf('MongoDate', $extra['foo']['d']['bar']);
+        unset($extra['a']);
+        unset($extra['foo']['a']);
+        unset($extra['foo']['d']['bar']);
+        $this->assertSame([
+            'bar' => 1,
+            'b'   => '[stdClass]',
+            'c'   => '[CM_Model_ContextFormatter_MongoDb_Mock:123]',
+            'd'   => [
+                'foo' => 'bar2',
+            ],
+            'foo' => [
+                'b' => '[stdClass]',
+                'c' => '[CM_Model_ContextFormatter_MongoDb_Mock:456]',
+                'd' => [
+                    'foo' => 'bar4',
+                    'baz' => '[CM_Model_ContextFormatter_MongoDb_Mock:789]',
+                ],
+            ],
+        ], $extra);
+    }
+
+    public function testFormatAppContext() {
+        $formatter = new CM_Log_ContextFormatter_MongoDb();
+        $exception = $this->catchException(function () use ($formatter) {
+            $formatter->formatAppContext(new CM_Log_Context());
+        });
+        $this->assertInstanceOf('CM_Exception_NotImplemented', $exception);
+    }
+}
+
+class CM_Model_ContextFormatter_MongoDb_Mock extends CM_Model_Abstract {
+
+    protected function _getData() {
+        return [];
+    }
+
+    public static function getTypeStatic() {
+        return 1;
+    }
+}

--- a/tests/library/CM/Log/ContextFormatter/MongoDbTest.php
+++ b/tests/library/CM/Log/ContextFormatter/MongoDbTest.php
@@ -57,13 +57,13 @@ class CM_Log_ContextFormatter_MongoDbTest extends CMTest_TestCase {
         unset($extra['foo']['a']);
         unset($extra['foo']['d']['bar']);
         $this->assertSame([
-            'bar' => 1,
-            'b'   => '[stdClass]',
-            'c'   => '[CM_Model_ContextFormatter_MongoDb_Mock:123]',
-            'd'   => [
+            'bar'  => 1,
+            'b'    => '[stdClass]',
+            'c'    => '[CM_Model_ContextFormatter_MongoDb_Mock:123]',
+            'd'    => [
                 'foo' => 'bar2',
             ],
-            'foo' => [
+            'foo'  => [
                 'b' => '[stdClass]',
                 'c' => '[CM_Model_ContextFormatter_MongoDb_Mock:456]',
                 'd' => [
@@ -71,6 +71,7 @@ class CM_Log_ContextFormatter_MongoDbTest extends CMTest_TestCase {
                     'baz' => '[CM_Model_ContextFormatter_MongoDb_Mock:789]',
                 ],
             ],
+            'type' => CM_Log_ContextFormatter_MongoDb::DEFAULT_TYPE,
         ], $extra);
     }
 

--- a/tests/library/CM/Log/ContextTest.php
+++ b/tests/library/CM/Log/ContextTest.php
@@ -13,17 +13,4 @@ class CM_Log_ContextTest extends CMTest_TestCase {
         $context->setHttpRequest($request);
         $this->assertSame($request, $context->getHttpRequest());
     }
-
-    public function testSetExtra() {
-        $extra = ['foo' => 'bar', 'baz' => ['quux' => 1, 'foo' => 0]];
-        $context = new CM_Log_Context();
-        $context->setExtra($extra);
-        $this->assertSame($extra, $context->getExtra());
-
-        $exception = $this->catchException(function () use ($context) {
-            $context->setExtra(['foo' => 'bar', 'fooBar' => ['1' => ['2' => new stdClass()]]]);
-        });
-        $this->assertInstanceOf('CM_Exception_Invalid', $exception);
-        $this->assertSame('Object can not be passed to "Extra"', $exception->getMessage());
-    }
 }

--- a/tests/library/CM/Log/Handler/FluentdTest.php
+++ b/tests/library/CM/Log/Handler/FluentdTest.php
@@ -22,16 +22,18 @@ class CM_Log_Handler_FluentdTest extends CMTest_TestCase {
         /** @var \Fluent\Logger\FluentLogger $fluentd */
 
         $contextFormatter = $this->mockInterface('CM_Log_ContextFormatter_Interface')->newInstanceWithoutConstructor();
-        $getRecordContext = $contextFormatter->mockMethod('formatRecordContext')->set('formatted-record');
+        $getFromattedContext = $contextFormatter->mockMethod('formatContext')->set(['bar' => 'foo']);
         /** @var CM_Log_ContextFormatter_Interface $contextFormatter */
 
         $handler = new CM_Log_Handler_Fluentd($fluentd, $contextFormatter, 'tag');
-        $record = $this->mockClass('CM_Log_Record')->newInstanceWithoutConstructor();
+        $record = new CM_Log_Record(CM_Log_Logger::DEBUG, 'log message foo', new CM_Log_Context());
         $formattedRecord = $this->callProtectedMethod($handler, '_formatRecord', [$record]);
 
-        $this->assertSame(1, $getRecordContext->getCallCount());
-        $this->assertSame($record, $getRecordContext->getLastCall()->getArgument(0));
-        $this->assertSame('formatted-record', $formattedRecord);
+        $this->assertSame(1, $getFromattedContext->getCallCount());
+        $this->assertSame('log message foo', $formattedRecord['message']);
+        $this->assertSame('debug', $formattedRecord['level']);
+        $this->assertSame('foo', $formattedRecord['bar']);
+        $this->assertArrayHasKey('timestamp', $formattedRecord);
     }
 
     public function testWriteRecord() {
@@ -39,13 +41,17 @@ class CM_Log_Handler_FluentdTest extends CMTest_TestCase {
         $postMock = $fluentd->mockMethod('post')->set(
             function ($tag, array $data) {
                 $this->assertSame('tag', $tag);
+                $this->assertSame('critical', $data['level']);
+                $this->assertSame('foo', $data['message']);
+                $this->assertArrayHasKey('timestamp', $data);
                 $this->assertSame('value', $data['key']);
+
             }
         );
         /** @var \Fluent\Logger\FluentLogger $fluentd */
 
         $contextFormatter = $this->mockInterface('CM_Log_ContextFormatter_Interface')->newInstanceWithoutConstructor();
-        $contextFormatter->mockMethod('formatRecordContext')->set(['key' => 'value']);
+        $contextFormatter->mockMethod('formatContext')->set(['key' => 'value']);
         /** @var CM_Log_ContextFormatter_Interface $contextFormatter */
 
         $handler = new CM_Log_Handler_Fluentd($fluentd, $contextFormatter, 'tag');

--- a/tests/library/CM/Log/Handler/MongoDbTest.php
+++ b/tests/library/CM/Log/Handler/MongoDbTest.php
@@ -85,7 +85,7 @@ class CM_Log_Handler_MongoDbTest extends CMTest_TestCase {
         $this->assertSame(
             [
                 'bar'  => ['baz' => 'quux'],
-                'type' => CM_Log_Handler_MongoDb::DEFAULT_TYPE,
+                'type' => CM_Log_ContextFormatter_MongoDb::DEFAULT_TYPE,
             ],
             $context['extra']
         );
@@ -93,12 +93,14 @@ class CM_Log_Handler_MongoDbTest extends CMTest_TestCase {
     }
 
     public function testWritingTyped() {
+        $mongoClient = $this->getServiceManager()->getMongoDb();
+        $contextFormatter = new CM_Log_ContextFormatter_MongoDb();
+
         $collection = 'cm_log';
         $level = CM_Log_Logger::INFO;
         $message = 'foo';
         $computerInfo = new CM_Log_Context_ComputerInfo('www.example.com', 'v7.0.1');
 
-        $mongoClient = $this->getServiceManager()->getMongoDb();
         $this->assertSame(0, $mongoClient->count($collection));
 
         $recordContext = new CM_Log_Context();
@@ -109,7 +111,7 @@ class CM_Log_Handler_MongoDbTest extends CMTest_TestCase {
         $recordContext->setComputerInfo($computerInfo);
         $record = new CM_Log_Record($level, $message, $recordContext);
 
-        $handler = new CM_Log_Handler_MongoDb($collection, null, ['w' => 0], $level);
+        $handler = new CM_Log_Handler_MongoDb($mongoClient, $contextFormatter, $collection, null, ['w' => 0], $level);
         $this->callProtectedMethod($handler, '_writeRecord', [$record]);
         $this->assertSame(1, $mongoClient->count($collection));
 

--- a/tests/library/CM/Log/Handler/MongoDbTest.php
+++ b/tests/library/CM/Log/Handler/MongoDbTest.php
@@ -7,16 +7,23 @@ class CM_Log_Handler_MongoDbTest extends CMTest_TestCase {
     }
 
     public function testConstructor() {
-        $handler = new CM_Log_Handler_MongoDb('foo');
+        /** @var CM_MongoDb_Client $client */
+        $client = $this->mockClass('CM_MongoDb_Client')->newInstanceWithoutConstructor();
+        /** @var CM_Log_ContextFormatter_Interface $contextFormatter */
+        $contextFormatter = $this->mockInterface('CM_Log_ContextFormatter_Interface')->newInstanceWithoutConstructor();
+
+        $handler = new CM_Log_Handler_MongoDb($client, $contextFormatter, 'foo');
         $this->assertInstanceOf('CM_Log_Handler_MongoDb', $handler);
     }
 
     public function testFailWithWrongTtl() {
         $collection = 'cm_event_log';
+        /** @var CM_Log_ContextFormatter_Interface $contextFormatter */
+        $contextFormatter = $this->mockInterface('CM_Log_ContextFormatter_Interface')->newInstanceWithoutConstructor();
         $mongoClient = $this->getServiceManager()->getMongoDb();
         $mongoClient->createIndex($collection, ['expireAt' => 1], ['expireAfterSeconds' => 0]);
-        $exception = $this->catchException(function () use ($collection) {
-            new CM_Log_Handler_MongoDb($collection, -10);
+        $exception = $this->catchException(function () use ($collection, $mongoClient, $contextFormatter) {
+            new CM_Log_Handler_MongoDb($mongoClient, $contextFormatter, $collection, -10);
         });
 
         $this->assertInstanceOf('CM_Exception_Invalid', $exception);
@@ -24,6 +31,9 @@ class CM_Log_Handler_MongoDbTest extends CMTest_TestCase {
     }
 
     public function testWriting() {
+        $mongoClient = $this->getServiceManager()->getMongoDb();
+        $contextFormatter = new CM_Log_ContextFormatter_MongoDb();
+
         $collection = 'cm_event_log';
         $level = CM_Log_Logger::DEBUG;
         $message = 'foo';
@@ -33,7 +43,6 @@ class CM_Log_Handler_MongoDbTest extends CMTest_TestCase {
         $clientId = $httpRequest->getClientId();
         $computerInfo = new CM_Log_Context_ComputerInfo('www.example.com', 'v7.0.1');
 
-        $mongoClient = $this->getServiceManager()->getMongoDb();
         $this->assertSame(0, $mongoClient->count($collection));
 
         $mongoClient->createIndex($collection, ['expireAt' => 1], ['expireAfterSeconds' => 0]);
@@ -44,7 +53,7 @@ class CM_Log_Handler_MongoDbTest extends CMTest_TestCase {
         $recordContext->setComputerInfo($computerInfo);
         $record = new CM_Log_Record($level, $message, $recordContext);
 
-        $handler = new CM_Log_Handler_MongoDb($collection, $ttl, ['w' => 0], $level);
+        $handler = new CM_Log_Handler_MongoDb($mongoClient, $contextFormatter, $collection, $ttl, ['w' => 0], $level);
         $this->callProtectedMethod($handler, '_writeRecord', [$record]);
         $this->assertSame(1, $mongoClient->count($collection));
 
@@ -78,7 +87,11 @@ class CM_Log_Handler_MongoDbTest extends CMTest_TestCase {
     }
 
     public function testSanitizeRecord() {
-        $handler = new CM_Log_Handler_MongoDb('foo');
+        /** @var CM_MongoDb_Client $client */
+        $client = $this->mockClass('CM_MongoDb_Client')->newInstanceWithoutConstructor();
+        /** @var CM_Log_ContextFormatter_Interface $contextFormatter */
+        $contextFormatter = $this->mockInterface('CM_Log_ContextFormatter_Interface')->newInstanceWithoutConstructor();
+        $handler = new CM_Log_Handler_MongoDb($client, $contextFormatter, 'foo');
         $record = [
             'foo'  => [
                 'baz' => 'quux',

--- a/tests/library/CM/Paging/LogTest.php
+++ b/tests/library/CM/Paging/LogTest.php
@@ -23,7 +23,10 @@ class CM_Paging_LogTest extends CMTest_TestCase {
     }
 
     public function testAddGet() {
-        $handler = new CM_Log_Handler_MongoDb(CM_Paging_Log::COLLECTION_NAME);
+        $client = $this->getServiceManager()->getMongoDb();
+        $contextFormatter = new CM_Log_ContextFormatter_MongoDb();
+        $handler = new CM_Log_Handler_MongoDb($client, $contextFormatter, CM_Paging_Log::COLLECTION_NAME);
+
         $user = CMTest_TH::createUser();
         $context = new CM_Log_Context();
         $context->setExtra(['bar' => 'quux']);
@@ -48,7 +51,7 @@ class CM_Paging_LogTest extends CMTest_TestCase {
         $this->assertSame(
             [
                 'bar'  => 'quux',
-                'type' => CM_Log_Handler_MongoDb::DEFAULT_TYPE
+                'type' => CM_Log_ContextFormatter_MongoDb::DEFAULT_TYPE
             ], $items[1]['context']['extra']
         );
 
@@ -67,7 +70,10 @@ class CM_Paging_LogTest extends CMTest_TestCase {
     }
 
     public function testCleanUp() {
-        $handler = new CM_Log_Handler_MongoDb(CM_Paging_Log::COLLECTION_NAME);
+        $client = $this->getServiceManager()->getMongoDb();
+        $contextFormatter = new CM_Log_ContextFormatter_MongoDb();
+        $handler = new CM_Log_Handler_MongoDb($client, $contextFormatter, CM_Paging_Log::COLLECTION_NAME);
+
         $context1 = new CM_Log_Context();
         $context1->setExtra(['bar' => 'quux']);
         $record1 = new CM_Log_Record(CM_Log_Logger::DEBUG, 'foo', $context1);
@@ -98,7 +104,10 @@ class CM_Paging_LogTest extends CMTest_TestCase {
     }
 
     public function testFlush() {
-        $handler = new CM_Log_Handler_MongoDb(CM_Paging_Log::COLLECTION_NAME);
+        $client = $this->getServiceManager()->getMongoDb();
+        $contextFormatter = new CM_Log_ContextFormatter_MongoDb();
+        $handler = new CM_Log_Handler_MongoDb($client, $contextFormatter, CM_Paging_Log::COLLECTION_NAME);
+
         $context1 = new CM_Log_Context();
         $context1->setExtra(['bar' => 'quux']);
         $record1 = new CM_Log_Record(CM_Log_Logger::INFO, 'foo', $context1);
@@ -124,7 +133,9 @@ class CM_Paging_LogTest extends CMTest_TestCase {
     }
 
     public function testAggregate() {
-        $handler = new CM_Log_Handler_MongoDb(CM_Paging_Log::COLLECTION_NAME);
+        $client = $this->getServiceManager()->getMongoDb();
+        $contextFormatter = new CM_Log_ContextFormatter_MongoDb();
+        $handler = new CM_Log_Handler_MongoDb($client, $contextFormatter, CM_Paging_Log::COLLECTION_NAME);
 
         $context1 = new CM_Log_Context();
         $context1->setExtra(['bar' => 'quux']);


### PR DESCRIPTION
Automatically encode certain object types in "metaInfo" as strings in the Logger.
Any `DateTime` should be encoded as `format('c')`.