### PR TITLE
Drop PHP 5.4 and 5.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
 
 services:

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "bin-dir": "bin/"
   },
   "require": {
+    "php": ">=5.6.0",
     "composer/composer": "~1.2.0",
     "smarty/smarty": "3.1.16",
     "leafo/lessphp": "~0.5.0",


### PR DESCRIPTION
Should we drop support to PHP 5.4 (unsupported since 1 year) and PHP 5.5 (unsupported since 1 month)? And maybe add PHP version requirement in `composer.json`?

@njam @tomaszdurka wdyt?