### PR TITLE
reload of popOut Component.

### DIFF
--- a/client-vendor/after-body/jquery.floatbox/jquery.floatbox.js
+++ b/client-vendor/after-body/jquery.floatbox/jquery.floatbox.js
@@ -105,6 +105,7 @@
       if (this.$parent.length) {
         this.$parent.append($element);
       }
+      this.$floatbox.trigger('floatbox-close');
       $element.removeData('floatbox');
       this.$layer.remove();
       $viewport.children('.floatbox-layer:last').addClass('active');

--- a/library/CM/Component/Abstract.js
+++ b/library/CM/Component/Abstract.js
@@ -42,18 +42,26 @@ var CM_Component_Abstract = CM_View_Abstract.extend({
     return $(selector, this.el);
   },
 
-  popOut: function(options) {
+  /**
+   * @param {Object} [options]
+   * @param {Boolean} [removeOnClose=true]
+   */
+  popOut: function(options, removeOnClose) {
+    if (_.isUndefined(removeOnClose)) {
+      removeOnClose = true;
+    }
     this.repaint();
-    this.$el.floatbox(options);
+    //we don't use `this.$el.floatbox(options);` cause `this` component can be reloaded.
+    var floatbox = new $.floatbox(options);
+    floatbox.show(this.$el);
     this.repaint();
 
-    var self = this;
-    this.$el.one('floatbox-close', function() {
-      if (cm.window.isHidden(self.el)) {
+    if (removeOnClose) {
+      var self = this;
+      floatbox.$floatbox.one('floatbox-close', function() {
         self.remove();
-      }
-      return false;
-    });
+      });
+    }
   },
 
   popIn: function() {

--- a/library/CM/Component/Abstract.js
+++ b/library/CM/Component/Abstract.js
@@ -44,12 +44,9 @@ var CM_Component_Abstract = CM_View_Abstract.extend({
 
   /**
    * @param {Object} [options]
-   * @param {Boolean} [removeOnClose=true]
+   * @param {Boolean} [removeOnClose]
    */
   popOut: function(options, removeOnClose) {
-    if (_.isUndefined(removeOnClose)) {
-      removeOnClose = true;
-    }
     this.repaint();
     //we don't use `this.$el.floatbox(options);` cause `this` component can be reloaded.
     var floatbox = new $.floatbox(options);

--- a/library/CM/Component/Example.js
+++ b/library/CM/Component/Example.js
@@ -45,6 +45,10 @@ var CM_Component_Example = CM_Component_Abstract.extend({
     this.message("Component ready, uname: " + this.uname);
   },
 
+  popOut: function() {
+    return CM_Component_Abstract.prototype.popOut.call(this, {}, false);
+  },
+
   multiLevelPopout: function() {
     var applyFloatbox = function($el) {
       var $popout = $el.children('.innerPopoutComponent');

--- a/library/CM/Component/Example.js
+++ b/library/CM/Component/Example.js
@@ -45,10 +45,6 @@ var CM_Component_Example = CM_Component_Abstract.extend({
     this.message("Component ready, uname: " + this.uname);
   },
 
-  popOut: function() {
-    return CM_Component_Abstract.prototype.popOut.call(this, {}, false);
-  },
-
   multiLevelPopout: function() {
     var applyFloatbox = function($el) {
       var $popout = $el.children('.innerPopoutComponent');

--- a/library/CM/View/Abstract.js
+++ b/library/CM/View/Abstract.js
@@ -341,7 +341,7 @@ var CM_View_Abstract = Backbone.View.extend({
   popOutComponent: function(className, params, options) {
     return this.prepareComponent(className, params, options)
       .then(function(component) {
-        component.popOut();
+        component.popOut({}, true);
         return component;
       });
   },


### PR DESCRIPTION
Firstly, when we do `component.popOut`, we do smth like this:
```js
this.$el.floatbox(options);
var self = this;
this.$el.one('floatbox-close', function() {
    self.remove();
});
```
if component gets reloaded, the new loaded replacement does not get such listener `.one('floatbox-close')` and when floatbox is closed the replacement component is kept under `cm.window._$hidden`.

Secondly, we use `replaceWithHtml` to load pages/layouts:
```js
replaceWithHtml: function($html) {
  this.remove(true);
  this.$el.replaceWith($html);
},
```

This method uses `this.remove(true)` which does not remove `component.$el` and presumes that all children's `$el` are inside parent's `$el` but that is not true for cases when children is in floatbox. So, in general we allow for component to be outside of its parent but `this.remove(true)` requires all children to be inside of their parents. How should we proceed in general? If I fix the bug of `'floatbox-close'` the problem might easily come up in the future with some custom usecase.