### PR TITLE
Set service manager on CM_MessageStream_Adapter_SocketRedis

### DIFF
--- a/library/CM/MessageStream/Factory.php
+++ b/library/CM/MessageStream/Factory.php
@@ -1,6 +1,8 @@
 <?php
 
-class CM_MessageStream_Factory {
+class CM_MessageStream_Factory implements CM_Service_ManagerAwareInterface {
+
+    use CM_Service_ManagerAwareTrait;
 
     /**
      * @param string     $adapterClass
@@ -25,6 +27,11 @@ class CM_MessageStream_Factory {
         if (!$reflectionClass->isSubclassOf('CM_MessageStream_Adapter_Abstract')) {
             throw new CM_Exception_Invalid('Adapter class is not valid stream message adapter', null, ['adapterClass' => $adapterClass]);
         }
-        return $reflectionClass->newInstanceArgs($adapterArguments);
+        /** @var CM_MessageStream_Adapter_Abstract $adapter */
+        $adapter = $reflectionClass->newInstanceArgs($adapterArguments);
+        if ($adapter instanceof CM_Service_ManagerAwareInterface) {
+            $adapter->setServiceManager($this->getServiceManager());
+        }
+        return $adapter;
     }
 }

--- a/library/CM/MessageStream/Service.php
+++ b/library/CM/MessageStream/Service.php
@@ -1,8 +1,6 @@
 <?php
 
-class CM_MessageStream_Service implements CM_Service_ManagerAwareInterface {
-
-    use CM_Service_ManagerAwareTrait;
+class CM_MessageStream_Service {
 
     /** @var CM_MessageStream_Adapter_Abstract|null */
     private $_adapter;
@@ -69,11 +67,5 @@ class CM_MessageStream_Service implements CM_Service_ManagerAwareInterface {
             return;
         }
         $this->getAdapter()->publish($channel, $event, CM_Params::encode($data));
-    }
-
-    protected function _onSetServiceManager() {
-        if ($this->_adapter instanceof CM_Service_ManagerAwareInterface) {
-            $this->_adapter->setServiceManager($this->getServiceManager());
-        }
     }
 }

--- a/library/CM/MessageStream/Service.php
+++ b/library/CM/MessageStream/Service.php
@@ -15,13 +15,6 @@ class CM_MessageStream_Service implements CM_Service_ManagerAwareInterface {
         $this->_adapter = $adapter;
     }
 
-    public function setServiceManager(CM_Service_Manager $serviceManager) {
-        $this->_serviceManager = $serviceManager;
-        if ($this->_adapter instanceof CM_Service_ManagerAwareInterface) {
-            $this->_adapter->setServiceManager($serviceManager);
-        }
-    }
-
     /**
      * @return boolean
      */
@@ -76,5 +69,11 @@ class CM_MessageStream_Service implements CM_Service_ManagerAwareInterface {
             return;
         }
         $this->getAdapter()->publish($channel, $event, CM_Params::encode($data));
+    }
+
+    protected function _onSetServiceManager() {
+        if ($this->_adapter instanceof CM_Service_ManagerAwareInterface) {
+            $this->_adapter->setServiceManager($this->getServiceManager());
+        }
     }
 }

--- a/library/CM/Service/Manager.php
+++ b/library/CM/Service/Manager.php
@@ -96,8 +96,8 @@ class CM_Service_Manager extends CM_Class_Abstract {
     }
 
     /**
-     * @param string       $serviceName
-     * @param mixed        $instance
+     * @param string $serviceName
+     * @param mixed  $instance
      * @throws CM_Exception_Invalid
      */
     public function registerInstance($serviceName, $instance) {

--- a/library/CM/Service/ManagerAwareTrait.php
+++ b/library/CM/Service/ManagerAwareTrait.php
@@ -6,6 +6,13 @@ trait CM_Service_ManagerAwareTrait {
     private $_serviceManager;
 
     /**
+     * @param CM_Service_Manager $serviceManager
+     */
+    public function setServiceManager(CM_Service_Manager $serviceManager) {
+        $this->_serviceManager = $serviceManager;
+    }
+
+    /**
      * @return CM_Service_Manager
      * @throws CM_Exception_Invalid
      */
@@ -14,16 +21,5 @@ trait CM_Service_ManagerAwareTrait {
             throw new CM_Exception_Invalid('Service manager not set');
         }
         return $this->_serviceManager;
-    }
-
-    /**
-     * @param CM_Service_Manager $serviceManager
-     */
-    public function setServiceManager(CM_Service_Manager $serviceManager) {
-        $this->_serviceManager = $serviceManager;
-        $this->_onSetServiceManager();
-    }
-
-    protected function _onSetServiceManager() {
     }
 }

--- a/library/CM/Service/ManagerAwareTrait.php
+++ b/library/CM/Service/ManagerAwareTrait.php
@@ -6,13 +6,6 @@ trait CM_Service_ManagerAwareTrait {
     private $_serviceManager;
 
     /**
-     * @param CM_Service_Manager $serviceManager
-     */
-    public function setServiceManager(CM_Service_Manager $serviceManager) {
-        $this->_serviceManager = $serviceManager;
-    }
-
-    /**
      * @return CM_Service_Manager
      * @throws CM_Exception_Invalid
      */
@@ -21,5 +14,16 @@ trait CM_Service_ManagerAwareTrait {
             throw new CM_Exception_Invalid('Service manager not set');
         }
         return $this->_serviceManager;
+    }
+
+    /**
+     * @param CM_Service_Manager $serviceManager
+     */
+    public function setServiceManager(CM_Service_Manager $serviceManager) {
+        $this->_serviceManager = $serviceManager;
+        $this->_onSetServiceManager();
+    }
+
+    protected function _onSetServiceManager() {
     }
 }

--- a/tests/library/CM/MessageStream/ServiceTest.php
+++ b/tests/library/CM/MessageStream/ServiceTest.php
@@ -54,20 +54,27 @@ class CM_MessageStream_ServiceTest extends CMTest_TestCase {
         $this->assertSame(1, $publishMethod->getCallCount());
     }
 
-    public function testSetServiceManager_AdapterNotServiceManagerAware() {
+    public function testServiceInstantiation() {
         $serviceManager = new CM_Service_Manager();
-        $adapter = $this->mockObject('CM_MessageStream_Adapter_Abstract');
-        $stream = new CM_MessageStream_Service($adapter);
-        $stream->setServiceManager($serviceManager);
-        $this->assertSame($serviceManager, $stream->getServiceManager());
-    }
-
-    public function testSetServiceManager_AdapterServiceManagerAware() {
-        $serviceManager = new CM_Service_Manager();
-        $adapter = new CM_MessageStream_Adapter_SocketRedis([]);
-        $stream = new CM_MessageStream_Service($adapter);
-        $stream->setServiceManager($serviceManager);
-        $this->assertSame($serviceManager, $stream->getServiceManager());
+        $serviceManager->registerWithArray('stream-message', [
+            'class'  => 'CM_MessageStream_Factory',
+            'method' => [
+                'name'      => 'createService',
+                'arguments' => [
+                    'adapterClass'     => 'CM_MessageStream_Adapter_SocketRedis',
+                    'adapterArguments' => [
+                        'servers' => [
+                            ['httpHost' => 'localhost', 'httpPort' => 8085, 'sockjsUrls' => ['http://localhost:8090']],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $stream = $serviceManager->get('stream-message');
+        $this->assertSame(true, $stream instanceof CM_MessageStream_Service);
+        $adapter = $stream->getAdapter();
+        $this->assertSame(true, $adapter instanceof CM_MessageStream_Adapter_SocketRedis);
+        /** @var CM_MessageStream_Adapter_SocketRedis $adapter */
         $this->assertSame($serviceManager, $adapter->getServiceManager());
     }
 }


### PR DESCRIPTION
Follow-up of #2341

@tomaszdurka we're still having these errors in production:

```
CM_Exception_Invalid: Service manager not set in /.../vendor/cargomedia/cm/library/CM/Service/ManagerAwareTrait.php on line 21
0. {main} at ./bin/cm line 0
1. CM_Cli_CommandManager->run(CM_Cli_Arguments) at /.../vendor/cargomedia/cm/bin/cm line 21
2. CM_Process->fork(Closure) at /.../vendor/cargomedia/cm/library/CM/Cli/CommandManager.php line 175
3. CM_Process->_fork(Closure, 1) at /.../vendor/cargomedia/cm/library/CM/Process.php line 65
4. CM_Process_ForkHandler->runAndSendWorkload() at /.../vendor/cargomedia/cm/library/CM/Process.php line 228
5. CM_Cli_CommandManager->{closure}(CM_Process_WorkloadResult) at /.../vendor/cargomedia/cm/library/CM/Process/ForkHandler.php line 76
6. CM_Cli_Command->run([], CM_InputStream_Readline, CM_OutputStream_Stream_StandardOutput, CM_OutputStream_Stream_StandardError) at /.../vendor/cargomedia/cm/library/CM/Cli/CommandManager.php line 288
7. call_user_func_array([], []) at /.../vendor/cargomedia/cm/library/CM/Cli/Command.php line 27
8. [internal function] at line
9. CM_Clockwork_Manager->start() at /.../vendor/cargomedia/cm/library/CM/Maintenance/Cli.php line 18
10. CM_Clockwork_Manager->runEvents() at /.../vendor/cargomedia/cm/library/CM/Clockwork/Manager.php line 102
11. CM_Clockwork_Manager->_runEvent(CM_Clockwork_Event) at /.../vendor/cargomedia/cm/library/CM/Clockwork/Manager.php line 57
12. CM_Process->fork(Closure) at /.../vendor/cargomedia/cm/library/CM/Clockwork/Manager.php line 228
13. CM_Process->_fork(Closure, 38961) at /.../vendor/cargomedia/cm/library/CM/Process.php line 65
14. CM_Process_ForkHandler->runAndSendWorkload() at /.../vendor/cargomedia/cm/library/CM/Process.php line 228
15. CM_Clockwork_Manager->{closure}(CM_Process_WorkloadResult) at /.../vendor/cargomedia/cm/library/CM/Process/ForkHandler.php line 76
16. CM_Clockwork_Event->run(DateTime) at /.../vendor/cargomedia/cm/library/CM/Clockwork/Manager.php line 227
17. call_user_func(Closure, DateTime) at /.../vendor/cargomedia/cm/library/CM/Clockwork/Event.php line 54
18. [internal function] at line
19. call_user_func_array(Closure, []) at /.../vendor/cargomedia/cm/library/CM/Maintenance/Cli.php line 147
20. [internal function] at line
21. CM_MessageStream_Service->synchronize() at /.../vendor/cargomedia/cm/library/CM/Maintenance/Cli.php line 66
22. CM_MessageStream_Adapter_SocketRedis->synchronize() at /.../vendor/cargomedia/cm/library/CM/MessageStream/Service.php line 50
23. CM_MessageStream_Adapter_SocketRedis->getServiceManager() at /.../vendor/cargomedia/cm/library/CM/MessageStream/Adapter/SocketRedis.php line 127
24. {throw} at /.../vendor/cargomedia/cm/library/CM/Service/ManagerAwareTrait.php line 21
```