### PR TITLE
Add {contex.extra.type:1, createdAt: 1} index, remove {level:1} index

### DIFF
--- a/resources/db/mongo/collections.json
+++ b/resources/db/mongo/collections.json
@@ -37,10 +37,11 @@
     },
     {
       "key": {
-        "level": 1
+        "context.extra.type": 1,
+        "createdAt": 1
       },
       "options": {
-        "name": "level_1"
+        "name": "context_extra_type_1_createdAt_1"
       }
     }
   ]

--- a/resources/db/update/73.php
+++ b/resources/db/update/73.php
@@ -1,0 +1,13 @@
+<?php
+
+return;
+
+$mongo = CM_Service_Manager::getInstance()->getMongoDb();
+
+if ($mongo->hasIndex('cm_log', ['level' => 1])) {
+    $mongo->deleteIndex('cm_log', ['level' => 1]);
+}
+
+if (!$mongo->hasIndex('cm_log', ['context.extra.type' => 1, 'createdAt' => 1])) {
+    $mongo->createIndex('cm_log', ['context.extra.type' => 1, 'createdAt' => 1], ['background' => true, 'wTimeoutMS' => 0, 'socketTimeoutMS' => -1]);
+}


### PR DESCRIPTION
Hopefully last stage. Sole compound index seems to work well.

We  could force  `{contex.extra.type:1, level: 1, createdAt: 1}` existing  index using if add extra  `{level : {$in : [100, 200, 300, 400, 500]}}` clause (which means "any")  to  `{type: 307}` query.
But I would prefer to be explicit now.