### PR TITLE
Fix invalid cache for subscriber-paging in onSubscribe-hook

### DIFF
--- a/library/CM/Model/Stream/Publish.php
+++ b/library/CM/Model/Stream/Publish.php
@@ -23,6 +23,10 @@ class CM_Model_Stream_Publish extends CM_Model_Stream_Abstract {
         return CM_Db_Db::select('cm_stream_publish', '*', array('id' => $this->getId()))->fetch();
     }
 
+    protected function _onCreate() {
+        $this->getStreamChannel()->onPublish($this);
+    }
+
     protected function _onDelete() {
         CM_Db_Db::delete('cm_stream_publish', array('id' => $this->getId()));
     }
@@ -72,7 +76,6 @@ class CM_Model_Stream_Publish extends CM_Model_Stream_Abstract {
             'channelId'    => $streamChannel->getId(),
         ));
         $streamPublish = new self($id);
-        $streamChannel->onPublish($streamPublish);
         return $streamPublish;
     }
 }

--- a/library/CM/Model/Stream/Subscribe.php
+++ b/library/CM/Model/Stream/Subscribe.php
@@ -23,6 +23,10 @@ class CM_Model_Stream_Subscribe extends CM_Model_Stream_Abstract {
         return CM_Db_Db::select('cm_stream_subscribe', '*', array('id' => $this->getId()))->fetch();
     }
 
+    protected function _onCreate() {
+        $this->getStreamChannel()->onSubscribe($this);
+    }
+
     protected function _onDeleteBefore() {
         $this->getStreamChannel()->onUnsubscribe($this);
     }
@@ -77,7 +81,6 @@ class CM_Model_Stream_Subscribe extends CM_Model_Stream_Abstract {
             'key'          => $key,
         ));
         $streamSubscribe = new self($id);
-        $streamChannel->onSubscribe($streamSubscribe);
         return $streamSubscribe;
     }
 }


### PR DESCRIPTION
CM_Paging_User_StreamChannelSubscriber and other similar pagings have an invalid state during onSubscibe()/onPublish() hooks, because they are called before the automatic cache invalidation mechanism kicks in.