### PR TITLE
Streamline how object/model/id are logged through fluentd/mongoDB

### DIFF
--- a/library/CM/Log/ContextFormatter/Cargomedia.php
+++ b/library/CM/Log/ContextFormatter/Cargomedia.php
@@ -70,11 +70,16 @@ class CM_Log_ContextFormatter_Cargomedia implements CM_Log_ContextFormatter_Inte
         $result = [];
         $appAttributes = $context->getExtra();
         if ($user = $context->getUser()) {
-            $appAttributes['user'] = $user->getId();
+            $appAttributes['user'] = [
+                'id'          => $user->getId(),
+                'displayName' => $user->getDisplayName(),
+            ];
         }
         $request = $context->getHttpRequest();
         if (null !== $request) {
-            $appAttributes['clientId'] = $request->getClientId();
+            $appAttributes['client'] = [
+                'id' => $request->getClientId(),
+            ];
         }
         $result[$this->_appName] = $appAttributes;
         return $result;

--- a/library/CM/Log/Encoder/MongoDb.php
+++ b/library/CM/Log/Encoder/MongoDb.php
@@ -11,7 +11,10 @@ class CM_Log_Encoder_MongoDb {
             return new MongoDate($value->getTimestamp());
         }
         if ($value instanceof CM_Model_Abstract) {
-            return '[' . get_class($value) . ':' . $value->getId() . ']';
+            return [
+                'class' => get_class($value),
+                'id'    => $value->getId(),
+            ];
         }
         if ($value instanceof JsonSerializable) {
             return $this->encode($value->jsonSerialize());
@@ -20,7 +23,9 @@ class CM_Log_Encoder_MongoDb {
             return array_map([$this, 'encode'], $value);
         }
         if (is_object($value)) {
-            return '[' . get_class($value) . ']';
+            return [
+                'class' => get_class($value),
+            ];
         }
         return $value;
     }

--- a/library/CM/Log/Handler/Fluentd.php
+++ b/library/CM/Log/Handler/Fluentd.php
@@ -74,28 +74,35 @@ class CM_Log_Handler_Fluentd extends CM_Log_Handler_Abstract {
     }
 
     /**
-     * @param array $value
+     * @param array      $value
+     * @param mixed|null $key
      * @return array
      */
-    protected function _encodeRecord($value) {
+    protected function _encodeRecord($value, $key = null) {
+        if ('id' === $key) {
+            return (string) $value;
+        }
         if ($value instanceof DateTime) {
             return $value->format('c');
         }
-
+        if ($value instanceof CM_Model_Abstract) {
+            return [
+                'class' => get_class($value),
+                'id'    => (string) $value->getId(),
+            ];
+        }
         if (is_object($value)) {
-            $encoded = '[';
-            $encoded .= get_class($value);
-            if ($value instanceof CM_Model_Abstract) {
-                $encoded .= ':' . $value->getId();
+            return [
+                'class' => get_class($value),
+            ];
+        }
+        if (is_array($value)) {
+            $encoded = [];
+            foreach ($value as $key => $val) {
+                $encoded[$key] = $this->_encodeRecord($val, $key);
             }
-            $encoded .= ']';
             return $encoded;
         }
-
-        if (is_array($value)) {
-            return array_map([$this, '_encodeRecord'], $value);
-        }
-
         return $value;
     }
 }

--- a/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
+++ b/tests/library/CM/Log/ContextFormatter/CargomediaTest.php
@@ -49,8 +49,8 @@ class CM_Log_ContextFormatter_CargomediaTest extends CMTest_TestCase {
         $this->assertSame('http://bar/baz', $formattedContext['httpRequest']['referer']);
         $this->assertSame('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_10)', $formattedContext['httpRequest']['useragent']);
         $this->assertSame('foo.bar', $formattedContext['httpRequest']['hostname']);
-        $this->assertSame($user->getId(), $formattedContext['appName']['user']);
-        $this->assertSame($clientId, $formattedContext['appName']['clientId']);
+        $this->assertSame(['id' => $user->getId(), 'displayName' => 'user' . $user->getId()], $formattedContext['appName']['user']);
+        $this->assertSame($clientId, $formattedContext['appName']['client']['id']);
         $this->assertSame('baz', $formattedContext['appName']['bar']);
         $this->assertSame('quux', $formattedContext['appName']['baz']);
 

--- a/tests/library/CM/Log/Handler/FluentdTest.php
+++ b/tests/library/CM/Log/Handler/FluentdTest.php
@@ -93,7 +93,7 @@ class CM_Log_Handler_FluentdTest extends CMTest_TestCase {
                 'id'  => 123,
                 'bar' => (object) ['baz'],
                 'baz' => new DateTime('01-01-2001'),
-                'bax' => new Fake_Model_Fluentd(),
+                'bax' => new CM_Model_Mock_Fluentd(),
             ],
         ];
         $this->assertSame([
@@ -104,7 +104,7 @@ class CM_Log_Handler_FluentdTest extends CMTest_TestCase {
                 ],
                 'baz' => '2001-01-01T00:00:00+00:00',
                 'bax' => [
-                    'class' => 'Fake_Model_Fluentd',
+                    'class' => 'CM_Model_Mock_Fluentd',
                     'id'    => '42',
                 ],
             ],
@@ -112,7 +112,7 @@ class CM_Log_Handler_FluentdTest extends CMTest_TestCase {
     }
 }
 
-class Fake_Model_Fluentd extends CM_Model_Abstract {
+class CM_Model_Mock_Fluentd extends CM_Model_Abstract {
 
     public function getIdRaw() {
         return ['id' => 42];


### PR DESCRIPTION
- record `object` as `{class: <instanceName>}`
- record `CM_Model_Abstact` instance as `{id: '123', class: <instanceName>}`
- cast to `string` any record with an `id` key (only for FluentD, see https://github.com/cargomedia/cm/issues/2329)
