### PR TITLE
Run synchronous jobs always with prio HIGH

### DIFF
--- a/library/CM/Jobdistribution/Job/Abstract.php
+++ b/library/CM/Jobdistribution/Job/Abstract.php
@@ -120,23 +120,9 @@ abstract class CM_Jobdistribution_Job_Abstract extends CM_Class_Abstract {
      * @param string        $workload
      * @param GearmanClient $gearmanClient
      * @return GearmanTask
-     * @throws CM_Exception
      */
     protected function _addTask($workload, $gearmanClient) {
-        switch ($this->getPriority()) {
-            case CM_Jobdistribution_Priority::HIGH:
-                $task = $gearmanClient->addTaskHigh($this->_getJobName(), $workload);
-                break;
-            case CM_Jobdistribution_Priority::NORMAL:
-                $task = $gearmanClient->addTask($this->_getJobName(), $workload);
-                break;
-            case CM_Jobdistribution_Priority::LOW:
-                $task = $gearmanClient->addTaskLow($this->_getJobName(), $workload);
-                break;
-            default:
-                throw new CM_Exception('Invalid priority', null, ['priority' => (string) $this->getPriority()]);
-        }
-        return $task;
+        return $gearmanClient->addTaskHigh($this->_getJobName(), $workload);
     }
 
     /**

--- a/tests/library/CM/Jobdistribution/Job/AbstractTest.php
+++ b/tests/library/CM/Jobdistribution/Job/AbstractTest.php
@@ -44,48 +44,6 @@ class CM_Jobdistribution_Job_AbstractTest extends CMTest_TestCase {
         ), $result);
     }
 
-    public function testRunMultiplePriority() {
-        if (!extension_loaded('gearman')) {
-            $this->markTestSkipped('Gearman Pecl Extension not installed.');
-        }
-        CM_Config::get()->CM_Jobdistribution_Job_Abstract->gearmanEnabled = true;
-
-        $gearmanClient = $this->mockClass('GearmanClient')->newInstanceWithoutConstructor();
-        $gearmanClient->mockMethod('runTasks')->set(true);
-        $gearmanClient->mockMethod('setCompleteCallback')->set(function($completeCallback) {
-            $task = $this->mockObject('GearmanTask');
-            $task->mockMethod('data')->set(CM_Util::jsonEncode(['foo' => 'bar']));
-            $completeCallback($task);
-        });
-        $mockAddTaskHigh = $gearmanClient->mockMethod('addTaskHigh');
-        $mockAddTask = $gearmanClient->mockMethod('addTask');
-        $mockAddTaskLow = $gearmanClient->mockMethod('addTaskLow');
-
-        /** @var CM_Jobdistribution_Job_Abstract|\Mocka\AbstractClassTrait $job */
-        $job = $this->mockObject('CM_Jobdistribution_Job_Abstract');
-        $job->mockMethod('_getGearmanClient')->set($gearmanClient);
-
-        // standard priority
-        $job->runMultiple([['foo' => 'bar']]);
-        $this->assertSame(1, $mockAddTask->getCallCount());
-
-        // normal priority
-        $priorityMock = $job->mockMethod('getPriority');
-        $priorityMock->set(new CM_Jobdistribution_Priority('normal'));
-        $job->runMultiple([['foo' => 'bar']]);
-        $this->assertSame(2, $mockAddTask->getCallCount());
-
-        // high priority
-        $priorityMock->set(new CM_Jobdistribution_Priority('high'));
-        $job->runMultiple([['foo' => 'bar']]);
-        $this->assertSame(1, $mockAddTaskHigh->getCallCount());
-
-        // low priority
-        $priorityMock->set(new CM_Jobdistribution_Priority('low'));
-        $job->runMultiple([['foo' => 'bar']]);
-        $this->assertSame(1, $mockAddTaskLow->getCallCount());
-    }
-
     public function testQueuePriority() {
         if (!extension_loaded('gearman')) {
             $this->markTestSkipped('Gearman Pecl Extension not installed.');
@@ -132,9 +90,9 @@ class CM_Jobdistribution_Job_AbstractTest extends CMTest_TestCase {
         CM_Config::get()->CM_Jobdistribution_Job_Abstract->gearmanEnabled = true;
 
         $mockBuilder = $this->getMockBuilder('GearmanClient');
-        $mockBuilder->setMethods(['addTask', 'runTasks', 'setCompleteCallback', 'setFailCallback']);
+        $mockBuilder->setMethods(['addTaskHigh', 'runTasks', 'setCompleteCallback', 'setFailCallback']);
         $gearmanClientMock = $mockBuilder->getMock();
-        $gearmanClientMock->expects($this->exactly(2))->method('addTask')->will($this->returnValue(true));
+        $gearmanClientMock->expects($this->exactly(2))->method('addTaskHigh')->will($this->returnValue(true));
         $gearmanClientMock->expects($this->exactly(1))->method('runTasks')->will($this->returnValue(true));
         $gearmanClientMock->expects($this->exactly(1))->method('setCompleteCallback')->will($this->returnCallback(function ($completeCallback) {
             $task1 = $this->getMockBuilder('GearmanTask')->setMethods(array('data'))->getMock();


### PR DESCRIPTION
Reasoning: since we run the job synchronously we usually want the response ASAP.