### PR TITLE
revert breaking fixes to recursive decoding

### DIFF
--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -650,9 +650,6 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
             if (!is_subclass_of($className, 'CM_ArrayConvertible')) {
                 throw new CM_Exception_InvalidParam('Class for decoding is not CM_ArrayConvertible', null, ['class' => $className]);
             }
-            if (!empty($value)) {
-                $value = self::decode($value);
-            }
             /** @var CM_ArrayConvertible $className */
             $value = $className::fromArray($value);
             if (!$value) {

--- a/tests/library/CM/ParamsTest.php
+++ b/tests/library/CM/ParamsTest.php
@@ -210,31 +210,6 @@ class CM_ParamsTest extends CMTest_TestCase {
         $this->assertSame(1, $fromArrayMethod->getCallCount());
     }
 
-    public function testDecodeArrayConvertibleRecursive() {
-        $objectOuter = $this->mockInterface('CM_ArrayConvertible');
-        $fromArrayMethodOuter = $objectOuter->mockStaticMethod('fromArray')->set(function ($encoded) {
-            $this->assertSame(['foo' => 1, 'object' => 2], $encoded);
-            return (int) $encoded['foo'] . $encoded['object'];
-        });
-        $objectInner = $this->mockInterface('CM_ArrayConvertible');
-        $fromArrayMethodInner = $objectInner->mockStaticMethod('fromArray')->set(function ($encoded) {
-            $this->assertSame(['bar' => 2], $encoded);
-            return $encoded['bar'];
-        });
-
-        $encodedArrayConvertible = [
-            'foo'    => 1,
-            '_class' => get_class($objectOuter->newInstance()),
-            'object' => [
-                'bar'    => 2,
-                '_class' => get_class($objectInner->newInstance()),
-            ]
-        ];
-        $this->assertEquals(12, CM_Params::decode($encodedArrayConvertible));
-        $this->assertSame(1, $fromArrayMethodInner->getCallCount());
-        $this->assertSame(1, $fromArrayMethodOuter->getCallCount());
-    }
-
     public function testEncodeArrayConvertible() {
         $object = $this->mockInterface('CM_ArrayConvertible')->newInstance();
         $toArrayMethod = $object->mockMethod('toArray')->set([


### PR DESCRIPTION
This reverts commit 03e0b602d6e392c2ce1dc5671f5ffa80c8b7c055, reversing
changes made to efc4e4acd12afc5938cea7b2629a92640040c3b6.

There are some side-effects because of the mixture of `CM_ArrayConvertible` and `JsonSerializable` properties in `CM_Params::encode()`.

I'm reverting this so we have a clean master-breanch.