### PR TITLE
CM_Jobdistribution_Cli: restart process after X job runs

### DIFF
--- a/library/CM/Jobdistribution/Cli.php
+++ b/library/CM/Jobdistribution/Cli.php
@@ -6,7 +6,7 @@ class CM_Jobdistribution_Cli extends CM_Cli_Runnable_Abstract {
      * @keepalive
      */
     public function startWorker() {
-        $worker = new CM_Jobdistribution_JobWorker();
+        $worker = new CM_Jobdistribution_JobWorker(1000);
         $worker->setServiceManager($this->getServiceManager());
         foreach (CM_Jobdistribution_Job_Abstract::getClassChildren() as $jobClassName) {
             /** @var CM_Jobdistribution_Job_Abstract $job */

--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -266,13 +266,15 @@ class CM_Process {
                 }
                 if ($pid > 0 && ($forkHandler = $this->_findForkHandlerByPid($pid))) {
                     unset($this->_forkHandlerList[$forkHandler->getIdentifier()]);
-                    $workloadResultList[$forkHandler->getIdentifier()] = $forkHandler->receiveWorkloadResult();
+                    $workloadResult = $forkHandler->receiveWorkloadResult();
+                    $workloadResultList[$forkHandler->getIdentifier()] = $workloadResult;
                     $forkHandler->closeIpcStream();
                     if (!$this->_hasForks()) {
                         $this->unbind('exit', [$this, 'killChildren']);
                     }
                     if ($keepAlive) {
-                        CM_Service_Manager::getInstance()->getLogger()->warning('Respawning dead child.', (new CM_Log_Context())->setExtra(['pid' => $pid]));
+                        $logLevel = $workloadResult->isSuccess() ? CM_Log_Logger::INFO : CM_Log_Logger::WARNING;
+                        CM_Service_Manager::getInstance()->getLogger()->addMessage('Respawning dead child.', $logLevel, (new CM_Log_Context())->setExtra(['pid' => $pid]));
                         usleep(self::RESPAWN_TIMEOUT * 1000000);
                         $this->_fork($forkHandler->getWorkload(), $forkHandler->getIdentifier());
                     }


### PR DESCRIPTION
Goal: restart job worker processes once in a while to avoid filling up memory. Like apache (or php-fpm) we could just exit a job worker after X job runs. The CLI manager would then restart the worker.

Default: 1000

<img width="1061" alt="screen shot 2016-11-14 at 10 38 17" src="https://cloud.githubusercontent.com/assets/360800/20259705/942008be-aa56-11e6-9fc2-9f397dfb375d.png">
