### PR TITLE
JS error handler improvements

### DIFF
--- a/client-vendor/source/cm/tests/media/common.js
+++ b/client-vendor/source/cm/tests/media/common.js
@@ -23,7 +23,10 @@ define(["cm/tests/media/common"], function() {
         .getPromiseLoaded()
         .then(function() {
           assert.equal(events['media:setSource'], 1);
-          assert.equal(el.networkState, HTMLMediaElement.NETWORK_IDLE);
+          assert.ok(
+            el.networkState == HTMLMediaElement.NETWORK_IDLE ||
+            el.networkState == HTMLMediaElement.NETWORK_LOADING
+          );
           assert.equal(el.readyState, HTMLMediaElement.HAVE_ENOUGH_DATA);
           assert.equal(media.isPlaying(), false);
           return media.play();

--- a/client-vendor/source/logger/index.js
+++ b/client-vendor/source/logger/index.js
@@ -26,7 +26,7 @@ Logger.getRecords = function() {
  * @param {Error} error
  */
 Logger.addRecordError = function(error) {
-  logRecorder.addRecord(['%s\n%s', error.message, error.stack], {level: Logger.ERROR});
+  logRecorder.addRecord([error.message], {level: Logger.ERROR});
 };
 
 Logger.setHandler(function(messages, context) {

--- a/client-vendor/source/logger/tests/handlers/recorderTest.js
+++ b/client-vendor/source/logger/tests/handlers/recorderTest.js
@@ -65,7 +65,5 @@ require(["logger/vendor/src/logger", "logger/handlers/recorder"], function(Logge
       '[' + date + ' INFO] 0 0 -1 1.123 -1.123 16',
       '[' + date + ' INFO] [] {} [1,2,3] {"foo":123} [{"foo":10}] /foo/ [Foo_Bar] [Foo_Bar_ID:1] ' + date + ' [object HTMLDivElement] {"foo1":1,"foo2":2,"foo3":3,"foo4":4,"foo5":5,…} ["foo1","foo2","foo3","foo4","foo5","foo6","fo…]'
     ].join('\n'));
-
-    console.log(recorder.getFormattedRecords());
   });
 });

--- a/client-vendor/source/logger/tests/handlers/recorderTest.js
+++ b/client-vendor/source/logger/tests/handlers/recorderTest.js
@@ -1,0 +1,71 @@
+require(["logger/vendor/src/logger", "logger/handlers/recorder"], function(Logger, Recorder) {
+
+  QUnit.module('logger/handlers/recorder', {
+    beforeEach: function() {
+      this.recorder = new Recorder();
+      var date = this.date = new Date();
+      this.recorder._getDate = function() {
+        return date;
+      };
+    }
+  });
+
+  QUnit.test("Recorder: substitution/formatting", function(assert) {
+    var recorder = this.recorder, date = this.date.toISOString();
+    recorder.addRecord(['test %s %i %d %f %o %O', 'foo', 10, 10, 1.1, document.createElement('div'), {foo: 10}], {level: Logger.INFO});
+    recorder.addRecord(['test %s %i %d %f %o %x', 'foo', 10, 10, 1.1, document.createElement('div'), {foo: 10}], {level: Logger.INFO});
+
+    assert.equal(recorder.getFormattedRecords(), [
+      '[' + date + ' INFO] test foo 10 10 1.1 [object HTMLDivElement] {"foo":10}',
+      '[' + date + ' INFO] test foo 10 10 1.1 [object HTMLDivElement] %x {"foo":10}'
+    ].join('\n'));
+  });
+
+
+  QUnit.test("Recorder: level", function(assert) {
+    var recorder = this.recorder, date = this.date.toISOString();
+    recorder.addRecord(['foo'], {level: Logger.DEBUG});
+    recorder.addRecord(['foo'], {level: Logger.INFO});
+    recorder.addRecord(['foo'], {level: Logger.WARN});
+    recorder.addRecord(['foo'], {level: Logger.ERROR});
+
+    assert.equal(recorder.getFormattedRecords(), [
+      '[' + date + ' DEBUG] foo',
+      '[' + date + ' INFO] foo',
+      '[' + date + ' WARN] foo',
+      '[' + date + ' ERROR] foo'
+    ].join('\n'));
+  });
+
+
+  QUnit.test("Recorder: type", function(assert) {
+    var recorder = this.recorder, date = this.date.toISOString();
+    var dom = document.createElement('div');
+    var big = (function() {
+      var i = 0, data = {};
+      while (++i < 100) {
+        data['foo' + i] = i;
+      }
+      return data;
+    })();
+    var modelWithoutId = {
+      _class: 'Foo_Bar'
+    };
+    var modelWithId = {
+      _class: 'Foo_Bar_ID',
+      _id: {id: 1}
+    };
+
+    recorder.addRecord([null, null, NaN, undefined, Infinity], {level: Logger.INFO});
+    recorder.addRecord([0, -0, -1, 1.123, -1.123, 0x10], {level: Logger.INFO});
+    recorder.addRecord([[], {}, [1, 2, 3], {foo: 123}, [{foo: 10}], /foo/, modelWithoutId, modelWithId, this.date, dom, big, Object.keys(big)], {level: Logger.INFO});
+
+    assert.equal(recorder.getFormattedRecords(), [
+      '[' + date + ' INFO] null null NaN undefined Infinity',
+      '[' + date + ' INFO] 0 0 -1 1.123 -1.123 16',
+      '[' + date + ' INFO] [] {} [1,2,3] {"foo":123} [{"foo":10}] /foo/ [Foo_Bar] [Foo_Bar_ID:1] ' + date + ' [object HTMLDivElement] {"foo1":1,"foo2":2,"foo3":3,"foo4":4,"foo5":5,…} ["foo1","foo2","foo3","foo4","foo5","foo6","fo…]'
+    ].join('\n'));
+
+    console.log(recorder.getFormattedRecords());
+  });
+});

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -437,7 +437,7 @@ var CM_App = CM_Class_Abstract.extend({
       var time = (Date.now() - performance.timing.navigationStart) / 1000;
       var timeFormatted = time.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2, useGrouping: false});
       var prefix = '[CM ' + timeFormatted + (performance.timing.isPolyfilled ? '!' : '') + ']';
-      cm.logger.debug.apply(cm.logger, _.union([prefix + ' ' + message], args));
+      cm.logger.debug.apply(cm.logger, [prefix + ' ' + message].concat(args));
     }
   },
 

--- a/library/CM/Http/Response/JsError.php
+++ b/library/CM/Http/Response/JsError.php
@@ -12,7 +12,9 @@ class CM_Http_Response_JsError extends CM_Http_Response_Abstract {
                 ]);
             }
             $context = new CM_Log_Context();
-            $context->setExtra($query);
+            $context->setExtra(array_merge($query, [
+                'type' => CM_Paging_Log_Javascript::getTypeStatic(),
+            ]));
             $this->getServiceManager()->getLogger()->warning('JS Error - ' . $query['error']['message'], $context);
         }
         $this->setHeader('Content-Type', 'application/json');

--- a/library/CM/Http/Response/JsError.php
+++ b/library/CM/Http/Response/JsError.php
@@ -6,6 +6,11 @@ class CM_Http_Response_JsError extends CM_Http_Response_Abstract {
         $request = $this->getRequest();
         if (!$request->isBotCrawler() && $request->isSupported()) {
             $query = $request->getQuery();
+            if (!isset($query['error']) || !isset($query['error']['message'])) {
+                throw new CM_Exception_Invalid('Failed to process a JS Error, "error.message" expected', CM_Exception::WARN, [
+                    'query' => $query
+                ]);
+            }
             $context = new CM_Log_Context();
             $context->setExtra($query);
             $this->getServiceManager()->getLogger()->warning('JS Error - ' . $query['error']['message'], $context);

--- a/tests/client/config.js
+++ b/tests/client/config.js
@@ -27,6 +27,10 @@ module.exports = {
           cancellation: true
         });
       }
+    },
+    {
+      name: 'util',
+      path: 'tests/client/vendor/builtins/util'
     }
   ]
 };

--- a/tests/client/suites/source.js
+++ b/tests/client/suites/source.js
@@ -5,6 +5,8 @@ module.exports = {
   modules: [
     'cm/tests/media/videoTest',
     'cm/tests/media/audioTest',
-    'cm/tests/media/audio/engineTest'
+    'cm/tests/media/audio/engineTest',
+
+    'logger/tests/handlers/recorderTest'
   ]
 };

--- a/tests/client/vendor/builtins/util.js
+++ b/tests/client/vendor/builtins/util.js
@@ -1,0 +1,599 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var formatRegExp = /%[sdj%]/g;
+exports.format = function(f) {
+  if (!isString(f)) {
+    var objects = [];
+    for (var i = 0; i < arguments.length; i++) {
+      objects.push(inspect(arguments[i]));
+    }
+    return objects.join(' ');
+  }
+
+  var i = 1;
+  var args = arguments;
+  var len = args.length;
+  var str = String(f).replace(formatRegExp, function(x) {
+    if (x === '%%') {
+      return '%';
+    }
+    if (i >= len) {
+      return x;
+    }
+    switch (x) {
+      case '%s':
+        return String(args[i++]);
+      case '%d':
+        return Number(args[i++]);
+      case '%j':
+        try {
+          return JSON.stringify(args[i++]);
+        } catch (_) {
+          return '[Circular]';
+        }
+      default:
+        return x;
+    }
+  });
+  for (var x = args[i]; i < len; x = args[++i]) {
+    if (isNull(x) || !isObject(x)) {
+      str += ' ' + x;
+    } else {
+      str += ' ' + inspect(x);
+    }
+  }
+  return str;
+};
+
+
+// Mark that a method should not be used.
+// Returns a modified function which warns once by default.
+// If --no-deprecation is set, then it is a no-op.
+exports.deprecate = function(fn, msg) {
+  // Allow for deprecating things in the process of starting up.
+  if (isUndefined(global.process)) {
+    return function() {
+      return exports.deprecate(fn, msg).apply(this, arguments);
+    };
+  }
+
+  if (process.noDeprecation === true) {
+    return fn;
+  }
+
+  var warned = false;
+
+  function deprecated() {
+    if (!warned) {
+      if (process.throwDeprecation) {
+        throw new Error(msg);
+      } else if (process.traceDeprecation) {
+        console.trace(msg);
+      } else {
+        console.error(msg);
+      }
+      warned = true;
+    }
+    return fn.apply(this, arguments);
+  }
+
+  return deprecated;
+};
+
+
+var debugs = {};
+var debugEnviron;
+exports.debuglog = function(set) {
+  if (isUndefined(debugEnviron)) {
+    debugEnviron = process.env.NODE_DEBUG || '';
+  }
+  set = set.toUpperCase();
+  if (!debugs[set]) {
+    if (new RegExp('\\b' + set + '\\b', 'i').test(debugEnviron)) {
+      var pid = process.pid;
+      debugs[set] = function() {
+        var msg = exports.format.apply(exports, arguments);
+        console.error('%s %d: %s', set, pid, msg);
+      };
+    } else {
+      debugs[set] = function() {
+      };
+    }
+  }
+  return debugs[set];
+};
+
+
+/**
+ * Echos the value of a value. Trys to print the value out
+ * in the best way possible given the different types.
+ *
+ * @param {Object} obj The object to print out.
+ * @param {Object} opts Optional options object that alters the output.
+ */
+/* legacy: obj, showHidden, depth, colors*/
+function inspect(obj, opts) {
+  // default options
+  var ctx = {
+    seen: [],
+    stylize: stylizeNoColor
+  };
+  // legacy...
+  if (arguments.length >= 3) {
+    ctx.depth = arguments[2];
+  }
+  if (arguments.length >= 4) {
+    ctx.colors = arguments[3];
+  }
+  if (isBoolean(opts)) {
+    // legacy...
+    ctx.showHidden = opts;
+  } else if (opts) {
+    // got an "options" object
+    exports._extend(ctx, opts);
+  }
+  // set default options
+  if (isUndefined(ctx.showHidden)) {
+    ctx.showHidden = false;
+  }
+  if (isUndefined(ctx.depth)) {
+    ctx.depth = 2;
+  }
+  if (isUndefined(ctx.colors)) {
+    ctx.colors = false;
+  }
+  if (isUndefined(ctx.customInspect)) {
+    ctx.customInspect = true;
+  }
+  if (ctx.colors) {
+    ctx.stylize = stylizeWithColor;
+  }
+  return formatValue(ctx, obj, ctx.depth);
+}
+exports.inspect = inspect;
+
+
+// http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
+inspect.colors = {
+  'bold': [1, 22],
+  'italic': [3, 23],
+  'underline': [4, 24],
+  'inverse': [7, 27],
+  'white': [37, 39],
+  'grey': [90, 39],
+  'black': [30, 39],
+  'blue': [34, 39],
+  'cyan': [36, 39],
+  'green': [32, 39],
+  'magenta': [35, 39],
+  'red': [31, 39],
+  'yellow': [33, 39]
+};
+
+// Don't use 'blue' not visible on cmd.exe
+inspect.styles = {
+  'special': 'cyan',
+  'number': 'yellow',
+  'boolean': 'yellow',
+  'undefined': 'grey',
+  'null': 'bold',
+  'string': 'green',
+  'date': 'magenta',
+  // "name": intentionally not styling
+  'regexp': 'red'
+};
+
+
+function stylizeWithColor(str, styleType) {
+  var style = inspect.styles[styleType];
+
+  if (style) {
+    return '\u001b[' + inspect.colors[style][0] + 'm' + str +
+      '\u001b[' + inspect.colors[style][1] + 'm';
+  } else {
+    return str;
+  }
+}
+
+
+function stylizeNoColor(str, styleType) {
+  return str;
+}
+
+
+function arrayToHash(array) {
+  var hash = {};
+
+  array.forEach(function(val, idx) {
+    hash[val] = true;
+  });
+
+  return hash;
+}
+
+
+function formatValue(ctx, value, recurseTimes) {
+  // Provide a hook for user-specified inspect functions.
+  // Check that value is an object with an inspect function on it
+  if (ctx.customInspect &&
+    value &&
+    isFunction(value.inspect) &&
+    // Filter out the util module, it's inspect function is special
+    value.inspect !== exports.inspect &&
+    // Also filter out any prototype objects using the circular check.
+    !(value.constructor && value.constructor.prototype === value)) {
+    var ret = value.inspect(recurseTimes, ctx);
+    if (!isString(ret)) {
+      ret = formatValue(ctx, ret, recurseTimes);
+    }
+    return ret;
+  }
+
+  // Primitive types cannot have properties
+  var primitive = formatPrimitive(ctx, value);
+  if (primitive) {
+    return primitive;
+  }
+
+  // Look up the keys of the object.
+  var keys = Object.keys(value);
+  var visibleKeys = arrayToHash(keys);
+
+  if (ctx.showHidden) {
+    keys = Object.getOwnPropertyNames(value);
+  }
+
+  // IE doesn't make error fields non-enumerable
+  // http://msdn.microsoft.com/en-us/library/ie/dww52sbt(v=vs.94).aspx
+  if (isError(value)
+    && (keys.indexOf('message') >= 0 || keys.indexOf('description') >= 0)) {
+    return formatError(value);
+  }
+
+  // Some type of object without properties can be shortcutted.
+  if (keys.length === 0) {
+    if (isFunction(value)) {
+      var name = value.name ? ': ' + value.name : '';
+      return ctx.stylize('[Function' + name + ']', 'special');
+    }
+    if (isRegExp(value)) {
+      return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
+    }
+    if (isDate(value)) {
+      return ctx.stylize(Date.prototype.toString.call(value), 'date');
+    }
+    if (isError(value)) {
+      return formatError(value);
+    }
+  }
+
+  var base = '', array = false, braces = ['{', '}'];
+
+  // Make Array say that they are Array
+  if (isArray(value)) {
+    array = true;
+    braces = ['[', ']'];
+  }
+
+  // Make functions say that they are functions
+  if (isFunction(value)) {
+    var n = value.name ? ': ' + value.name : '';
+    base = ' [Function' + n + ']';
+  }
+
+  // Make RegExps say that they are RegExps
+  if (isRegExp(value)) {
+    base = ' ' + RegExp.prototype.toString.call(value);
+  }
+
+  // Make dates with properties first say the date
+  if (isDate(value)) {
+    base = ' ' + Date.prototype.toUTCString.call(value);
+  }
+
+  // Make error with message first say the error
+  if (isError(value)) {
+    base = ' ' + formatError(value);
+  }
+
+  if (keys.length === 0 && (!array || value.length == 0)) {
+    return braces[0] + base + braces[1];
+  }
+
+  if (recurseTimes < 0) {
+    if (isRegExp(value)) {
+      return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
+    } else {
+      return ctx.stylize('[Object]', 'special');
+    }
+  }
+
+  ctx.seen.push(value);
+
+  var output;
+  if (array) {
+    output = formatArray(ctx, value, recurseTimes, visibleKeys, keys);
+  } else {
+    output = keys.map(function(key) {
+      return formatProperty(ctx, value, recurseTimes, visibleKeys, key, array);
+    });
+  }
+
+  ctx.seen.pop();
+
+  return reduceToSingleString(output, base, braces);
+}
+
+
+function formatPrimitive(ctx, value) {
+  if (isUndefined(value)) {
+    return ctx.stylize('undefined', 'undefined');
+  }
+  if (isString(value)) {
+    var simple = '\'' + JSON.stringify(value).replace(/^"|"$/g, '')
+        .replace(/'/g, "\\'")
+        .replace(/\\"/g, '"') + '\'';
+    return ctx.stylize(simple, 'string');
+  }
+  if (isNumber(value)) {
+    return ctx.stylize('' + value, 'number');
+  }
+  if (isBoolean(value)) {
+    return ctx.stylize('' + value, 'boolean');
+  }
+  // For some reason typeof null is "object", so special case here.
+  if (isNull(value)) {
+    return ctx.stylize('null', 'null');
+  }
+}
+
+
+function formatError(value) {
+  return '[' + Error.prototype.toString.call(value) + ']';
+}
+
+
+function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
+  var output = [];
+  for (var i = 0, l = value.length; i < l; ++i) {
+    if (hasOwnProperty(value, String(i))) {
+      output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
+        String(i), true));
+    } else {
+      output.push('');
+    }
+  }
+  keys.forEach(function(key) {
+    if (!key.match(/^\d+$/)) {
+      output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
+        key, true));
+    }
+  });
+  return output;
+}
+
+
+function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
+  var name, str, desc;
+  desc = Object.getOwnPropertyDescriptor(value, key) || {value: value[key]};
+  if (desc.get) {
+    if (desc.set) {
+      str = ctx.stylize('[Getter/Setter]', 'special');
+    } else {
+      str = ctx.stylize('[Getter]', 'special');
+    }
+  } else {
+    if (desc.set) {
+      str = ctx.stylize('[Setter]', 'special');
+    }
+  }
+  if (!hasOwnProperty(visibleKeys, key)) {
+    name = '[' + key + ']';
+  }
+  if (!str) {
+    if (ctx.seen.indexOf(desc.value) < 0) {
+      if (isNull(recurseTimes)) {
+        str = formatValue(ctx, desc.value, null);
+      } else {
+        str = formatValue(ctx, desc.value, recurseTimes - 1);
+      }
+      if (str.indexOf('\n') > -1) {
+        if (array) {
+          str = str.split('\n').map(function(line) {
+            return '  ' + line;
+          }).join('\n').substr(2);
+        } else {
+          str = '\n' + str.split('\n').map(function(line) {
+              return '   ' + line;
+            }).join('\n');
+        }
+      }
+    } else {
+      str = ctx.stylize('[Circular]', 'special');
+    }
+  }
+  if (isUndefined(name)) {
+    if (array && key.match(/^\d+$/)) {
+      return str;
+    }
+    name = JSON.stringify('' + key);
+    if (name.match(/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/)) {
+      name = name.substr(1, name.length - 2);
+      name = ctx.stylize(name, 'name');
+    } else {
+      name = name.replace(/'/g, "\\'")
+        .replace(/\\"/g, '"')
+        .replace(/(^"|"$)/g, "'");
+      name = ctx.stylize(name, 'string');
+    }
+  }
+
+  return name + ': ' + str;
+}
+
+
+function reduceToSingleString(output, base, braces) {
+  var numLinesEst = 0;
+  var length = output.reduce(function(prev, cur) {
+    numLinesEst++;
+    if (cur.indexOf('\n') >= 0) {
+      numLinesEst++;
+    }
+    return prev + cur.replace(/\u001b\[\d\d?m/g, '').length + 1;
+  }, 0);
+
+  if (length > 60) {
+    return braces[0] +
+      (base === '' ? '' : base + '\n ') +
+      ' ' +
+      output.join(',\n  ') +
+      ' ' +
+      braces[1];
+  }
+
+  return braces[0] + base + ' ' + output.join(', ') + ' ' + braces[1];
+}
+
+
+// NOTE: These type checking functions intentionally don't use `instanceof`
+// because it is fragile and can be easily faked with `Object.create()`.
+function isArray(ar) {
+  return Array.isArray(ar);
+}
+exports.isArray = isArray;
+
+function isBoolean(arg) {
+  return typeof arg === 'boolean';
+}
+exports.isBoolean = isBoolean;
+
+function isNull(arg) {
+  return arg === null;
+}
+exports.isNull = isNull;
+
+function isNullOrUndefined(arg) {
+  return arg == null;
+}
+exports.isNullOrUndefined = isNullOrUndefined;
+
+function isNumber(arg) {
+  return typeof arg === 'number';
+}
+exports.isNumber = isNumber;
+
+function isString(arg) {
+  return typeof arg === 'string';
+}
+exports.isString = isString;
+
+function isSymbol(arg) {
+  return typeof arg === 'symbol';
+}
+exports.isSymbol = isSymbol;
+
+function isUndefined(arg) {
+  return arg === void 0;
+}
+exports.isUndefined = isUndefined;
+
+function isRegExp(re) {
+  return isObject(re) && objectToString(re) === '[object RegExp]';
+}
+exports.isRegExp = isRegExp;
+
+function isObject(arg) {
+  return typeof arg === 'object' && arg !== null;
+}
+exports.isObject = isObject;
+
+function isDate(d) {
+  return isObject(d) && objectToString(d) === '[object Date]';
+}
+exports.isDate = isDate;
+
+function isError(e) {
+  return isObject(e) &&
+    (objectToString(e) === '[object Error]' || e instanceof Error);
+}
+exports.isError = isError;
+
+function isFunction(arg) {
+  return typeof arg === 'function';
+}
+exports.isFunction = isFunction;
+
+function isPrimitive(arg) {
+  return arg === null ||
+    typeof arg === 'boolean' ||
+    typeof arg === 'number' ||
+    typeof arg === 'string' ||
+    typeof arg === 'symbol' ||  // ES6 symbol
+    typeof arg === 'undefined';
+}
+exports.isPrimitive = isPrimitive;
+
+function objectToString(o) {
+  return Object.prototype.toString.call(o);
+}
+
+
+function pad(n) {
+  return n < 10 ? '0' + n.toString(10) : n.toString(10);
+}
+
+
+var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep',
+  'Oct', 'Nov', 'Dec'];
+
+// 26 Feb 16:19:34
+function timestamp() {
+  var d = new Date();
+  var time = [pad(d.getHours()),
+    pad(d.getMinutes()),
+    pad(d.getSeconds())].join(':');
+  return [d.getDate(), months[d.getMonth()], time].join(' ');
+}
+
+
+// log is just a thin wrapper to console.log that prepends a timestamp
+exports.log = function() {
+  console.log('%s - %s', timestamp(), exports.format.apply(exports, arguments));
+};
+
+exports._extend = function(origin, add) {
+  // Don't do anything if add isn't an object
+  if (!add || !isObject(add)) {
+    return origin;
+  }
+
+  var keys = Object.keys(add);
+  var i = keys.length;
+  while (i--) {
+    origin[keys[i]] = add[keys[i]];
+  }
+  return origin;
+};
+
+function hasOwnProperty(obj, prop) {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+}


### PR DESCRIPTION
- Recorder: _messageFormatter: Stringify objects in a space conserving way. Like just the "class name".
- CM_Http_Response_JsError: Throw warning if `$query['error']['message']` missing