### PR TITLE
Remove error formfield icon

### DIFF
--- a/layout/default/FormField/Abstract/default.less
+++ b/layout/default/FormField/Abstract/default.less
@@ -2,14 +2,6 @@
   position: relative;
 }
 
-&[data-formfield-error=true] {
-  .formFieldFeedback-error {
-    visibility: visible;
-    animation: formError 1000ms ease 0s 1;
-    animation-fill-mode: forwards;
-  }
-}
-
 &[data-formfield-success=true] {
   .formFieldFeedback-success {
     visibility: visible;

--- a/layout/default/css/animation.less
+++ b/layout/default/css/animation.less
@@ -1,11 +1,3 @@
-@keyframes formError {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
 @keyframes formSuccess {
   0% {
     opacity: 0;

--- a/layout/default/css/form.less
+++ b/layout/default/css/form.less
@@ -329,7 +329,8 @@ input[type=checkbox].checkbox-switch {
   }
 }
 
-.formFieldFeedback {
+.formFieldFeedback-success {
+  color: @colorOk;
   font-size: 1.2rem;
   line-height: @heightInputText;
   opacity: 0;
@@ -340,8 +341,4 @@ input[type=checkbox].checkbox-switch {
   top: 0;
   visibility: hidden;
   width: @heightInputText;
-
-  &.formFieldFeedback-success {
-    color: @colorOk;
-  }
 }

--- a/layout/default/css/form.less
+++ b/layout/default/css/form.less
@@ -341,11 +341,6 @@ input[type=checkbox].checkbox-switch {
   visibility: hidden;
   width: @heightInputText;
 
-  .icon {
-    padding: 3px;
-    background-color: white;
-  }
-
   &.formFieldFeedback-success {
     color: @colorOk;
   }

--- a/layout/default/css/form.less
+++ b/layout/default/css/form.less
@@ -346,10 +346,6 @@ input[type=checkbox].checkbox-switch {
     background-color: white;
   }
 
-  &.formFieldFeedback-error {
-    color: @colorError;
-  }
-
   &.formFieldFeedback-success {
     color: @colorOk;
   }

--- a/library/CM/RenderAdapter/FormField.php
+++ b/library/CM/RenderAdapter/FormField.php
@@ -22,7 +22,6 @@ class CM_RenderAdapter_FormField extends CM_RenderAdapter_Abstract {
         if (!$field instanceof CM_FormField_Hidden) {
             $content .= '<div class="messages"></div>';
             $content .= '<div class="formFieldFeedback formFieldFeedback-success"><span class="icon icon-verified"></span></div>';
-            $content .= '<div class="formFieldFeedback formFieldFeedback-error"><span class="icon icon-error"></span></div>';
         }
         $tagAttributes = [
             'id'    => $viewResponse->getAutoId(),

--- a/library/CM/RenderAdapter/FormField.php
+++ b/library/CM/RenderAdapter/FormField.php
@@ -21,7 +21,7 @@ class CM_RenderAdapter_FormField extends CM_RenderAdapter_Abstract {
         $content = trim($this->getRender()->fetchViewResponse($viewResponse));
         if (!$field instanceof CM_FormField_Hidden) {
             $content .= '<div class="messages"></div>';
-            $content .= '<div class="formFieldFeedback formFieldFeedback-success"><span class="icon icon-verified"></span></div>';
+            $content .= '<div class="formFieldFeedback-success"><span class="icon icon-verified"></span></div>';
         }
         $tagAttributes = [
             'id'    => $viewResponse->getAutoId(),


### PR DESCRIPTION
It's not needed, because we additionally have an error message.
And it's in conflict with other form field UI

And Make formfield success icon transparent