### PR TITLE
Drop {type, level, createdAt} index

### DIFF
--- a/resources/db/mongo/collections.json
+++ b/resources/db/mongo/collections.json
@@ -19,16 +19,6 @@
     },
     {
       "key": {
-        "context.extra.type": 1,
-        "level": 1,
-        "createdAt": 1
-      },
-      "options": {
-        "name": "context_extra_type_1_level_1_createdAt_1"
-      }
-    },
-    {
-      "key": {
         "message": 1
       },
       "options": {

--- a/resources/db/update/75.php
+++ b/resources/db/update/75.php
@@ -1,7 +1,5 @@
 <?php
 
-return;
-
 $mongo = CM_Service_Manager::getInstance()->getMongoDb();
 
 if ($mongo->hasIndex('cm_log', ['context.extra.type' => 1, 'level' => 1, 'createdAt' => 1])) {

--- a/resources/db/update/75.php
+++ b/resources/db/update/75.php
@@ -1,0 +1,9 @@
+<?php
+
+return;
+
+$mongo = CM_Service_Manager::getInstance()->getMongoDb();
+
+if ($mongo->hasIndex('cm_log', ['context.extra.type' => 1, 'level' => 1, 'createdAt' => 1])) {
+    $mongo->deleteIndex('cm_log', ['context.extra.type' => 1, 'level' => 1, 'createdAt' => 1]);
+}


### PR DESCRIPTION
https://github.com/cargomedia/cm/issues/2309

Personally I doubt that it won't affect the performance. On dev environment it shows "QueryOptimizerCursor" (which is usually slow on production servers) instead of  "Complex Plan" (which should be in case of intersected indexes according documentation), but maybe it's worth to try.

@njam wdyt?