### PR TITLE
PersistentStorage: read/write on every access

### DIFF
--- a/client-vendor/source/cm/adapter/memory.js
+++ b/client-vendor/source/cm/adapter/memory.js
@@ -1,0 +1,39 @@
+/**
+ * @param {Object} [data]
+ * @class AdapterMemory
+ */
+function AdapterMemory(data) {
+  this._data = data || {};
+}
+
+AdapterMemory.prototype = {
+  /**
+   * @param {String} key
+   * @param {*} value
+   */
+  setItem: function(key, value) {
+    this._data[key] = value;
+  },
+
+  /**
+   * @param {String} key
+   * @returns {*|undefined}
+   */
+  getItem: function(key) {
+    return this._data[key];
+  },
+
+  removeItem: function(key) {
+    delete this._data[key];
+  },
+
+  clear: function() {
+    Object.keys(this._data).forEach(function(key) {
+      this.removeItem(key);
+    }.bind(this));
+  }
+};
+
+AdapterMemory.prototype.constructor = AdapterMemory;
+
+module.exports = AdapterMemory;

--- a/client-vendor/source/cm/adapter/memory.js
+++ b/client-vendor/source/cm/adapter/memory.js
@@ -17,10 +17,11 @@ AdapterMemory.prototype = {
 
   /**
    * @param {String} key
-   * @returns {*|undefined}
+   * @returns {*|null}
    */
   getItem: function(key) {
-    return this._data[key];
+    var value = this._data[key];
+    return !_.isUndefined(value) ? value : null;
   },
 
   removeItem: function(key) {

--- a/client-vendor/source/cm/storage.js
+++ b/client-vendor/source/cm/storage.js
@@ -14,7 +14,6 @@ var PersistentStorage = Event.extend({
    */
   constructor: function(name, adapter, logger) {
     this._name = name;
-    this._data = {};
     this._adapter = null;
     this._logger = logger && logger.warn ? logger : console;
     if (this._isSupported(adapter)) {
@@ -75,7 +74,7 @@ var PersistentStorage = Event.extend({
   },
 
   delete: function() {
-    this._adapter.removeItem(this._name);
+    this.getAdapter().removeItem(this.getName());
   },
 
   /**
@@ -84,12 +83,12 @@ var PersistentStorage = Event.extend({
   read: function() {
     var data = {};
     try {
-      var rawData = this._adapter.getItem(this._name);
+      var rawData = this.getAdapter().getItem(this.getName());
       if (!_.isUndefined(rawData)) {
         data = JSON.parse(rawData);
       }
     } catch (error) {
-      this.getLogger().warn('Failed to parse the `%s` PersistentStorage', this._name);
+      this.getLogger().warn('Failed to parse the `%s` PersistentStorage', this.getName(), error);
     }
     return data;
   },
@@ -99,7 +98,28 @@ var PersistentStorage = Event.extend({
    */
   write: function(obj) {
     obj = !_.isUndefined(obj) ? obj : {};
-    this._adapter.setItem(this._name, JSON.stringify(obj));
+    this.getAdapter().setItem(this.getName(), JSON.stringify(obj));
+  },
+
+  /**
+   * @returns {String}
+   */
+  getName: function() {
+    return this._name;
+  },
+
+  /**
+   * @returns {Storage|*}
+   */
+  getAdapter: function() {
+    return this._adapter;
+  },
+
+  /**
+   * @returns {*}
+   */
+  getLogger: function() {
+    return this._logger;
   },
 
   /**

--- a/client-vendor/source/cm/tests/storageTest.js
+++ b/client-vendor/source/cm/tests/storageTest.js
@@ -1,4 +1,4 @@
-define(["cm/storage"], function(PersistentStorage) {
+define(["cm/storage", "cm/adapter/memory"], function(PersistentStorage, AdapterMemory) {
 
   QUnit.module('cm/storage');
 
@@ -41,6 +41,10 @@ define(["cm/storage"], function(PersistentStorage) {
     assert.strictEqual(data.has('foo'), true);
     assert.equal(data.get('foo'), 100);
     assert.deepEqual(data.get(), {foo: 100});
+
+    adapter.setItem('bar', '{\"foo\":200}');
+    assert.equal(data.get('foo'), 200);
+    assert.deepEqual(data.get(), {foo: 200});
 
     sessionStorage.clear();
   });

--- a/client-vendor/source/cm/tests/storageTest.js
+++ b/client-vendor/source/cm/tests/storageTest.js
@@ -2,76 +2,83 @@ define(["cm/storage", "cm/adapter/memory"], function(PersistentStorage, AdapterM
 
   QUnit.module('cm/storage');
 
-  QUnit.test("Storage: sessionStorage adapter", function(assert) {
-    var adapter = window.sessionStorage;
-    var data = new PersistentStorage('foo', adapter);
+  QUnit.test("Storage: get/set/del", function(assert) {
+    var adapters = [
+      window.sessionStorage,
+      window.localStorage,
+      new AdapterMemory()
+    ];
 
-    data.set({
-      foo: 100
+    adapters.forEach(function(adapter) {
+      var data = new PersistentStorage('foo', adapter);
+
+      data.set({
+        foo: 100
+      });
+      assert.strictEqual(data.has('foo'), true);
+      assert.equal(data.get('foo'), 100);
+      assert.deepEqual(data.get(), {foo: 100});
+      assert.equal(adapter.getItem('foo'), '{\"foo\":100}');
+
+      data.set('bar', '10');
+      assert.deepEqual(data.get(), {foo: 100, bar: "10"});
+      assert.equal(adapter.getItem('foo'), '{\"foo\":100,\"bar\":"10"}');
+
+      data.set({
+        foo: 100,
+        bar: '100'
+      });
+      assert.deepEqual(data.get(), {foo: 100, bar: "100"});
+      assert.equal(adapter.getItem('foo'), '{\"foo\":100,\"bar\":"100"}');
+
+      data.remove('foobar');
+      assert.strictEqual(data.has('foobar'), false);
+      assert.strictEqual(data.get('foobar'), undefined);
+      assert.equal(adapter.getItem('foo'), '{\"foo\":100,\"bar\":"100"}');
+
+      data.clear();
+      assert.equal(adapter.getItem('foo'), '{}');
+
+      data.delete();
+      assert.equal(adapter.getItem('foo'), null);
+
+      var logger = {
+        callCount: 0,
+        warn: function(message, key, error) {
+          this.callCount++;
+          assert.equal('Failed to parse the `%s` PersistentStorage', message);
+          assert.equal('bar', key);
+          assert.equal("SyntaxError", error.name);
+        }
+      };
+
+      adapter.setItem('bar', '{\"foo\":100}');
+      data = new PersistentStorage('bar', adapter, logger);
+      assert.strictEqual(data.has('foo'), true);
+      assert.equal(data.get('foo'), 100);
+      assert.deepEqual(data.get(), {foo: 100});
+
+      adapter.setItem('bar', '{\"foo\":200}');
+      assert.equal(data.get('foo'), 200);
+      assert.deepEqual(data.get(), {foo: 200});
+      assert.equal(logger.callCount, 0);
+
+      adapter.setItem('bar', 'invalid json string');
+      assert.strictEqual(data.get('foo'), undefined);
+      assert.equal(logger.callCount, 1);
+
+      data.set('foo', 300);
+      assert.equal(data.get('foo'), 300);
+      assert.equal(logger.callCount, 2);
+
+      data.set('foo', 400);
+      assert.equal(data.get('foo'), 400);
+      assert.equal(logger.callCount, 2);
+
+      adapter.clear();
+      assert.equal(adapter.getItem('foo'), null);
+      assert.equal(adapter.getItem('bar'), null);
     });
-    assert.strictEqual(data.has('foo'), true);
-    assert.equal(data.get('foo'), 100);
-    assert.deepEqual(data.get(), {foo: 100});
-    assert.equal(adapter.getItem('foo'), '{\"foo\":100}');
-
-    data.set('bar', '10');
-    assert.deepEqual(data.get(), {foo: 100, bar: "10"});
-    assert.equal(adapter.getItem('foo'), '{\"foo\":100,\"bar\":"10"}');
-
-    data.set({
-      foo: 100,
-      bar: '100'
-    });
-    assert.deepEqual(data.get(), {foo: 100, bar: "100"});
-    assert.equal(adapter.getItem('foo'), '{\"foo\":100,\"bar\":"100"}');
-
-    data.remove('foobar');
-    assert.strictEqual(data.has('foobar'), false);
-    assert.strictEqual(data.get('foobar'), undefined);
-    assert.equal(adapter.getItem('foo'), '{\"foo\":100,\"bar\":"100"}');
-
-    data.clear();
-    assert.equal(adapter.getItem('foo'), '{}');
-
-    data.delete();
-    assert.equal(adapter.getItem('foo'), null);
-
-    var logger = {
-      callCount: 0,
-      warn: function(message, key, error) {
-        this.callCount++;
-        assert.equal('Failed to parse the `%s` PersistentStorage', message);
-        assert.equal('bar', key);
-        assert.equal("SyntaxError", error.name);
-      }
-    };
-
-    adapter.setItem('bar', '{\"foo\":100}');
-    data = new PersistentStorage('bar', adapter, logger);
-    assert.strictEqual(data.has('foo'), true);
-    assert.equal(data.get('foo'), 100);
-    assert.deepEqual(data.get(), {foo: 100});
-
-    adapter.setItem('bar', '{\"foo\":200}');
-    assert.equal(data.get('foo'), 200);
-    assert.deepEqual(data.get(), {foo: 200});
-    assert.equal(logger.callCount, 0);
-
-    adapter.setItem('bar', 'invalid json string');
-    assert.strictEqual(data.get('foo'), undefined);
-    assert.equal(logger.callCount, 1);
-
-    data.set('foo', 300);
-    assert.equal(data.get('foo'), 300);
-    assert.equal(logger.callCount, 2);
-
-    data.set('foo', 400);
-    assert.equal(data.get('foo'), 400);
-    assert.equal(logger.callCount, 2);
-
-    adapter.clear();
-    assert.equal(adapter.getItem('foo'), null);
-    assert.equal(adapter.getItem('bar'), null);
   });
 
   QUnit.test("Storage: not supported adapter", function(assert) {

--- a/client-vendor/source/cm/tests/storageTest.js
+++ b/client-vendor/source/cm/tests/storageTest.js
@@ -40,7 +40,7 @@ define(["cm/storage", "cm/adapter/memory"], function(PersistentStorage, AdapterM
       assert.equal(adapter.getItem('foo'), '{}');
 
       data.delete();
-      assert.equal(adapter.getItem('foo'), null);
+      assert.strictEqual(adapter.getItem('foo'), null);
 
       var logger = {
         callCount: 0,
@@ -76,8 +76,8 @@ define(["cm/storage", "cm/adapter/memory"], function(PersistentStorage, AdapterM
       assert.equal(logger.callCount, 2);
 
       adapter.clear();
-      assert.equal(adapter.getItem('foo'), null);
-      assert.equal(adapter.getItem('bar'), null);
+      assert.strictEqual(adapter.getItem('foo'), null);
+      assert.strictEqual(adapter.getItem('bar'), null);
     });
   });
 
@@ -97,7 +97,7 @@ define(["cm/storage", "cm/adapter/memory"], function(PersistentStorage, AdapterM
     assert.strictEqual(data.has('foo'), true);
     assert.equal(data.get('foo'), 100);
     data.remove('foo');
-    assert.equal(data.has('foobar'), false);
+    assert.strictEqual(data.has('foobar'), false);
 
     var logger = {
       warn: function(message, error) {
@@ -121,6 +121,6 @@ define(["cm/storage", "cm/adapter/memory"], function(PersistentStorage, AdapterM
     assert.strictEqual(data.has('foo'), true);
     assert.equal(data.get('foo'), 100);
     data.remove('foo');
-    assert.equal(data.has('foobar'), false);
+    assert.strictEqual(data.has('foobar'), false);
   });
 });


### PR DESCRIPTION
Followup of https://github.com/cargomedia/cm/pull/2332

Problem: LocalStorage can be accessed by multiple tabs, so we cannot cache `_data` locally.
Idea: Always read/write from local storage. If not available instead install a "Object" adapter.

cc @vogdb 