### PR TITLE
Change the ordering criteria in CM_Paging_Log.

### DIFF
--- a/library/CM/Paging/Log.php
+++ b/library/CM/Paging/Log.php
@@ -73,7 +73,7 @@ class CM_Paging_Log extends CM_Paging_Abstract implements CM_Typed {
             ];
             $source = new CM_PagingSource_MongoDb(self::COLLECTION_NAME, null, null, $aggregate);
         } else {
-            $source = new CM_PagingSource_MongoDb(self::COLLECTION_NAME, $criteria, null, null, ['_id' => -1]);
+            $source = new CM_PagingSource_MongoDb(self::COLLECTION_NAME, $criteria, null, null, ['createdAt' => -1]);
         }
 
         parent::__construct($source);


### PR DESCRIPTION
according to https://docs.mongodb.com/v2.6/core/index-intersection/#index-intersection-and-sort 
Lets sort by `createdAt` but not by `_id`  ( because we already have `{level:1, createdAt:1}` index)