### PR TITLE
Fix custom floatbox opening

### DIFF
--- a/client-vendor/after-body/jquery.floatbox/jquery.floatbox.js
+++ b/client-vendor/after-body/jquery.floatbox/jquery.floatbox.js
@@ -95,6 +95,7 @@
       this._getFocusElement().focus();
       this.$floatbox.trap();
 
+      this.$layer.data('floatbox', this);
       $element.trigger('floatbox-open');
     },
     close: function() {
@@ -170,7 +171,6 @@
       } else {
         floatbox = new $.floatbox(methodOrOptions);
         floatbox.show($(this));
-        $(this).closest('.floatbox-layer').data('floatbox', floatbox);
       }
     });
   };


### PR DESCRIPTION
When open floatbox through `new $.floatbox` we loose `.data` instance on it.