### PR TITLE
Fix CommandManager "locking/synchronizing" mechanism

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,12 @@
     "guzzlehttp/guzzle": "~5.3.1",
     "kickbox/kickbox": "~1.0.3",
     "tomaszdurka/codegenerator": "~0.5.0",
-    "jenssegers/agent" : "~2.3.1",
+    "jenssegers/agent": "~2.3.1",
     "fluent/logger": "~1.0.0",
     "predis/predis": "~1.0.3",
     "danielstjules/stringy": "~2.3",
-    "swiftmailer/swiftmailer": "~5.4.3"
+    "swiftmailer/swiftmailer": "~5.4.3",
+    "ramsey/uuid": "~3.5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.5.0",

--- a/library/CM/Cli/CommandManager.php
+++ b/library/CM/Cli/CommandManager.php
@@ -334,7 +334,19 @@ class CM_Cli_CommandManager {
      * @return string
      */
     protected function _getMachineId() {
-        $file = new CM_File('/etc/machine-id'); // https://www.freedesktop.org/software/systemd/man/machine-id.html
+        // Global machine-id from systemd https://www.freedesktop.org/software/systemd/man/machine-id.html
+        $file = new CM_File('/etc/machine-id');
+
+        if (!$file->exists()) {
+            // Local machine-id as a backup
+            $serviceManager = CM_Service_Manager::getInstance();
+            $file = new CM_File('machine-id', $serviceManager->getFilesystems()->getData());
+            if (!$file->exists()) {
+                $uuid = Ramsey\Uuid\Uuid::uuid4()->toString();
+                $file->write($uuid);
+            }
+        }
+
         return trim($file->read());
     }
 

--- a/library/CM/Cli/CommandManager.php
+++ b/library/CM/Cli/CommandManager.php
@@ -116,15 +116,15 @@ class CM_Cli_CommandManager {
         $time = time();
         $timeoutStamp = $time + self::TIMEOUT;
         $process = $this->_getProcess();
-        $hostId = $process->getHostId();
-        $result = CM_Db_Db::select('cm_cli_command_manager_process', array('commandName', 'processId'), array('hostId' => $hostId));
+        $machineId = $this->_getMachineId();
+        $result = CM_Db_Db::select('cm_cli_command_manager_process', ['commandName', 'processId'], ['machineId' => $machineId]);
         foreach ($result->fetchAll() as $row) {
             $commandName = $row['commandName'];
             $processId = (int) $row['processId'];
             if ($process->isRunning($processId)) {
-                CM_Db_Db::update('cm_cli_command_manager_process', array('timeoutStamp' => $timeoutStamp), array('commandName' => $commandName));
+                CM_Db_Db::update('cm_cli_command_manager_process', ['timeoutStamp' => $timeoutStamp], ['commandName' => $commandName]);
             } else {
-                CM_Db_Db::delete('cm_cli_command_manager_process', array('commandName' => $commandName));
+                CM_Db_Db::delete('cm_cli_command_manager_process', ['commandName' => $commandName]);
             }
         }
         CM_Db_Db::delete('cm_cli_command_manager_process', '`timeoutStamp` < ' . $time);
@@ -196,10 +196,14 @@ class CM_Cli_CommandManager {
      */
     public function unlockCommand(CM_Cli_Command $command) {
         $commandName = $command->getName();
-        $process = $this->_getProcess();
-        $hostId = $process->getHostId();
-        $processId = $process->getProcessId();
-        CM_Db_Db::delete('cm_cli_command_manager_process', array('commandName' => $commandName, 'hostId' => $hostId, 'processId' => $processId));
+        $machineId = $this->_getMachineId();
+        $processId = $this->_getProcess()->getProcessId();
+
+        CM_Db_Db::delete('cm_cli_command_manager_process', [
+            'commandName' => $commandName,
+            'machineId'   => $machineId,
+            'processId'   => $processId,
+        ]);
     }
 
     /**
@@ -212,9 +216,9 @@ class CM_Cli_CommandManager {
             return;
         }
         $commandName = $command->getName();
-        $hostId = dechex($lock['hostId']);
+        $machineId = $lock['machineId'];
         $processId = (int) $lock['processId'];
-        throw new CM_Cli_Exception_Internal("Command `$commandName` still running (process `$processId` on host `$hostId`)");
+        throw new CM_Cli_Exception_Internal("Command `$commandName` still running (process `$processId` on machine `$machineId`)");
     }
 
     /**
@@ -236,7 +240,7 @@ class CM_Cli_CommandManager {
      */
     protected function _findLock(CM_Cli_Command $command) {
         $commandName = $command->getName();
-        $lock = CM_Db_Db::select('cm_cli_command_manager_process', array('hostId', 'processId'), array('commandName' => $commandName))->fetch();
+        $lock = CM_Db_Db::select('cm_cli_command_manager_process', ['machineId', 'processId'], ['commandName' => $commandName])->fetch();
         if (false === $lock) {
             return null;
         }
@@ -261,7 +265,7 @@ class CM_Cli_CommandManager {
     /**
      * @return CM_Process
      */
-    protected function  _getProcess() {
+    protected function _getProcess() {
         return CM_Process::getInstance();
     }
 
@@ -307,11 +311,15 @@ class CM_Cli_CommandManager {
     protected function _lockCommand(CM_Cli_Command $command) {
         $commandName = $command->getName();
         $process = $this->_getProcess();
-        $hostId = $process->getHostId();
+        $machineId = $this->_getMachineId();
         $processId = $process->getProcessId();
         $timeoutStamp = time() + self::TIMEOUT;
-        CM_Db_Db::insert('cm_cli_command_manager_process',
-            array('commandName' => $commandName, 'hostId' => $hostId, 'processId' => $processId, 'timeoutStamp' => $timeoutStamp));
+        CM_Db_Db::insert('cm_cli_command_manager_process', [
+            'commandName'  => $commandName,
+            'machineId'    => $machineId,
+            'processId'    => $processId,
+            'timeoutStamp' => $timeoutStamp,
+        ]);
     }
 
     /**
@@ -319,6 +327,14 @@ class CM_Cli_CommandManager {
      */
     protected function _outputError($message) {
         $this->_streamError->writeln($message);
+    }
+
+    /**
+     * @return string
+     */
+    protected function _getMachineId() {
+        $file = new CM_File('/etc/machine-id'); // https://www.freedesktop.org/software/systemd/man/machine-id.html
+        return trim($file->read());
     }
 
     /**

--- a/library/CM/Cli/CommandManager.php
+++ b/library/CM/Cli/CommandManager.php
@@ -121,10 +121,11 @@ class CM_Cli_CommandManager {
         foreach ($result->fetchAll() as $row) {
             $commandName = $row['commandName'];
             $processId = (int) $row['processId'];
+            $where = ['machineId' => $machineId, 'commandName' => $commandName];
             if ($process->isRunning($processId)) {
-                CM_Db_Db::update('cm_cli_command_manager_process', ['timeoutStamp' => $timeoutStamp], ['commandName' => $commandName]);
+                CM_Db_Db::update('cm_cli_command_manager_process', ['timeoutStamp' => $timeoutStamp], $where);
             } else {
-                CM_Db_Db::delete('cm_cli_command_manager_process', ['commandName' => $commandName]);
+                CM_Db_Db::delete('cm_cli_command_manager_process', $where);
             }
         }
         CM_Db_Db::delete('cm_cli_command_manager_process', '`timeoutStamp` < ' . $time);

--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -68,13 +68,6 @@ class CM_Process {
     /**
      * @return int
      */
-    public function getHostId() {
-        return (int) hexdec(CM_Util::exec('hostid'));
-    }
-
-    /**
-     * @return int
-     */
     public function getProcessId() {
         return posix_getpid();
     }

--- a/resources/db/structure.sql
+++ b/resources/db/structure.sql
@@ -50,11 +50,11 @@ DROP TABLE IF EXISTS `cm_cli_command_manager_process`;
 
 CREATE TABLE `cm_cli_command_manager_process` (
   `commandName` varchar(100) NOT NULL,
-  `hostId` int(10) unsigned NOT NULL,
+  `machineId` varchar(100) NOT NULL,
   `processId` int(10) unsigned DEFAULT NULL,
   `timeoutStamp` int(10) unsigned NOT NULL,
   PRIMARY KEY (`commandName`),
-  KEY `hostId` (`hostId`),
+  KEY `machineId` (`machineId`),
   KEY `timeoutStamp` (`timeoutStamp`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 

--- a/resources/db/update/70.php
+++ b/resources/db/update/70.php
@@ -1,0 +1,12 @@
+<?php
+
+if (CM_Db_Db::existsColumn('cm_cli_command_manager_process', 'hostId')) {
+    CM_Db_Db::exec('
+        ALTER TABLE `cm_cli_command_manager_process`
+          DROP KEY `hostId`,
+          DROP COLUMN `hostId`,
+          ADD COLUMN `machineId` varchar(100) NOT NULL AFTER `commandName`,
+          ADD KEY `machineId` (`machineId`)
+    ');
+    CM_Db_Db::delete('cm_cli_command_manager_process');
+}

--- a/tests/library/CM/Cli/CommandManagerTest.php
+++ b/tests/library/CM/Cli/CommandManagerTest.php
@@ -49,8 +49,8 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
 
     public function testSingleThreadSynchronizedLocked() {
         $commandMock = $this->_getCommandMock(true, false, 0);
-        $commandManagerMock = $this->_getCommandManagerMock($commandMock, "ERROR: Command `package-mock command-mock` still running (process `5432` on host `7f0101`)\n");
-        $lock = array('hostId' => '8323329', 'processId' => '5432');
+        $commandManagerMock = $this->_getCommandManagerMock($commandMock, "ERROR: Command `package-mock command-mock` still running (process `5432` on machine `my-machine-1`)\n");
+        $lock = array('machineId' => 'my-machine-1', 'processId' => '5432');
         $commandManagerMock->expects($this->once())->method('_findLock')->with($commandMock)->will($this->returnValue($lock));
         $commandManagerMock->expects($this->never())->method('_lockCommand');
         $commandManagerMock->expects($this->never())->method('unlockCommand');
@@ -68,8 +68,8 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
 
     public function testKeepAliveSynchronizedLocked() {
         $commandMock = $this->_getCommandMock(true, true, 0);
-        $commandManagerMock = $this->_getCommandManagerMock($commandMock, "ERROR: Command `package-mock command-mock` still running (process `5432` on host `7f0101`)\n");
-        $lock = array('hostId' => '8323329', 'processId' => '5432');
+        $commandManagerMock = $this->_getCommandManagerMock($commandMock, "ERROR: Command `package-mock command-mock` still running (process `5432` on machine `my-machine-1`)\n");
+        $lock = array('machineId' => 'my-machine-1', 'processId' => '5432');
         $commandManagerMock->expects($this->once())->method('_findLock')->with($commandMock)->will($this->returnValue($lock));
         $commandManagerMock->expects($this->never())->method('_lockCommand');
         $commandManagerMock->expects($this->never())->method('unlockCommand');
@@ -87,8 +87,8 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
 
     public function testForkSynchronizedLocked() {
         $commandMock = $this->_getCommandMock(true, false, 0);
-        $commandManagerMock = $this->_getCommandManagerMock($commandMock, "ERROR: Command `package-mock command-mock` still running (process `5432` on host `7f0101`)\n");
-        $lock = array('hostId' => '8323329', 'processId' => '5432');
+        $commandManagerMock = $this->_getCommandManagerMock($commandMock, "ERROR: Command `package-mock command-mock` still running (process `5432` on machine `my-machine-1`)\n");
+        $lock = array('machineId' => 'my-machine-1', 'processId' => '5432');
         $commandManagerMock->expects($this->once())->method('_findLock')->with($commandMock)->will($this->returnValue($lock));
         $commandManagerMock->expects($this->never())->method('_lockCommand');
         $commandManagerMock->expects($this->never())->method('unlockCommand');
@@ -106,8 +106,8 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
 
     public function testForkAndKeepAliveSynchronizedLocked() {
         $commandMock = $this->_getCommandMock(true, false, 0);
-        $commandManagerMock = $this->_getCommandManagerMock($commandMock, "ERROR: Command `package-mock command-mock` still running (process `5432` on host `7f0101`)\n");
-        $lock = array('hostId' => '8323329', 'processId' => '5432');
+        $commandManagerMock = $this->_getCommandManagerMock($commandMock, "ERROR: Command `package-mock command-mock` still running (process `5432` on machine `my-machine-1`)\n");
+        $lock = array('machineId' => 'my-machine-1', 'processId' => '5432');
         $commandManagerMock->expects($this->once())->method('_findLock')->with($commandMock)->will($this->returnValue($lock));
         $commandManagerMock->expects($this->never())->method('_lockCommand');
         $commandManagerMock->expects($this->never())->method('unlockCommand');
@@ -116,27 +116,27 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
 
     public function testMonitorSynchronizedCommands() {
         $mockBuilder = $this->getMockBuilder('CM_Process');
-        $mockBuilder->setMethods(['getHostId', 'isRunning']);
+        $mockBuilder->setMethods(['isRunning']);
         $mockBuilder->disableOriginalConstructor();
         $processMock = $mockBuilder->getMock();
-        $processMock->expects($this->any())->method('getHostId')->will($this->returnValue(1));
         $processMock->expects($this->any())->method('isRunning')->will($this->returnCallback(function ($processId) {
             return $processId !== 3;
         }));
         $mockBuilder = $this->getMockBuilder('CM_Cli_CommandManager');
-        $mockBuilder->setMethods(['_getProcess']);
+        $mockBuilder->setMethods(['_getProcess', '_getMachineId']);
         $commandManagerMock = $mockBuilder->getMock();
         $commandManagerMock->expects($this->any())->method('_getProcess')->will($this->returnValue($processMock));
+        $commandManagerMock->expects($this->any())->method('_getMachineId')->will($this->returnValue('my-machine-1'));
         CM_Db_Db::insert('cm_cli_command_manager_process',
-            array('commandName' => 'command-mock1', 'hostId' => 1, 'processId' => 1, 'timeoutStamp' => time() + 60));
+            array('commandName' => 'command-mock1', 'machineId' => 'my-machine-1', 'processId' => 1, 'timeoutStamp' => time() + 60));
         CM_Db_Db::insert('cm_cli_command_manager_process',
-            array('commandName' => 'command-mock2', 'hostId' => 1, 'processId' => 2, 'timeoutStamp' => time() - 60));
+            array('commandName' => 'command-mock2', 'machineId' => 'my-machine-1', 'processId' => 2, 'timeoutStamp' => time() - 60));
         CM_Db_Db::insert('cm_cli_command_manager_process',
-            array('commandName' => 'command-mock3', 'hostId' => 1, 'processId' => 3, 'timeoutStamp' => time() + 60));
+            array('commandName' => 'command-mock3', 'machineId' => 'my-machine-1', 'processId' => 3, 'timeoutStamp' => time() + 60));
         CM_Db_Db::insert('cm_cli_command_manager_process',
-            array('commandName' => 'command-mock4', 'hostId' => 2, 'processId' => 4, 'timeoutStamp' => time() + 60));
+            array('commandName' => 'command-mock4', 'machineId' => 'my-machine-2', 'processId' => 4, 'timeoutStamp' => time() + 60));
         CM_Db_Db::insert('cm_cli_command_manager_process',
-            array('commandName' => 'command-mock5', 'hostId' => 2, 'processId' => 5, 'timeoutStamp' => time() - 60));
+            array('commandName' => 'command-mock5', 'machineId' => 'my-machine-2', 'processId' => 5, 'timeoutStamp' => time() - 60));
         /** @var CM_Cli_CommandManager $commandManagerMock */
         $commandManagerMock->monitorSynchronizedCommands();
         $timeoutStampExpected = time() + CM_Cli_CommandManager::TIMEOUT;


### PR DESCRIPTION
`CM_Cli_CommandManager` has a mechanism to ensure a CLI command that defines the `@synchronized` annotation only runs once across the installation of the application.

See `monitorSynchronizedCommands`, `_lockCommand` and `_checkLock`.

The mechanism relies on a unique host identifier, by calling `hostid`, unfortunately that identifier is not unique across our hosts.

Let's investigate why `hostid` is not unique and/or find another mechanism.

Another improvement: in the foreach of `monitorSynchronizedCommands` let's only modify rows of the *current* host.