### PR TITLE
Fix fractional dateTime creation

### DIFF
--- a/library/CM/Log/Record.php
+++ b/library/CM/Log/Record.php
@@ -30,7 +30,7 @@ class CM_Log_Record {
         $this->_level = $level;
         $this->_message = $message;
         $this->_context = $context;
-        $timeStruct = gettimeofday(true);
+        $timeStruct = gettimeofday();
         $this->_createdAt = DateTime::createFromFormat('U.u', $timeStruct['sec'] . '.' . $timeStruct['usec']);
     }
 

--- a/library/CM/Log/Record.php
+++ b/library/CM/Log/Record.php
@@ -30,8 +30,7 @@ class CM_Log_Record {
         $this->_level = $level;
         $this->_message = $message;
         $this->_context = $context;
-        $timeStruct = gettimeofday();
-        $this->_createdAt = DateTime::createFromFormat('U.u', $timeStruct['sec'] . '.' . $timeStruct['usec']);
+        $this->_createdAt = CM_Util::createDateTimeWithMillis();
     }
 
     /**

--- a/library/CM/Log/Record.php
+++ b/library/CM/Log/Record.php
@@ -30,7 +30,8 @@ class CM_Log_Record {
         $this->_level = $level;
         $this->_message = $message;
         $this->_context = $context;
-        $this->_createdAt = DateTime::createFromFormat('U.u', (string) gettimeofday(true));
+        $timeStruct = gettimeofday(true);
+        $this->_createdAt = DateTime::createFromFormat('U.u', $timeStruct['sec'] . '.' . $timeStruct['usec']);
     }
 
     /**

--- a/library/CM/Util.php
+++ b/library/CM/Util.php
@@ -624,4 +624,12 @@ class CM_Util {
         }
         return $newPosition;
     }
+
+    /**
+     * @return DateTime
+     */
+    public static function createDateTimeWithMillis() {
+        $timeStruct = gettimeofday();
+        return DateTime::createFromFormat('U.u', $timeStruct['sec'] . '.' . $timeStruct['usec']);
+    }
 }

--- a/tests/library/CM/UtilTest.php
+++ b/tests/library/CM/UtilTest.php
@@ -167,4 +167,9 @@ class CM_UtilTest extends CMTest_TestCase {
         $this->assertInstanceOf('CM_Exception_Invalid', $exception);
         $this->assertSame('Initial position is invalid', $exception->getMessage());
     }
+
+    public function testCreateDateTimeWithMillis() {
+        $dateTime = CM_Util::createDateTimeWithMillis();
+        $this->assertInstanceOf('DateTime', $dateTime);
+    }
 }


### PR DESCRIPTION
`DateTime::createFromFormat('U.u', (string) gettimeofday(true))`  is failed when called in a moment of time without fractional parts.