### PR TITLE
make StreamChannel::_decryptKey() usable in a static context

### DIFF
--- a/library/CM/Model/StreamChannel/Abstract.php
+++ b/library/CM/Model/StreamChannel/Abstract.php
@@ -167,14 +167,6 @@ abstract class CM_Model_StreamChannel_Abstract extends CM_Model_Abstract {
     }
 
     /**
-     * @param string $encryptionKey
-     * @return string Data
-     */
-    protected function _decryptKey($encryptionKey) {
-        return (new CM_Util_Encryption())->decrypt($this->getKey(), $encryptionKey);
-    }
-
-    /**
      * @param int      $id
      * @param int|null $type
      * @throws CM_Exception_Invalid|CM_Exception_Nonexistent
@@ -232,6 +224,15 @@ abstract class CM_Model_StreamChannel_Abstract extends CM_Model_Abstract {
             return null;
         }
         return $streamChannel;
+    }
+
+    /**
+     * @param string $streamChannelKey
+     * @param string $encryptionKey
+     * @return string Data
+     */
+    protected static function _decryptKey($streamChannelKey, $encryptionKey) {
+        return (new CM_Util_Encryption())->decrypt($streamChannelKey, $encryptionKey);
     }
 
     /**

--- a/library/CM/Model/StreamChannel/Message/User.php
+++ b/library/CM/Model/StreamChannel/Message/User.php
@@ -49,7 +49,7 @@ class CM_Model_StreamChannel_Message_User extends CM_Model_StreamChannel_Message
      * @return CM_Model_User
      */
     public function getUser() {
-        $userId = $this->_decryptKey(self::SALT);
+        $userId = self::_decryptKey($this->getKey(), self::SALT);
         return CM_Model_User::factory($userId);
     }
 

--- a/tests/library/CM/Model/StreamChannel/AbstractTest.php
+++ b/tests/library/CM/Model/StreamChannel/AbstractTest.php
@@ -202,11 +202,9 @@ class CM_Model_StreamChannel_AbstractTest extends CMTest_TestCase {
         $encryptMethod->setAccessible(true);
         $encryptedData = $encryptMethod->invoke(null, $data, $encryptionKey);
 
-        $streamChannel = $this->getMockBuilder('CM_Model_StreamChannel_Abstract')->setMethods(array('getKey'))->disableOriginalConstructor()->getMockForAbstractClass();
-        $streamChannel->expects($this->any())->method('getKey')->will($this->returnValue($encryptedData));
         $decryptMethod = new ReflectionMethod('CM_Model_StreamChannel_Abstract', '_decryptKey');
         $decryptMethod->setAccessible(true);
-        $decryptedData = $decryptMethod->invoke($streamChannel, $encryptionKey);
+        $decryptedData = $decryptMethod->invoke(null, $encryptedData, $encryptionKey);
         $this->assertSame($data, $decryptedData);
     }
 


### PR DESCRIPTION
So it can be used to decrypt encoded keys when creating a streamchannel and other stuff.