### PR TITLE
Enable recursive decoding of an encoded object's ArrayConvertible-properties

### DIFF
--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -641,21 +641,14 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
         if ($json) {
             $value = CM_Util::jsonDecode($value);
         }
-        if (is_array($value) && isset($value['_class'])) {
+        if (is_array($value) && isset($value['_class']) && is_subclass_of($value['_class'], 'CM_ArrayConvertible')) {
             $className = (string) $value['_class'];
             unset($value['_class']);
-            if (!class_exists($className)) {
-                throw new CM_Exception_InvalidParam('Class for decoding does not exist', null, ['class' => $className]);
-            }
             if (!empty($value)) {
                 $value = self::decode($value);
             }
-            if (is_subclass_of($className, 'CM_ArrayConvertible')) {
-                /** @var CM_ArrayConvertible $className */
-                $value = $className::fromArray($value);
-            } elseif (!is_subclass_of($className, 'JsonSerializable')) {
-                throw new CM_Exception_InvalidParam('Class for decoding is neither CM_ArrayConvertible nor JsonSerializable', null, ['class' => $className]);
-            }
+            /** @var CM_ArrayConvertible $className */
+            $value = $className::fromArray($value);
             if (!$value) {
                 return false;
             }

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -635,7 +635,6 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
      * @param string       $value
      * @param boolean|null $json
      * @return mixed|false
-     * @throws CM_Exception_InvalidParam
      */
     public static function decode($value, $json = null) {
         if ($json) {

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -650,6 +650,9 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
             if (!is_subclass_of($className, 'CM_ArrayConvertible')) {
                 throw new CM_Exception_InvalidParam('Class for decoding is not CM_ArrayConvertible', null, ['class' => $className]);
             }
+            if (!empty($value)) {
+                $value = self::decode($value);
+            }
             /** @var CM_ArrayConvertible $className */
             $value = $className::fromArray($value);
             if (!$value) {

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -647,14 +647,15 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
             if (!class_exists($className)) {
                 throw new CM_Exception_InvalidParam('Class for decoding does not exist', null, ['class' => $className]);
             }
-            if (!is_subclass_of($className, 'CM_ArrayConvertible')) {
-                throw new CM_Exception_InvalidParam('Class for decoding is not CM_ArrayConvertible', null, ['class' => $className]);
-            }
             if (!empty($value)) {
                 $value = self::decode($value);
             }
-            /** @var CM_ArrayConvertible $className */
-            $value = $className::fromArray($value);
+            if (is_subclass_of($className, 'CM_ArrayConvertible')) {
+                /** @var CM_ArrayConvertible $className */
+                $value = $className::fromArray($value);
+            } elseif (!is_subclass_of($className, 'JsonSerializable')) {
+                throw new CM_Exception_InvalidParam('Class for decoding is neither CM_ArrayConvertible nor JsonSerializable', null, ['class' => $className]);
+            }
             if (!$value) {
                 return false;
             }

--- a/tests/library/CM/ParamsTest.php
+++ b/tests/library/CM/ParamsTest.php
@@ -210,6 +210,31 @@ class CM_ParamsTest extends CMTest_TestCase {
         $this->assertSame(1, $fromArrayMethod->getCallCount());
     }
 
+    public function testDecodeArrayConvertibleRecursive() {
+        $objectOuter = $this->mockInterface('CM_ArrayConvertible');
+        $fromArrayMethodOuter = $objectOuter->mockStaticMethod('fromArray')->set(function ($encoded) {
+            $this->assertSame(['foo' => 1, 'object' => 2], $encoded);
+            return (int) $encoded['foo'] . $encoded['object'];
+        });
+        $objectInner = $this->mockInterface('CM_ArrayConvertible');
+        $fromArrayMethodInner = $objectInner->mockStaticMethod('fromArray')->set(function ($encoded) {
+            $this->assertSame(['bar' => 2], $encoded);
+            return $encoded['bar'];
+        });
+
+        $encodedArrayConvertible = [
+            'foo'    => 1,
+            '_class' => get_class($objectOuter->newInstance()),
+            'object' => [
+                'bar'    => 2,
+                '_class' => get_class($objectInner->newInstance()),
+            ]
+        ];
+        $this->assertEquals(12, CM_Params::decode($encodedArrayConvertible));
+        $this->assertSame(1, $fromArrayMethodInner->getCallCount());
+        $this->assertSame(1, $fromArrayMethodOuter->getCallCount());
+    }
+
     public function testEncodeArrayConvertible() {
         $object = $this->mockInterface('CM_ArrayConvertible')->newInstance();
         $toArrayMethod = $object->mockMethod('toArray')->set([


### PR DESCRIPTION
Followup to https://github.com/cargomedia/cm/pull/2361