### PR TITLE
Logger: record "httpRequest.query" as a string vs array

### DIFF
--- a/library/CM/Log/ContextFormatter/Cargomedia.php
+++ b/library/CM/Log/ContextFormatter/Cargomedia.php
@@ -29,7 +29,7 @@ class CM_Log_ContextFormatter_Cargomedia implements CM_Log_ContextFormatter_Inte
             ];
             $query = $request->findQuery();
             unset($query['viewInfoList']);
-            $formattedRequest['query'] = $this->_encodeAsArray($query);
+            $formattedRequest['query'] = json_encode($query);
             if (array_key_exists('http_referer', $serverArray)) {
                 $formattedRequest['referer'] = (string) $serverArray['http_referer'];
             }
@@ -78,38 +78,5 @@ class CM_Log_ContextFormatter_Cargomedia implements CM_Log_ContextFormatter_Inte
         }
         $result[$this->_appName] = $appAttributes;
         return $result;
-    }
-
-    /**
-     * @param array $data
-     * @return array
-     */
-    protected function _encodeAsArray(array $data) {
-        $iterator = new RecursiveIteratorIterator(new RecursiveArrayIterator($data));
-        $result = [];
-        foreach ($iterator as $key => $value) {
-            $result[] = [
-                'key'   => $this->_getCurrentKeyPath($iterator),
-                'value' => $value,
-            ];
-        }
-        usort($result, function (array $a, array $b) {
-            return strcmp($a['key'], $b['key']);
-        });
-        return $result;
-    }
-
-    /**
-     * @param RecursiveIteratorIterator $iterator
-     * @return string
-     */
-    private function _getCurrentKeyPath(RecursiveIteratorIterator $iterator) {
-        $i = 0;
-        $keyList = [];
-        while ($subIterator = $iterator->getSubIterator($i)) {
-            $keyList[] = $subIterator->key();
-            $i += 1;
-        }
-        return join('.', $keyList);
     }
 }

--- a/library/CM/Log/ContextFormatter/Cargomedia.php
+++ b/library/CM/Log/ContextFormatter/Cargomedia.php
@@ -29,7 +29,7 @@ class CM_Log_ContextFormatter_Cargomedia implements CM_Log_ContextFormatter_Inte
             ];
             $query = $request->findQuery();
             unset($query['viewInfoList']);
-            $formattedRequest['query'] = json_encode($query);
+            $formattedRequest['query'] = CM_Util::jsonEncode($query, true);
             if (array_key_exists('http_referer', $serverArray)) {
                 $formattedRequest['referer'] = (string) $serverArray['http_referer'];
             }

--- a/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
+++ b/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
@@ -35,15 +35,7 @@ class CM_Log_ContextFormatter_CargomediaTest extends CMTest_TestCase {
         $this->assertSame('www.example.com', $formattedContext['computerInfo']['fqdn']);
         $this->assertSame('v7.0.1', $formattedContext['computerInfo']['phpVersion']);
         $this->assertSame('/foo?bar=1&baz=quux&viewInfoList=fooBar', $formattedContext['httpRequest']['uri']);
-        $this->assertSame(
-            [
-                ['key' => 'bar', 'value' => '1'],
-                ['key' => 'baz', 'value' => 'quux'],
-                ['key' => 'foo', 'value' => 'bar'],
-                ['key' => 'quux', 'value' => 'baz'],
-            ],
-            $formattedContext['httpRequest']['query']
-        );
+        $this->assertSame(json_encode(['bar' => '1', 'baz' => 'quux', 'foo' => 'bar', 'quux' => 'baz',]), $formattedContext['httpRequest']['query']);
 
         $this->assertSame('POST', $formattedContext['httpRequest']['method']);
         $this->assertSame('http://bar/baz', $formattedContext['httpRequest']['referer']);
@@ -60,63 +52,5 @@ class CM_Log_ContextFormatter_CargomediaTest extends CMTest_TestCase {
         $this->assertInternalType('string', $formattedContext['exception']['stack']);
         $this->assertSame(['foo' => "'bar'"], $formattedContext['exception']['metaInfo']);
         $this->assertRegExp('/library\/CM\/Log\/ContextFormatter\/CargomediaTest\.php\(\d+\)/', $formattedContext['exception']['stack']);
-    }
-
-    public function testArrayEncoding() {
-        /** @var CM_Log_ContextFormatter_Cargomedia|\Mocka\AbstractClassTrait $mock */
-        $mock = $this->mockClass('CM_Log_ContextFormatter_Cargomedia')->newInstanceWithoutConstructor();
-
-        $this->assertSame([], CMTest_TH::callProtectedMethod($mock, '_encodeAsArray', [[]])); //empty array
-        $array = [
-            'foo4' => 'val4',
-            'foo1' => ['bar1' => ['quux1' => 'val11', 'baz1' => 'val12']],
-            'foo2' => ['bar2' => 'val21'],
-            'foo3' => [4, '1', 3],
-            'foo7' => ['bar4' => [1, 2]],
-            'foo5' => '',
-            'foo6' => [],
-        ];
-        $this->assertSame(
-            [
-                ['key' => 'foo1.bar1.baz1', 'value' => 'val12'],
-                ['key' => 'foo1.bar1.quux1', 'value' => 'val11'],
-                ['key' => 'foo2.bar2', 'value' => 'val21'],
-                ['key' => 'foo3.0', 'value' => 4],
-                ['key' => 'foo3.1', 'value' => '1'],
-                ['key' => 'foo3.2', 'value' => 3],
-                ['key' => 'foo4', 'value' => 'val4'],
-                ['key' => 'foo5', 'value' => ''],
-                ['key' => 'foo7.bar4.0', 'value' => 1],
-                ['key' => 'foo7.bar4.1', 'value' => 2],
-            ],
-            CMTest_TH::callProtectedMethod($mock, '_encodeAsArray', [$array])
-        );
-
-        $array = [
-            [
-                4,
-                5,
-                6,
-                [1, 2, 3]
-            ],
-            [1, 2, 3],
-            [7, 8]
-        ];
-        $this->assertSame(
-            [
-                ['key' => '0.0', 'value' => 4],
-                ['key' => '0.1', 'value' => 5],
-                ['key' => '0.2', 'value' => 6],
-                ['key' => '0.3.0', 'value' => 1],
-                ['key' => '0.3.1', 'value' => 2],
-                ['key' => '0.3.2', 'value' => 3],
-                ['key' => '1.0', 'value' => 1],
-                ['key' => '1.1', 'value' => 2],
-                ['key' => '1.2', 'value' => 3],
-                ['key' => '2.0', 'value' => 7],
-                ['key' => '2.1', 'value' => 8],
-            ],
-            CMTest_TH::callProtectedMethod($mock, '_encodeAsArray', [$array])
-        );
     }
 }

--- a/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
+++ b/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
@@ -35,7 +35,12 @@ class CM_Log_ContextFormatter_CargomediaTest extends CMTest_TestCase {
         $this->assertSame('www.example.com', $formattedContext['computerInfo']['fqdn']);
         $this->assertSame('v7.0.1', $formattedContext['computerInfo']['phpVersion']);
         $this->assertSame('/foo?bar=1&baz=quux&viewInfoList=fooBar', $formattedContext['httpRequest']['uri']);
-        $this->assertSame(json_encode(['bar' => '1', 'baz' => 'quux', 'foo' => 'bar', 'quux' => 'baz',]), $formattedContext['httpRequest']['query']);
+        $this->assertSame(join("\n", ['{',
+            '    "bar": "1",',
+            '    "baz": "quux",',
+            '    "foo": "bar",',
+            '    "quux": "baz"',
+            '}']), $formattedContext['httpRequest']['query']);
 
         $this->assertSame('POST', $formattedContext['httpRequest']['method']);
         $this->assertSame('http://bar/baz', $formattedContext['httpRequest']['referer']);


### PR DESCRIPTION
It's quite useless to have `httpRequest.query` as an array:
- not searchable on loggly
- produce some failures when fluentd is [used in local, in combination with  ElasticSearch](https://github.com/cargomedia/docker-fluentd)      
```
elasticsearch_1  | MapperParsingException[failed to parse]; nested: IllegalArgumentException[mapper [httpRequest.query.value] of different type, current_type [string], merged_type [long]];
```


What about recording it as a string instead? maybe as a JSON? wdyt @fvovan  @tomaszdurka? 

cc @njam 