### PR TITLE
Smarty function "lessVariable" uses file storage

### DIFF
--- a/library/CM/Frontend/Render.php
+++ b/library/CM/Frontend/Render.php
@@ -523,17 +523,21 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
     public function getLessVariable($variableName) {
         $variableName = (string) $variableName;
 
-        $assetCss = new CM_Asset_Css($this);
-        $assetCss->addVariables();
-        $assetCss->add('foo:@' . $variableName);
-        $css = $assetCss->get(true);
-        if (!preg_match('/^foo:(.+);$/', $css, $matches)) {
-            throw new CM_Exception_Invalid('Cannot detect variable from CSS.', null, [
-                'variableName' => $variableName,
-                'css'          => $css,
-            ]);
-        }
-        return (string) $matches[1];
+        $cache = new CM_Cache_Local();
+        return $cache->get($cache->key(__METHOD__, $variableName) , function () use ($variableName) {
+            $assetCss = new CM_Asset_Css($this);
+            $assetCss->addVariables();
+            $assetCss->add('foo:@' . $variableName);
+
+            $css = $assetCss->get(true);
+            if (!preg_match('/^foo:(.+);$/', $css, $matches)) {
+                throw new CM_Exception_Invalid('Cannot detect variable from CSS.', null, [
+                    'variableName' => $variableName,
+                    'css'          => $css,
+                ]);
+            }
+            return (string) $matches[1];
+        });
     }
 
     /**

--- a/library/CM/Frontend/Render.php
+++ b/library/CM/Frontend/Render.php
@@ -524,7 +524,7 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
         $variableName = (string) $variableName;
 
         $cache = new CM_Cache_Local();
-        return $cache->get($cache->key(__METHOD__, $variableName) , function () use ($variableName) {
+        return $cache->get($cache->key(__METHOD__, $variableName), function () use ($variableName) {
             $assetCss = new CM_Asset_Css($this);
             $assetCss->addVariables();
             $assetCss->add('foo:@' . $variableName);


### PR DESCRIPTION
In `CM_Asset_Css::_compile()` we use *file* storage because the assumption is that this code is only executed a few times and then cached by the CDN. But it turns out that `smarty_function_lessVariable` also calls this code, which is executed with every rendering.

We could probably cache the result of `Render::getLessVariable()` in APC?

@tomaszdurka @zazabe wdyt?