### PR TITLE
Force index usage

### DIFF
--- a/library/CM/Paging/Log.php
+++ b/library/CM/Paging/Log.php
@@ -119,6 +119,8 @@ class CM_Paging_Log extends CM_Paging_Abstract implements CM_Typed {
 
         if (null !== $this->_filterLevelList) {
             $criteria['level'] = ['$in' => $this->_filterLevelList];
+        } else {
+            $criteria['level'] = ['$in' => array_values(CM_Log_Logger::getLevels())];
         }
 
         if (null !== $this->_ageMax) {

--- a/library/CM/Paging/Log.php
+++ b/library/CM/Paging/Log.php
@@ -4,7 +4,7 @@ class CM_Paging_Log extends CM_Paging_Abstract implements CM_Typed {
 
     const COLLECTION_NAME = 'cm_log';
 
-    /** @var array|null */
+    /** @var array */
     protected $_filterLevelList;
 
     /** @var int|boolean|null */
@@ -28,6 +28,8 @@ class CM_Paging_Log extends CM_Paging_Abstract implements CM_Typed {
                     throw new CM_Exception_Invalid('Log level does not exist.', null, ['level' => $level]);
                 }
             }
+        } else {
+            $filterLevelList = array_values(CM_Log_Logger::getLevels());
         }
 
         if (null !== $filterType && false !== $filterType && !self::isValidType((int) $filterType)) {
@@ -116,13 +118,7 @@ class CM_Paging_Log extends CM_Paging_Abstract implements CM_Typed {
         } elseif (null !== $this->_filterType) {
             $criteria['context.extra.type'] = (int) $this->_filterType;
         }
-
-        if (null !== $this->_filterLevelList) {
-            $criteria['level'] = ['$in' => $this->_filterLevelList];
-        } else {
-            $criteria['level'] = ['$in' => array_values(CM_Log_Logger::getLevels())];
-        }
-
+        $criteria['level'] = ['$in' => $this->_filterLevelList];
         if (null !== $this->_ageMax) {
             $criteria['createdAt'] = ['$gt' => new MongoDate(time() - $this->_ageMax)];
         }


### PR DESCRIPTION
https://github.com/cargomedia/cm/issues/2309
Needed for `all=1` listing.
It completes the query to match "left prefix" rule for `{level:1, created:1}` index. (the index itself can not be reversed because we do `count` queries without sorting).  