### PR TITLE
ColorPalette form field

### DIFF
--- a/layout/default/Component/Example/tabs/forms.tpl
+++ b/layout/default/Component/Example/tabs/forms.tpl
@@ -17,6 +17,7 @@
 {formField name='file' label="Upload Files"}
 {formField name='image' label="Upload Photos"}
 {formField name='color' label="Color"}
+{formField name='color2' label="Color (Palette)"}
 {formField name='date' label="Date"}
 {formField name='dateTimeInterval' label = "DateTimeInterval" placeholderStart='Starting Time' placeholderEnd='End'}
 {formField name='birthdate' label="Birth Date between 18 and 30"}

--- a/layout/default/FormField/Color/default.tpl
+++ b/layout/default/FormField/Color/default.tpl
@@ -1,1 +1,1 @@
-<input type="color" name="{$name}" id="{$inputId}" value="{$value}" />
+<input type="color" name="{$name}" id="{$inputId}" {if $color}value="#{$color->getHexString()}"{/if} />

--- a/layout/default/FormField/ColorPalette/default.less
+++ b/layout/default/FormField/ColorPalette/default.less
@@ -5,31 +5,49 @@
 }
 
 .palette-item {
-  align-items: center;
-  border: 3px solid white;
-  border-radius: 50%;
-  box-shadow: 0 0 4px 1px @colorFgBorderEmphasize3;
-  display: flex;
-  flex: 0 0 auto;
-  height: @sizeButton;
-  justify-content: center;
-  transform: scale(.8);
-  text-align: center;
-  transition: transform @transitionDuration cubic-bezier(0.175, 0.885, 0.32, 1.275);
-  width: @sizeButton;
+  input[type=radio] {
+    + label {
+      align-items: center;
+      background-clip: content-box;
+      border: 1px solid @colorInputBorder;
+      border-radius: 50%;
+      display: flex;
+      flex: 0 0 auto;
+      height: @sizeButton;
+      justify-content: center;
+      margin: 0;
+      padding: 3px;
+      transform: scale(.85);
+      text-align: center;
+      transition: transform @transitionDuration cubic-bezier(0.175, 0.885, 0.32, 1.275);
+      width: @sizeButton;
 
-  .icon-check {
-    color: white;
-    opacity: 0;
-    pointer-events: none;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, .3);
-  }
+      &::before {
+        display: none;
+      }
 
-  &.selected {
-    transform: scale(.95);
+      .icon-check {
+        color: white;
+        opacity: 0;
+        pointer-events: none;
+        text-shadow: 1px 1px 2px rgba(0, 0, 0, .3);
+      }
+    }
 
-    .icon-check {
-      opacity: 1;
+    &:checked {
+      + label {
+        transform: scale(.95);
+
+        .icon-check {
+          opacity: 1;
+        }
+      }
+    }
+
+    &:focus {
+      &:not(:disabled) + label {
+        .input_focus;
+      }
     }
   }
 }

--- a/layout/default/FormField/ColorPalette/default.less
+++ b/layout/default/FormField/ColorPalette/default.less
@@ -5,18 +5,31 @@
 }
 
 .palette-item {
+  align-items: center;
   border: 3px solid white;
   border-radius: 50%;
-  box-shadow: 0 0 4px rgba(0, 0, 0, .3);
-  cursor: pointer;
+  box-shadow: 0 0 4px 1px @colorFgBorderEmphasize3;
+  display: flex;
   flex: 0 0 auto;
   height: @sizeButton;
+  justify-content: center;
   transform: scale(.8);
   text-align: center;
-  transition: transform @transitionDuration;
+  transition: transform @transitionDuration cubic-bezier(0.175, 0.885, 0.32, 1.275);
   width: @sizeButton;
+
+  .icon-check {
+    color: white;
+    opacity: 0;
+    pointer-events: none;
+    text-shadow: 1px 1px 2px rgba(0, 0, 0, .3);
+  }
 
   &.selected {
     transform: scale(.95);
+
+    .icon-check {
+      opacity: 1;
+    }
   }
 }

--- a/layout/default/FormField/ColorPalette/default.less
+++ b/layout/default/FormField/ColorPalette/default.less
@@ -1,0 +1,22 @@
+.palette {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 3px;
+}
+
+.palette-item {
+  border: 3px solid white;
+  border-radius: 50%;
+  box-shadow: 0 0 4px rgba(0, 0, 0, .3);
+  cursor: pointer;
+  flex: 0 0 auto;
+  height: @sizeButton;
+  transform: scale(.8);
+  text-align: center;
+  transition: transform @transitionDuration;
+  width: @sizeButton;
+
+  &.selected {
+    transform: scale(.95);
+  }
+}

--- a/layout/default/FormField/ColorPalette/default.tpl
+++ b/layout/default/FormField/ColorPalette/default.tpl
@@ -1,0 +1,6 @@
+<input type="color" name="{$name}" id="{$inputId}" {if $color}value="#{$color->getHexString()}"{/if} readonly />
+<ul class="palette">
+  {foreach $palette as $paletteColor}
+    <li class="setValueFromPalette" data-value="#{$paletteColor->getHexString()}">{$paletteColor->getHexString()}</li>
+  {/foreach}
+</ul>

--- a/layout/default/FormField/ColorPalette/default.tpl
+++ b/layout/default/FormField/ColorPalette/default.tpl
@@ -1,10 +1,10 @@
-<input type="hidden" name="{$name}" id="{$inputId}" {if $color}value="#{$color->getHexString()}"{/if} readonly />
 <ul class="palette">
   {foreach $palette as $paletteColor}
-    <li>
-      <a href="javascript:;" class="setValueFromPalette palette-item {if $paletteColor->equals($color)}selected{/if}" data-value="#{$paletteColor->getHexString()}" style="background-color: #{$paletteColor->getHexString()}">
+    <li class="palette-item">
+      <input id="{$inputId}-{$paletteColor->getHexString()}" name="{$name}" type="radio" value="#{$paletteColor->getHexString()}" {if $paletteColor->equals($color)}checked{/if} />
+      <label for="{$inputId}-{$paletteColor->getHexString()}" style="background-color: #{$paletteColor->getHexString()}">
         <span class="icon icon-check"></span>
-      </a>
+      </label>
     </li>
   {/foreach}
 </ul>

--- a/layout/default/FormField/ColorPalette/default.tpl
+++ b/layout/default/FormField/ColorPalette/default.tpl
@@ -1,6 +1,10 @@
-<input type="color" name="{$name}" id="{$inputId}" {if $color}value="#{$color->getHexString()}"{/if} readonly />
+<input type="hidden" name="{$name}" id="{$inputId}" {if $color}value="#{$color->getHexString()}"{/if} readonly />
 <ul class="palette">
   {foreach $palette as $paletteColor}
-    <li class="setValueFromPalette palette-item" data-value="#{$paletteColor->getHexString()}" style="background-color: #{$paletteColor->getHexString()}"></li>
+    <li>
+      <a href="javascript:;" class="setValueFromPalette palette-item" data-value="#{$paletteColor->getHexString()}" style="background-color: #{$paletteColor->getHexString()}">
+        <span class="icon icon-check"></span>
+      </a>
+    </li>
   {/foreach}
 </ul>

--- a/layout/default/FormField/ColorPalette/default.tpl
+++ b/layout/default/FormField/ColorPalette/default.tpl
@@ -2,7 +2,7 @@
 <ul class="palette">
   {foreach $palette as $paletteColor}
     <li>
-      <a href="javascript:;" class="setValueFromPalette palette-item" data-value="#{$paletteColor->getHexString()}" style="background-color: #{$paletteColor->getHexString()}">
+      <a href="javascript:;" class="setValueFromPalette palette-item {if $paletteColor->equals($color)}selected{/if}" data-value="#{$paletteColor->getHexString()}" style="background-color: #{$paletteColor->getHexString()}">
         <span class="icon icon-check"></span>
       </a>
     </li>

--- a/layout/default/FormField/ColorPalette/default.tpl
+++ b/layout/default/FormField/ColorPalette/default.tpl
@@ -1,6 +1,6 @@
 <input type="color" name="{$name}" id="{$inputId}" {if $color}value="#{$color->getHexString()}"{/if} readonly />
 <ul class="palette">
   {foreach $palette as $paletteColor}
-    <li class="setValueFromPalette" data-value="#{$paletteColor->getHexString()}">{$paletteColor->getHexString()}</li>
+    <li class="setValueFromPalette palette-item" data-value="#{$paletteColor->getHexString()}" style="background-color: #{$paletteColor->getHexString()}"></li>
   {/foreach}
 </ul>

--- a/layout/default/FormField/ColorPalette/default.tpl
+++ b/layout/default/FormField/ColorPalette/default.tpl
@@ -1,8 +1,8 @@
-<ul class="palette">
-  {foreach $palette as $paletteColor}
+<ul id="{$inputId}" class="palette">
+  {foreach $optionList as $itemValue}
     <li class="palette-item">
-      <input id="{$inputId}-{$paletteColor->getHexString()}" name="{$name}" type="radio" value="#{$paletteColor->getHexString()}" {if $paletteColor->equals($color)}checked{/if} />
-      <label for="{$inputId}-{$paletteColor->getHexString()}" style="background-color: #{$paletteColor->getHexString()}">
+      <input id="{$inputId}-{$itemValue}" name="{$name}" type="radio" value="{$itemValue}" {if $value && $value->getHexString() == $itemValue}checked{/if} />
+      <label for="{$inputId}-{$itemValue}" style="background-color: #{$itemValue}">
         <span class="icon icon-check"></span>
       </label>
     </li>

--- a/library/CM/Color/RGB.php
+++ b/library/CM/Color/RGB.php
@@ -1,6 +1,6 @@
 <?php
 
-class CM_Color_RGB {
+class CM_Color_RGB implements CM_Comparable {
 
     /** @var \MischiefCollective\ColorJizz\Formats\RGB */
     private $_colorJizz;
@@ -107,4 +107,12 @@ class CM_Color_RGB {
         $rgb = $colorJizz->toRGB();
         return new self($rgb->red, $rgb->green, $rgb->blue);
     }
+
+    public function equals(CM_Comparable $other = null) {
+        if (!$other instanceof CM_Color_RGB) {
+            return false;
+        }
+        return $this->getRed() === $other->getRed() && $this->getGreen() === $other->getGreen() && $this->getBlue() === $other->getBlue();
+    }
+
 }

--- a/library/CM/Color/RGB.php
+++ b/library/CM/Color/RGB.php
@@ -49,7 +49,7 @@ class CM_Color_RGB {
         $hsl = $this->_colorJizz->toHSL();
         $hsl->hue = $relative ? $hsl->hue + $hue : $hue;
         $hsl->hue = fmod($hsl->hue, 360);
-        return self::_factoryByColorJizz($hsl);
+        return self::_fromColorJizz($hsl);
     }
 
     /**
@@ -61,7 +61,7 @@ class CM_Color_RGB {
         $hsl = $this->_colorJizz->toHSL();
         $hsl->saturation = $relative ? $hsl->saturation + $saturation : $saturation;
         $hsl->saturation = fmod($hsl->saturation, 100);
-        return self::_factoryByColorJizz($hsl);
+        return self::_fromColorJizz($hsl);
     }
 
     /**
@@ -74,7 +74,7 @@ class CM_Color_RGB {
         $hsl = $this->_colorJizz->toHSL();
         $hsl->lightness = $relative ? $hsl->lightness + $lightness : $lightness;
         $hsl->lightness = fmod($hsl->lightness, 100);
-        return self::_factoryByColorJizz($hsl);
+        return self::_fromColorJizz($hsl);
     }
 
     /**
@@ -89,7 +89,7 @@ class CM_Color_RGB {
      * @return CM_Color_RGB
      * @throws CM_Exception_Invalid
      */
-    public static function factoryByHexString($hexString) {
+    public static function fromHexString($hexString) {
         try {
             $hex = \MischiefCollective\ColorJizz\Formats\Hex::fromString($hexString);
         } catch (\MischiefCollective\ColorJizz\Exceptions\InvalidArgumentException $ex) {
@@ -103,7 +103,7 @@ class CM_Color_RGB {
      * @param \MischiefCollective\ColorJizz\ColorJizz $colorJizz
      * @return CM_Color_RGB
      */
-    private static function _factoryByColorJizz(\MischiefCollective\ColorJizz\ColorJizz $colorJizz) {
+    private static function _fromColorJizz(\MischiefCollective\ColorJizz\ColorJizz $colorJizz) {
         $rgb = $colorJizz->toRGB();
         return new self($rgb->red, $rgb->green, $rgb->blue);
     }

--- a/library/CM/Color/RGB.php
+++ b/library/CM/Color/RGB.php
@@ -9,9 +9,14 @@ class CM_Color_RGB {
      * @param float $red   0-255
      * @param float $green 0-255
      * @param float $blue  0-255
+     * @throws CM_Exception_Invalid
      */
     public function __construct($red, $green, $blue) {
-        $this->_colorJizz = new \MischiefCollective\ColorJizz\Formats\RGB($red, $green, $blue);
+        try {
+            $this->_colorJizz = new \MischiefCollective\ColorJizz\Formats\RGB($red, $green, $blue);
+        } catch (\MischiefCollective\ColorJizz\Exceptions\InvalidArgumentException $ex) {
+            throw new CM_Exception_Invalid($ex->getMessage());
+        }
     }
 
     /**
@@ -75,16 +80,21 @@ class CM_Color_RGB {
     /**
      * @return string
      */
-    public function toHexString() {
+    public function getHexString() {
         return $this->_colorJizz->toHex()->__toString();
     }
 
     /**
      * @param string $hexString
      * @return CM_Color_RGB
+     * @throws CM_Exception_Invalid
      */
     public static function factoryByHexString($hexString) {
-        $hex = \MischiefCollective\ColorJizz\Formats\Hex::fromString($hexString);
+        try {
+            $hex = \MischiefCollective\ColorJizz\Formats\Hex::fromString($hexString);
+        } catch (\MischiefCollective\ColorJizz\Exceptions\InvalidArgumentException $ex) {
+            throw new CM_Exception_Invalid($ex->getMessage());
+        }
         $rgb = $hex->toRGB();
         return new self($rgb->red, $rgb->green, $rgb->blue);
     }

--- a/library/CM/Form/Example.php
+++ b/library/CM/Form/Example.php
@@ -17,6 +17,11 @@ class CM_Form_Example extends CM_Form_Abstract {
         $this->registerField(new CM_FormField_File(['name' => 'file', 'cardinality' => 2]));
         $this->registerField(new CM_FormField_FileImage(['name' => 'image', 'cardinality' => 2]));
         $this->registerField(new CM_FormField_Color(['name' => 'color']));
+        $this->registerField(new CM_FormField_ColorPalette(['name' => 'color2', 'palette' => [
+            CM_Color_RGB::fromHexString('ff0000'),
+            CM_Color_RGB::fromHexString('00ff00'),
+            CM_Color_RGB::fromHexString('0000ff'),
+        ]]));
         $this->registerField(new CM_FormField_Date(['name' => 'date']));
         $this->registerField(new CM_FormField_DateTimeInterval(['name' => 'dateTimeInterval', 'yearFirst' => date('Y'), 'yearLast' => (int) date('Y') + 1]));
         $this->registerField(new CM_FormField_Birthdate(['name' => 'birthdate', 'minAge' => 18, 'maxAge' => 30]));

--- a/library/CM/Form/ExampleIcon.php
+++ b/library/CM/Form/ExampleIcon.php
@@ -14,7 +14,7 @@ class CM_Form_ExampleIcon extends CM_Form_Abstract {
 
     public function prepare(CM_Frontend_Environment $environment, CM_Frontend_ViewResponse $viewResponse) {
         $this->getField('sizeSlider')->setValue(18);
-        $this->getField('shadowColor')->setValue('#333');
-        $this->getField('colorBackground')->setValue('#fafafa');
+        $this->getField('shadowColor')->setValue(CM_Color_RGB::fromHexString('333333'));
+        $this->getField('colorBackground')->setValue(CM_Color_RGB::fromHexString('fafafa'));
     }
 }

--- a/library/CM/FormField/Color.js
+++ b/library/CM/FormField/Color.js
@@ -6,7 +6,7 @@ var CM_FormField_Color = CM_FormField_Abstract.extend({
   _class: 'CM_FormField_Color',
 
   events: {
-    'change input': function() {
+    'input input': function() {
       this.trigger('change');
     }
   }

--- a/library/CM/FormField/Color.php
+++ b/library/CM/FormField/Color.php
@@ -2,10 +2,26 @@
 
 class CM_FormField_Color extends CM_FormField_Abstract {
 
+    /**
+     * @param CM_Frontend_Environment $environment
+     * @param string                  $userInput
+     * @return CM_Color_RGB
+     * @throws CM_Exception_FormFieldValidation
+     */
     public function validate(CM_Frontend_Environment $environment, $userInput) {
-        if (!preg_match('/^#[abcdef\d]{6}$/i', $userInput)) {
+        try {
+            $color = CM_Color_RGB::fromHexString($userInput);
+        } catch (CM_Exception_Invalid $ex) {
             throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid color'));
         }
-        return (string) $userInput;
+        return $color;
     }
+
+    public function prepare(CM_Params $renderParams, CM_Frontend_Environment $environment, CM_Frontend_ViewResponse $viewResponse) {
+        /** @var CM_Color_RGB $value */
+        $color = $this->getValue();
+
+        $viewResponse->set('color', $color);
+    }
+
 }

--- a/library/CM/FormField/ColorPalette.js
+++ b/library/CM/FormField/ColorPalette.js
@@ -1,28 +1,7 @@
 /**
  * @class CM_FormField_ColorPalette
- * @extends CM_FormField_Abstract
+ * @extends CM_FormField_Set_Select
  */
-var CM_FormField_ColorPalette = CM_FormField_Abstract.extend({
-  _class: 'CM_FormField_ColorPalette',
-
-  events: {
-    'click .setValueFromPalette': function(event) {
-      var value = $(event.currentTarget).data('value');
-      this.setValue(value);
-    }
-  },
-
-  /**
-   * @param {String} value
-   */
-  setValue: function(value) {
-    var $paletteItem = this.$('.palette-item[data-value="' + value + '"]');
-    this.$('.palette-item').not($paletteItem).removeClass('selected');
-    $paletteItem.addClass('selected');
-
-    CM_FormField_Abstract.prototype.setValue.call(this, value);
-
-    this.trigger('change');
-  }
-
+var CM_FormField_ColorPalette = CM_FormField_Set_Select.extend({
+  _class: 'CM_FormField_ColorPalette'
 });

--- a/library/CM/FormField/ColorPalette.js
+++ b/library/CM/FormField/ColorPalette.js
@@ -10,10 +10,11 @@ var CM_FormField_ColorPalette = CM_FormField_Abstract.extend({
       this.trigger('change');
     },
     'click .setValueFromPalette': function(event) {
-      var value = $(event.currentTarget).data('value');
-      this.setValue(value);
+      this.$('.palette-item').removeClass('selected');
+      var $selectedItem = $(event.currentTarget);
+      $selectedItem.addClass('selected');
+      this.setValue($selectedItem.data('value'));
       this.trigger('change');
     }
   }
-
 });

--- a/library/CM/FormField/ColorPalette.js
+++ b/library/CM/FormField/ColorPalette.js
@@ -6,15 +6,23 @@ var CM_FormField_ColorPalette = CM_FormField_Abstract.extend({
   _class: 'CM_FormField_ColorPalette',
 
   events: {
-    'input input': function() {
-      this.trigger('change');
-    },
     'click .setValueFromPalette': function(event) {
-      this.$('.palette-item').removeClass('selected');
-      var $selectedItem = $(event.currentTarget);
-      $selectedItem.addClass('selected');
-      this.setValue($selectedItem.data('value'));
-      this.trigger('change');
+      var value = $(event.currentTarget).data('value');
+      this.setValue(value);
     }
+  },
+
+  /**
+   * @param {String} value
+   */
+  setValue: function(value) {
+    var $paletteItem = this.$('.palette-item[data-value="' + value + '"]');
+    this.$('.palette-item').not($paletteItem).removeClass('selected');
+    $paletteItem.addClass('selected');
+
+    CM_FormField_Abstract.prototype.setValue.call(this, value);
+
+    this.trigger('change');
   }
+
 });

--- a/library/CM/FormField/ColorPalette.js
+++ b/library/CM/FormField/ColorPalette.js
@@ -1,0 +1,19 @@
+/**
+ * @class CM_FormField_ColorPalette
+ * @extends CM_FormField_Abstract
+ */
+var CM_FormField_ColorPalette = CM_FormField_Abstract.extend({
+  _class: 'CM_FormField_ColorPalette',
+
+  events: {
+    'input input': function() {
+      this.trigger('change');
+    },
+    'click .setValueFromPalette': function(event) {
+      var value = $(event.currentTarget).data('value');
+      this.setValue(value);
+      this.trigger('change');
+    }
+  }
+
+});

--- a/library/CM/FormField/ColorPalette.php
+++ b/library/CM/FormField/ColorPalette.php
@@ -1,6 +1,6 @@
 <?php
 
-class CM_FormField_ColorPalette extends CM_FormField_Abstract {
+class CM_FormField_ColorPalette extends CM_FormField_Set_Select {
 
     /** @var CM_Color_RGB[] */
     private $_palette;

--- a/library/CM/FormField/ColorPalette.php
+++ b/library/CM/FormField/ColorPalette.php
@@ -1,0 +1,51 @@
+<?php
+
+class CM_FormField_ColorPalette extends CM_FormField_Abstract {
+
+    /** @var CM_Color_RGB[] */
+    private $_palette;
+
+    protected function _initialize() {
+        $palette = $this->_params->getArray('palette');
+        foreach ($palette as $color) {
+            if (!$color instanceof CM_Color_RGB) {
+                throw new CM_Exception_Invalid('Palette contains non-color');
+            }
+        }
+        $this->_palette = $palette;
+
+        parent::_initialize();
+    }
+
+    /**
+     * @param CM_Frontend_Environment $environment
+     * @param string                  $userInput
+     * @return CM_Color_RGB
+     * @throws CM_Exception_FormFieldValidation
+     */
+    public function validate(CM_Frontend_Environment $environment, $userInput) {
+        try {
+            $color = CM_Color_RGB::fromHexString($userInput);
+        } catch (CM_Exception_Invalid $ex) {
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid color'));
+        }
+
+        $partOfPalette = Functional\some($this->_palette, function (CM_Color_RGB $colorPalette) use ($color) {
+            return $color->equals($colorPalette);
+        });
+        if (!$partOfPalette) {
+            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Color not part of palette'));
+        }
+
+        return $color;
+    }
+
+    public function prepare(CM_Params $renderParams, CM_Frontend_Environment $environment, CM_Frontend_ViewResponse $viewResponse) {
+        /** @var CM_Color_RGB $value */
+        $color = $this->getValue();
+
+        $viewResponse->set('color', $color);
+        $viewResponse->set('palette', $this->_palette);
+    }
+
+}

--- a/library/CM/FormField/ColorPalette.php
+++ b/library/CM/FormField/ColorPalette.php
@@ -17,6 +17,14 @@ class CM_FormField_ColorPalette extends CM_FormField_Set_Select {
         parent::_initialize();
     }
 
+    protected function _getOptionList() {
+        $optionList = [];
+        foreach ($this->_palette as $color) {
+            $optionList[$color->getHexString()] = $color->getHexString();
+        }
+        return $optionList;
+    }
+
     /**
      * @param CM_Frontend_Environment $environment
      * @param string                  $userInput
@@ -24,28 +32,15 @@ class CM_FormField_ColorPalette extends CM_FormField_Set_Select {
      * @throws CM_Exception_FormFieldValidation
      */
     public function validate(CM_Frontend_Environment $environment, $userInput) {
+        $userInput = parent::validate($environment, $userInput);
+
         try {
             $color = CM_Color_RGB::fromHexString($userInput);
         } catch (CM_Exception_Invalid $ex) {
             throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Invalid color'));
         }
 
-        $partOfPalette = Functional\some($this->_palette, function (CM_Color_RGB $colorPalette) use ($color) {
-            return $color->equals($colorPalette);
-        });
-        if (!$partOfPalette) {
-            throw new CM_Exception_FormFieldValidation(new CM_I18n_Phrase('Color not part of palette'));
-        }
-
         return $color;
-    }
-
-    public function prepare(CM_Params $renderParams, CM_Frontend_Environment $environment, CM_Frontend_ViewResponse $viewResponse) {
-        /** @var CM_Color_RGB $value */
-        $color = $this->getValue();
-
-        $viewResponse->set('color', $color);
-        $viewResponse->set('palette', $this->_palette);
     }
 
 }

--- a/tests/library/CM/Color/RGBTest.php
+++ b/tests/library/CM/Color/RGBTest.php
@@ -44,8 +44,8 @@ class CM_Color_RGBTest extends CMTest_TestCase {
         $this->assertSame('00FF00', $color->getHexString());
     }
 
-    public function factoryByHexString() {
-        $color = CM_Color_RGB::factoryByHexString('00FF00');
+    public function testFromHexString() {
+        $color = CM_Color_RGB::fromHexString('00FF00');
 
         $this->assertSame(0, $color->getRed());
         $this->assertSame(255, $color->getGreen());
@@ -55,8 +55,8 @@ class CM_Color_RGBTest extends CMTest_TestCase {
     /**
      * @expectedException CM_Exception_Invalid
      */
-    public function factoryByHexStringInvalid() {
-        CM_Color_RGB::factoryByHexString('00ZZZZ');
+    public function testFromHexStringInvalid() {
+        CM_Color_RGB::fromHexString('00ZZZZ');
     }
 
 }

--- a/tests/library/CM/Color/RGBTest.php
+++ b/tests/library/CM/Color/RGBTest.php
@@ -10,31 +10,38 @@ class CM_Color_RGBTest extends CMTest_TestCase {
         $this->assertSame(12.3, $color->getBlue());
     }
 
+    /**
+     * @expectedException CM_Exception_Invalid
+     */
+    public function testConstructorInvalid() {
+        new CM_Color_RGB(0, 0, 999);
+    }
+
     public function testSetHue() {
         $color = new CM_Color_RGB(0, 255, 0);
 
-        $this->assertSame('FF8000', $color->setHue(30)->toHexString());
-        $this->assertSame('00FF80', $color->setHue(30, true)->toHexString());
+        $this->assertSame('FF8000', $color->setHue(30)->getHexString());
+        $this->assertSame('00FF80', $color->setHue(30, true)->getHexString());
     }
 
     public function testSetSaturation() {
         $color = new CM_Color_RGB(0, 255, 0);
 
-        $this->assertSame('59A659', $color->setSaturation(30)->toHexString());
-        $this->assertSame('26D926', $color->setSaturation(-30, true)->toHexString());
+        $this->assertSame('59A659', $color->setSaturation(30)->getHexString());
+        $this->assertSame('26D926', $color->setSaturation(-30, true)->getHexString());
     }
 
     public function testSetLightness() {
         $color = new CM_Color_RGB(0, 255, 0);
 
-        $this->assertSame('009900', $color->setLightness(30)->toHexString());
-        $this->assertSame('006600', $color->setLightness(-30, true)->toHexString());
+        $this->assertSame('009900', $color->setLightness(30)->getHexString());
+        $this->assertSame('006600', $color->setLightness(-30, true)->getHexString());
     }
 
-    public function testToHexString() {
+    public function testGetHexString() {
         $color = new CM_Color_RGB(0, 255, 0);
 
-        $this->assertSame('00FF00', $color->toHexString());
+        $this->assertSame('00FF00', $color->getHexString());
     }
 
     public function factoryByHexString() {
@@ -43,6 +50,13 @@ class CM_Color_RGBTest extends CMTest_TestCase {
         $this->assertSame(0, $color->getRed());
         $this->assertSame(255, $color->getGreen());
         $this->assertSame(0, $color->getBlue());
+    }
+
+    /**
+     * @expectedException CM_Exception_Invalid
+     */
+    public function factoryByHexStringInvalid() {
+        CM_Color_RGB::factoryByHexString('00ZZZZ');
     }
 
 }

--- a/tests/library/CM/Color/RGBTest.php
+++ b/tests/library/CM/Color/RGBTest.php
@@ -59,4 +59,12 @@ class CM_Color_RGBTest extends CMTest_TestCase {
         CM_Color_RGB::fromHexString('00ZZZZ');
     }
 
+    public function testComparable() {
+        $color = CM_Color_RGB::fromHexString('00FF00');
+
+        $this->assertSame(true, $color->equals(CM_Color_RGB::fromHexString('00FF00')));
+        $this->assertSame(false, $color->equals(CM_Color_RGB::fromHexString('FF0000')));
+        $this->assertSame(false, $color->equals(null));
+    }
+
 }

--- a/tests/library/CM/FormField/ColorPaletteTest.php
+++ b/tests/library/CM/FormField/ColorPaletteTest.php
@@ -40,8 +40,8 @@ class CM_FormField_ColorPaletteTest extends CMTest_TestCase {
 
         $html = $this->_renderFormField($field);
 
-        $this->assertSame('#00FF00', $html->find('input')->getAttribute('value'));
-        $this->assertSame(2, $html->find('.setValueFromPalette')->count());
+        $this->assertSame('#FF0000', $html->find('input')->getAttribute('value'));
+        $this->assertSame(2, $html->find('input')->count());
     }
 
 }

--- a/tests/library/CM/FormField/ColorPaletteTest.php
+++ b/tests/library/CM/FormField/ColorPaletteTest.php
@@ -7,7 +7,7 @@ class CM_FormField_ColorPaletteTest extends CMTest_TestCase {
         $field = new CM_FormField_ColorPalette(['name' => 'foo', 'palette' => $palette]);
         $environment = new CM_Frontend_Environment();
 
-        $value = $field->validate($environment, '#00FF00');
+        $value = $field->validate($environment, '00FF00');
         $this->assertSame('00FF00', $value->getHexString());
     }
 
@@ -30,7 +30,7 @@ class CM_FormField_ColorPaletteTest extends CMTest_TestCase {
         $field = new CM_FormField_ColorPalette(['name' => 'foo', 'palette' => $palette]);
         $environment = new CM_Frontend_Environment();
 
-        $field->validate($environment, '#0000FF');
+        $field->validate($environment, '0000FF');
     }
 
     public function testRender() {
@@ -40,7 +40,18 @@ class CM_FormField_ColorPaletteTest extends CMTest_TestCase {
 
         $html = $this->_renderFormField($field);
 
-        $this->assertSame('#FF0000', $html->find('input')->getAttribute('value'));
+        $this->assertSame('FF0000', $html->find('input')->getAttribute('value'));
+        $this->assertSame(2, $html->find('input')->count());
+    }
+
+    public function testRenderWithValue() {
+        $palette = [CM_Color_RGB::fromHexString('FF0000'), CM_Color_RGB::fromHexString('00FF00')];
+        $field = new CM_FormField_ColorPalette(['name' => 'foo', 'palette' => $palette]);
+        $field->setValue(CM_Color_RGB::fromHexString('00FF00'));
+
+        $html = $this->_renderFormField($field);
+
+        $this->assertSame('FF0000', $html->find('input')->getAttribute('value'));
         $this->assertSame(2, $html->find('input')->count());
     }
 

--- a/tests/library/CM/FormField/ColorPaletteTest.php
+++ b/tests/library/CM/FormField/ColorPaletteTest.php
@@ -1,0 +1,47 @@
+<?php
+
+class CM_FormField_ColorPaletteTest extends CMTest_TestCase {
+
+    public function testValidate() {
+        $palette = [CM_Color_RGB::fromHexString('FF0000'), CM_Color_RGB::fromHexString('00FF00')];
+        $field = new CM_FormField_ColorPalette(['name' => 'foo', 'palette' => $palette]);
+        $environment = new CM_Frontend_Environment();
+
+        $value = $field->validate($environment, '#00FF00');
+        $this->assertSame('00FF00', $value->getHexString());
+    }
+
+    /**
+     * @expectedException CM_Exception_FormFieldValidation
+     */
+    public function testValidateInvalid() {
+        $palette = [CM_Color_RGB::fromHexString('FF0000'), CM_Color_RGB::fromHexString('00FF00')];
+        $field = new CM_FormField_ColorPalette(['name' => 'foo', 'palette' => $palette]);
+        $environment = new CM_Frontend_Environment();
+
+        $field->validate($environment, '#zzzzzzzzz');
+    }
+
+    /**
+     * @expectedException CM_Exception_FormFieldValidation
+     */
+    public function testValidateNotInPalette() {
+        $palette = [CM_Color_RGB::fromHexString('FF0000'), CM_Color_RGB::fromHexString('00FF00')];
+        $field = new CM_FormField_ColorPalette(['name' => 'foo', 'palette' => $palette]);
+        $environment = new CM_Frontend_Environment();
+
+        $field->validate($environment, '#0000FF');
+    }
+
+    public function testRender() {
+        $palette = [CM_Color_RGB::fromHexString('FF0000'), CM_Color_RGB::fromHexString('00FF00')];
+        $field = new CM_FormField_ColorPalette(['name' => 'foo', 'palette' => $palette]);
+        $field->setValue(CM_Color_RGB::fromHexString('00FF00'));
+
+        $html = $this->_renderFormField($field);
+
+        $this->assertSame('#00FF00', $html->find('input')->getAttribute('value'));
+        $this->assertSame(2, $html->find('.setValueFromPalette')->count());
+    }
+
+}

--- a/tests/library/CM/FormField/ColorTest.php
+++ b/tests/library/CM/FormField/ColorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+class CM_FormField_ColorTest extends CMTest_TestCase {
+
+    public function testValidate() {
+        $field = new CM_FormField_Color(['name' => 'foo']);
+        $environment = new CM_Frontend_Environment();
+
+        $value = $field->validate($environment, '#00FF00');
+        $this->assertSame('00FF00', $value->getHexString());
+    }
+
+    /**
+     * @expectedException CM_Exception_FormFieldValidation
+     */
+    public function testValidateInvalid() {
+        $field = new CM_FormField_Color(['name' => 'foo']);
+        $environment = new CM_Frontend_Environment();
+
+        $field->validate($environment, '#zzzzzzzzz');
+    }
+
+    public function testRender() {
+        $field = new CM_FormField_Color(['name' => 'foo']);
+        $field->setValue(CM_Color_RGB::fromHexString('00FF00'));
+
+        $html = $this->_renderFormField($field);
+
+        $this->assertSame('color', $html->find('input')->getAttribute('type'));
+        $this->assertSame('#00FF00', $html->find('input')->getAttribute('value'));
+    }
+
+}


### PR DESCRIPTION
For https://github.com/cargomedia/sk/issues/4251

Abstract class `CM_Type_Color` extends `MischiefCollective\ColorJizz\ColorJizz\RGB` (https://github.com/mikeemoo/ColorJizz-PHP):
- __construct($red, $green, $blue)
- brightness
- saturation
- hue
- toHexString
- factoryFromHexString

New fields:
- CM_FormField_Color
- CM_FormField_ColorPalette