### PR TITLE
Fluentd Logger adapter: send time with sub-second resolution

### DIFF
--- a/library/CM/Log/Handler/Fluentd.php
+++ b/library/CM/Log/Handler/Fluentd.php
@@ -54,7 +54,7 @@ class CM_Log_Handler_Fluentd extends CM_Log_Handler_Abstract {
         $result = [
             'message'   => (string) $record->getMessage(),
             'level'     => strtolower($levelsMapping[$record->getLevel()]),
-            'timestamp' => $record->getCreatedAt()->format(DateTime::ISO8601),
+            'timestamp' => $record->getCreatedAt()->format('Y-m-d\TH:i:s.uO'), // ISO8601 with fractions
         ];
         $result = array_merge($result, $this->_contextFormatter->formatContext($context));
         return $result;

--- a/library/CM/Log/Record.php
+++ b/library/CM/Log/Record.php
@@ -30,8 +30,7 @@ class CM_Log_Record {
         $this->_level = $level;
         $this->_message = $message;
         $this->_context = $context;
-        $timeOfDay = gettimeofday();
-        $this->_createdAt = DateTime::createFromFormat('U.u', $timeOfDay['sec'] . '.' . $timeOfDay['usec']);
+        $this->_createdAt = DateTime::createFromFormat('U.u', (string) microtime(true));
     }
 
     /**

--- a/library/CM/Log/Record.php
+++ b/library/CM/Log/Record.php
@@ -30,8 +30,8 @@ class CM_Log_Record {
         $this->_level = $level;
         $this->_message = $message;
         $this->_context = $context;
-        $this->_createdAt = new DateTime();
-        $this->_createdAt->setTimestamp(time());
+        $timeOfDay = gettimeofday();
+        $this->_createdAt = DateTime::createFromFormat('U.u', $timeOfDay['sec'] . '.' . $timeOfDay['usec']);
     }
 
     /**

--- a/library/CM/Log/Record.php
+++ b/library/CM/Log/Record.php
@@ -30,7 +30,7 @@ class CM_Log_Record {
         $this->_level = $level;
         $this->_message = $message;
         $this->_context = $context;
-        $this->_createdAt = DateTime::createFromFormat('U.u', (string) microtime(true));
+        $this->_createdAt = DateTime::createFromFormat('U.u', (string) gettimeofday(true));
     }
 
     /**

--- a/tests/helpers/CMTest/library/CMTest/TH.php
+++ b/tests/helpers/CMTest/library/CMTest/TH.php
@@ -47,8 +47,8 @@ class CMTest_TH {
             runkit_function_copy('time', 'time_original');
             runkit_function_redefine('time', '', 'return CMTest_TH::time();');
 
-            runkit_function_copy('microtime', 'microtime_original');
-            runkit_function_redefine('microtime', '$get_as_float = null', 'return CMTest_TH::microtime($get_as_float);');
+            runkit_function_copy('gettimeofday', 'gettimeofday_original');
+            runkit_function_redefine('gettimeofday', '$returnFloat = null', 'return CMTest_TH::gettimeofday($returnFloat);');
         }
         self::$_timeStart = time_original();
         self::$timeDelta = 0;
@@ -58,12 +58,15 @@ class CMTest_TH {
         return self::$_timeStart + self::$timeDelta;
     }
 
-    public static function microtime($getAsFloat = null) {
+    public static function gettimeofday($returnFloat = null) {
         $pseudoTime = self::time();
-        if ($getAsFloat) {
+        if ($returnFloat) {
             return $pseudoTime + 0.1234;
         }
-        return '0.12345600 ' . $pseudoTime;
+        $dateStruct = gettimeofday_original();
+        $dateStruct['sec'] = $pseudoTime;
+        $dateStruct['usec'] = 123456;
+        return $dateStruct;
     }
 
     public static function timeForward($sec) {

--- a/tests/helpers/CMTest/library/CMTest/TH.php
+++ b/tests/helpers/CMTest/library/CMTest/TH.php
@@ -46,6 +46,9 @@ class CMTest_TH {
         if (!isset(self::$_timeStart)) {
             runkit_function_copy('time', 'time_original');
             runkit_function_redefine('time', '', 'return CMTest_TH::time();');
+
+            runkit_function_copy('gettimeofday', 'gettimeofday_original');
+            runkit_function_redefine('gettimeofday', '$returnFloat = null', 'return CMTest_TH::gettimeofday($returnFloat);');
         }
         self::$_timeStart = time_original();
         self::$timeDelta = 0;
@@ -53,6 +56,17 @@ class CMTest_TH {
 
     public static function time() {
         return self::$_timeStart + self::$timeDelta;
+    }
+
+    public static function gettimeofday($returnFloat = null) {
+        $pseudoTime = self::time();
+        if ($returnFloat) {
+            return $pseudoTime + 0.1234;
+        }
+        $dateStruct = gettimeofday_original();
+        $dateStruct['sec'] = $pseudoTime;
+        $dateStruct['usec'] = 123456;
+        return $dateStruct;
     }
 
     public static function timeForward($sec) {

--- a/tests/helpers/CMTest/library/CMTest/TH.php
+++ b/tests/helpers/CMTest/library/CMTest/TH.php
@@ -47,8 +47,8 @@ class CMTest_TH {
             runkit_function_copy('time', 'time_original');
             runkit_function_redefine('time', '', 'return CMTest_TH::time();');
 
-            runkit_function_copy('gettimeofday', 'gettimeofday_original');
-            runkit_function_redefine('gettimeofday', '$returnFloat = null', 'return CMTest_TH::gettimeofday($returnFloat);');
+            runkit_function_copy('microtime', 'microtime_original');
+            runkit_function_redefine('microtime', '$get_as_float = null', 'return CMTest_TH::microtime($get_as_float);');
         }
         self::$_timeStart = time_original();
         self::$timeDelta = 0;
@@ -58,15 +58,12 @@ class CMTest_TH {
         return self::$_timeStart + self::$timeDelta;
     }
 
-    public static function gettimeofday($returnFloat = null) {
+    public static function microtime($getAsFloat = null) {
         $pseudoTime = self::time();
-        if ($returnFloat) {
+        if ($getAsFloat) {
             return $pseudoTime + 0.1234;
         }
-        $dateStruct = gettimeofday_original();
-        $dateStruct['sec'] = $pseudoTime;
-        $dateStruct['usec'] = 123456;
-        return $dateStruct;
+        return '0.12345600 ' . $pseudoTime;
     }
 
     public static function timeForward($sec) {

--- a/tests/library/CM/Log/Handler/FluentdTest.php
+++ b/tests/library/CM/Log/Handler/FluentdTest.php
@@ -43,7 +43,7 @@ class CM_Log_Handler_FluentdTest extends CMTest_TestCase {
                 $this->assertSame('tag', $tag);
                 $this->assertSame('critical', $data['level']);
                 $this->assertSame('foo', $data['message']);
-                $this->assertArrayHasKey('timestamp', $data);
+                $this->assertRegExp('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+\d{4}$/', $data['timestamp']);
                 $this->assertSame('value', $data['key']);
 
             }
@@ -53,7 +53,7 @@ class CM_Log_Handler_FluentdTest extends CMTest_TestCase {
         $contextFormatter = $this->mockInterface('CM_Log_ContextFormatter_Interface')->newInstanceWithoutConstructor();
         $contextFormatter->mockMethod('formatContext')->set(['key' => 'value']);
         /** @var CM_Log_ContextFormatter_Interface $contextFormatter */
-        
+
         $handler = new CM_Log_Handler_Fluentd($fluentd, $contextFormatter, 'tag');
 
         $record = new CM_Log_Record(CM_Log_Logger::CRITICAL, 'foo', new CM_Log_Context());


### PR DESCRIPTION
For https://github.com/cargomedia/puppet-cargomedia/issues/1575

Instead of:
> 2016-10-15T15:37:28+0000

Should be:
> 2016-10-15T15:37:28.123+0000