### PR TITLE
Exceptions not displayed in CLI

### DIFF
--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -228,7 +228,7 @@ class CM_Process {
                 $forkHandler->runAndSendWorkload();
                 $forkHandler->closeIpcStream();
             } catch (Exception $e) {
-                CM_Service_Manager::getInstance()->getLogger()->addMessage('Forking workload failed', CM_Log_Logger::exceptionToLevel($e), (new CM_Log_Context())->setException($e));
+                CM_Bootloader::getInstance()->getExceptionHandler()->handleException($e);
             }
             exit;
         }

--- a/library/CM/Process/ForkHandler.php
+++ b/library/CM/Process/ForkHandler.php
@@ -76,7 +76,7 @@ class CM_Process_ForkHandler {
             $return = $workload($result);
             $result->setResult($return);
         } catch (Exception $e) {
-            CM_Service_Manager::getInstance()->getLogger()->addMessage('Forked workload failed', CM_Log_Logger::exceptionToLevel($e), (new CM_Log_Context())->setException($e));
+            CM_Bootloader::getInstance()->getExceptionHandler()->handleException($e);
             $result->setException($e);
         }
 

--- a/tests/library/CM/Redis/ClientTest.php
+++ b/tests/library/CM/Redis/ClientTest.php
@@ -223,6 +223,7 @@ class CM_Redis_ClientTest extends CMTest_TestCase {
         foreach ($resultList as $result) {
             $this->assertSame(['foo', 'bar'], $result->getResult());
         }
+        $process->waitForChildren();
     }
 
     /**
@@ -252,6 +253,7 @@ class CM_Redis_ClientTest extends CMTest_TestCase {
             return null;
         });
         $this->assertSame(['foo', ['bar0', 'bar1']], $response);
+        $process->waitForChildren();
     }
 
     /**
@@ -278,5 +280,6 @@ class CM_Redis_ClientTest extends CMTest_TestCase {
             }
         });
         $this->assertSame(['foo', 'test', 'bar'], $response);
+        $process->waitForChildren();
     }
 }

--- a/tests/library/CM/Redis/ClientTest.php
+++ b/tests/library/CM/Redis/ClientTest.php
@@ -223,7 +223,6 @@ class CM_Redis_ClientTest extends CMTest_TestCase {
         foreach ($resultList as $result) {
             $this->assertSame(['foo', 'bar'], $result->getResult());
         }
-        $process->waitForChildren();
     }
 
     /**


### PR DESCRIPTION
For example: running `bin/cm app setup --reload` would throw an error/exception:
> Argument 1 passed to Denkmal_Model_Venue::setFacebookPage() must be an instance of Denkmal_Model_FacebookPage, null given, called in /home/vagrant/denkmal/library/Denkmal/library/Denkmal/Model/Venue.php on line 292 and defined

But no error is displayed on the standard output.
Exit code is 1 though.

@fvovan @tomaszdurka can you look into this?