### PR TITLE
Remove Process forking IPC

### DIFF
--- a/library/CM/Cli/CommandManager.php
+++ b/library/CM/Cli/CommandManager.php
@@ -280,7 +280,7 @@ class CM_Cli_CommandManager {
      * @return callable
      */
     protected function _getProcessWorkload($transactionName, CM_Cli_Command $command, CM_Cli_Arguments $arguments, CM_InputStream_Interface $streamInput, CM_OutputStream_Interface $streamOutput, CM_OutputStream_Interface $streamError) {
-        return function (CM_Process_WorkloadResult $result) use ($transactionName, $command, $arguments, $streamInput, $streamOutput, $streamError) {
+        return function () use ($transactionName, $command, $arguments, $streamInput, $streamOutput, $streamError) {
             try {
                 $parameters = $command->extractParameters($arguments);
                 $this->_checkUnusedArguments($arguments);
@@ -298,10 +298,8 @@ class CM_Cli_CommandManager {
                 } else {
                     $this->_outputError($this->getHelp());
                 }
-                $result->setException($ex);
             } catch (CM_Cli_Exception_Internal $ex) {
                 $this->_outputError('ERROR: ' . $ex->getMessage() . PHP_EOL);
-                $result->setException($ex);
             }
         };
     }

--- a/library/CM/Cli/CommandManager.php
+++ b/library/CM/Cli/CommandManager.php
@@ -179,7 +179,7 @@ class CM_Cli_CommandManager {
             if ($command->getSynchronized()) {
                 $this->unlockCommand($command);
             }
-            $failure = Functional\some($resultList, function (CM_Process_WorkloadResult $result) {
+            $failure = Functional\some($resultList, function (CM_Process_Result $result) {
                 return !$result->isSuccess();
             });
             if ($failure) {

--- a/library/CM/Clockwork/Manager.php
+++ b/library/CM/Clockwork/Manager.php
@@ -72,11 +72,11 @@ class CM_Clockwork_Manager {
     }
 
     /**
-     * @param CM_Clockwork_Event        $event
-     * @param CM_Process_WorkloadResult $result
+     * @param CM_Clockwork_Event $event
+     * @param CM_Process_Result  $result
      * @throws CM_Exception_Invalid
      */
-    public function handleEventResult(CM_Clockwork_Event $event, CM_Process_WorkloadResult $result) {
+    public function handleEventResult(CM_Clockwork_Event $event, CM_Process_Result $result) {
         if ($result->isSuccess()) {
             $this->_markCompleted($event);
         }

--- a/library/CM/Process.php
+++ b/library/CM/Process.php
@@ -141,7 +141,7 @@ class CM_Process {
 
     /**
      * @param boolean|null $keepAlive
-     * @return CM_Process_WorkloadResult[]
+     * @return CM_Process_Result[]
      * @throws CM_Exception
      */
     public function listenForChildren($keepAlive = null) {
@@ -150,7 +150,7 @@ class CM_Process {
 
     /**
      * @param bool|null $keepAlive
-     * @return CM_Process_WorkloadResult[]
+     * @return CM_Process_Result[]
      * @throws CM_Exception
      */
     public function waitForChildren($keepAlive = null) {
@@ -239,7 +239,7 @@ class CM_Process {
     /**
      * @param bool|null $keepAlive
      * @param boolean   $nohang
-     * @return CM_Process_WorkloadResult[]
+     * @return CM_Process_Result[]
      * @throws CM_Exception
      * @throws Exception
      * @internal param callable|null $terminationCallback
@@ -257,7 +257,7 @@ class CM_Process {
                 }
                 if ($pid > 0 && ($forkHandler = $this->_findForkHandlerByPid($pid))) {
                     unset($this->_forkHandlerList[$forkHandler->getIdentifier()]);
-                    $workloadResult = new CM_Process_WorkloadResult();
+                    $workloadResult = new CM_Process_Result();
                     if (pcntl_wifexited($status)) {
                         $returnCode = pcntl_wexitstatus($status);
                         $workloadResult->setReturnCode($returnCode);

--- a/library/CM/Process/Result.php
+++ b/library/CM/Process/Result.php
@@ -1,6 +1,6 @@
 <?php
 
-class CM_Process_WorkloadResult {
+class CM_Process_Result {
 
     /** @var int|null */
     private $_returnCode;

--- a/library/CM/Process/WorkloadResult.php
+++ b/library/CM/Process/WorkloadResult.php
@@ -2,41 +2,29 @@
 
 class CM_Process_WorkloadResult {
 
-    /** @var mixed */
-    private $_result;
-
-    /** @var CM_ExceptionHandling_SerializableException|null */
-    private $_exception;
+    /** @var int|null */
+    private $_returnCode;
 
     /**
-     * @return mixed
+     * @param int|null $returnCode
      */
-    public function getResult() {
-        return $this->_result;
+    public function __construct($returnCode = null) {
+        $this->setReturnCode($returnCode);
     }
 
     /**
-     * @param mixed $result
+     * @return int|null
+     */
+    public function getReturnCode() {
+        return $this->_returnCode;
+    }
+
+    /**
+     * @param int|null $code
      * @return $this
      */
-    public function setResult($result) {
-        $this->_result = $result;
-        return $this;
-    }
-
-    /**
-     * @return CM_ExceptionHandling_SerializableException|null
-     */
-    public function getException() {
-        return $this->_exception;
-    }
-
-    /**
-     * @param Exception $exception
-     * @return static
-     */
-    public function setException(Exception $exception) {
-        $this->_exception = new CM_ExceptionHandling_SerializableException($exception);
+    public function setReturnCode($code) {
+        $this->_returnCode = (null !== $code) ? (int) $code : null;
         return $this;
     }
 
@@ -44,6 +32,6 @@ class CM_Process_WorkloadResult {
      * @return bool
      */
     public function isSuccess() {
-        return null === $this->getException();
+        return 0 === $this->_returnCode;
     }
 }

--- a/tests/library/CM/Cli/CommandManagerTest.php
+++ b/tests/library/CM/Cli/CommandManagerTest.php
@@ -163,20 +163,20 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
             ->at(0, function () use ($processMock) {
                 $processSuccess = $processMock->newInstance();
                 $processSuccess->mockMethod('waitForChildren')->set([
-                    new CM_Process_WorkloadResult(0),
-                    new CM_Process_WorkloadResult(0),
-                    new CM_Process_WorkloadResult(0),
-                    new CM_Process_WorkloadResult(0),
+                    new CM_Process_Result(0),
+                    new CM_Process_Result(0),
+                    new CM_Process_Result(0),
+                    new CM_Process_Result(0),
                 ]);
                 return $processSuccess;
             })
             ->at(1, function () use ($processMock) {
                 $processFailure = $processMock->newInstance();
                 $processFailure->mockMethod('waitForChildren')->set([
-                    new CM_Process_WorkloadResult(0),
-                    new CM_Process_WorkloadResult(1),
-                    new CM_Process_WorkloadResult(0),
-                    new CM_Process_WorkloadResult(0),
+                    new CM_Process_Result(0),
+                    new CM_Process_Result(1),
+                    new CM_Process_Result(0),
+                    new CM_Process_Result(0),
                 ]);
                 return $processFailure;
             });
@@ -239,7 +239,7 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
         $mockBuilder->disableOriginalConstructor();
         $processMock = $mockBuilder->getMock();
         $processMock->expects($this->any())->method('fork')->will($this->returnCallback(function ($workload) {
-            $workload(new CM_Process_WorkloadResult());
+            $workload(new CM_Process_Result());
         }));
         $waitForChildrenMock = function ($keepAlive) {
             return array();

--- a/tests/library/CM/Cli/CommandManagerTest.php
+++ b/tests/library/CM/Cli/CommandManagerTest.php
@@ -239,7 +239,7 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
         $mockBuilder->disableOriginalConstructor();
         $processMock = $mockBuilder->getMock();
         $processMock->expects($this->any())->method('fork')->will($this->returnCallback(function ($workload) {
-            $workload(new CM_Process_Result());
+            $workload();
         }));
         $waitForChildrenMock = function ($keepAlive) {
             return array();

--- a/tests/library/CM/Cli/CommandManagerTest.php
+++ b/tests/library/CM/Cli/CommandManagerTest.php
@@ -163,20 +163,20 @@ class CM_Cli_CommandManagerTest extends CMTest_TestCase {
             ->at(0, function () use ($processMock) {
                 $processSuccess = $processMock->newInstance();
                 $processSuccess->mockMethod('waitForChildren')->set([
-                    (new CM_Process_WorkloadResult())->setResult(true),
-                    (new CM_Process_WorkloadResult())->setResult(true),
-                    (new CM_Process_WorkloadResult())->setResult(true),
-                    (new CM_Process_WorkloadResult())->setResult(true),
+                    new CM_Process_WorkloadResult(0),
+                    new CM_Process_WorkloadResult(0),
+                    new CM_Process_WorkloadResult(0),
+                    new CM_Process_WorkloadResult(0),
                 ]);
                 return $processSuccess;
             })
             ->at(1, function () use ($processMock) {
                 $processFailure = $processMock->newInstance();
                 $processFailure->mockMethod('waitForChildren')->set([
-                    (new CM_Process_WorkloadResult())->setResult(true),
-                    (new CM_Process_WorkloadResult())->setResult(false)->setException(new Exception('Workload failed')),
-                    (new CM_Process_WorkloadResult())->setResult(true),
-                    (new CM_Process_WorkloadResult())->setResult(true),
+                    new CM_Process_WorkloadResult(0),
+                    new CM_Process_WorkloadResult(1),
+                    new CM_Process_WorkloadResult(0),
+                    new CM_Process_WorkloadResult(0),
                 ]);
                 return $processFailure;
             });

--- a/tests/library/CM/Clockwork/ManagerTest.php
+++ b/tests/library/CM/Clockwork/ManagerTest.php
@@ -47,7 +47,7 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
             $callbackCallCount++;
         });
 
-        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_WorkloadResult()]);
+        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_WorkloadResult(0)]);
         $manager->runEvents();
         $this->assertSame(1, $callbackCallCount);
         $this->assertNull($lastRuntimeActual);
@@ -55,7 +55,7 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         // check if we get the correct lastRuntime
         $expectedLastRuntime = clone $currently;
         $currently->modify('10 seconds');
-        $process->mockMethod('listenForChildren')->set([2 => new CM_Process_WorkloadResult()]);
+        $process->mockMethod('listenForChildren')->set([2 => new CM_Process_WorkloadResult(0)]);
         $manager->runEvents();
         $this->assertSame(2, $callbackCallCount);
         $this->assertSameTime($expectedLastRuntime, $lastRuntimeActual);
@@ -67,7 +67,7 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $expectedLastRuntime = clone $currently;
         $currently->modify('10 seconds');
         $secondCallbackCallCount = 0;
-        $process->mockMethod('listenForChildren')->set([3 => new CM_Process_WorkloadResult()]);
+        $process->mockMethod('listenForChildren')->set([3 => new CM_Process_WorkloadResult(0)]);
         $manager->runEvents();
         $this->assertSame(1, $secondCallbackCallCount);
         $this->assertSame(3, $callbackCallCount);
@@ -76,19 +76,17 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         // check if error in event callback will not update the lastRuntime
         $expectedLastRuntime = clone $currently;
         $currently->modify('10 seconds');
-        $workloadResult = new CM_Process_WorkloadResult();
-        $workloadResult->setException(new CM_Exception_Invalid());
-        $process->mockMethod('listenForChildren')->set([4 => $workloadResult]);
+        $process->mockMethod('listenForChildren')->set([4 => new CM_Process_WorkloadResult(1)]);
         $manager->runEvents();
         $this->assertSame(4, $callbackCallCount);
         $this->assertSameTime($expectedLastRuntime, $lastRuntimeActual);
 
-        $process->mockMethod('listenForChildren')->set([5 => new CM_Process_WorkloadResult()]);
+        $process->mockMethod('listenForChildren')->set([5 => new CM_Process_WorkloadResult(0)]);
         $manager->runEvents();
         $this->assertSame(5, $callbackCallCount);
         $this->assertSameTime($expectedLastRuntime, $lastRuntimeActual);
 
-        $process->mockMethod('listenForChildren')->set([6 => new CM_Process_WorkloadResult()]);
+        $process->mockMethod('listenForChildren')->set([6 => new CM_Process_WorkloadResult(0)]);
         $manager->runEvents();
         $this->assertSame(6, $callbackCallCount);
         $this->assertSameTime($currently, $lastRuntimeActual);
@@ -121,7 +119,7 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $this->assertTrue(CMTest_TH::callProtectedMethod($manager, '_isRunning', [$event2]));
 
         // event 2 finishes
-        $process->mockMethod('listenForChildren')->set([2 => new CM_Process_WorkloadResult()]);
+        $process->mockMethod('listenForChildren')->set([2 => new CM_Process_WorkloadResult(0)]);
         $manager->runEvents();
         $this->assertSame(2, $forkMock->getCallCount());
         $this->assertTrue(CMTest_TH::callProtectedMethod($manager, '_isRunning', [$event1]));
@@ -135,8 +133,8 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $this->assertTrue(CMTest_TH::callProtectedMethod($manager, '_isRunning', [$event2]));
 
         // both events finish, event 2 finishes with an error
-        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_WorkloadResult(),
-                                                        3 => (new CM_Process_WorkloadResult())->setException(new CM_Exception())]);
+        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_WorkloadResult(0),
+                                                        3 => new CM_Process_WorkloadResult(1)]);
         $manager->runEvents();
 
         $this->assertFalse(CMTest_TH::callProtectedMethod($manager, '_isRunning', [$event1]));
@@ -193,7 +191,7 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
 
         $currently->modify('1 second');
         $this->assertTrue($_shouldRun->invoke($manager, $event1));
-        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_WorkloadResult(null, null)]);
+        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_WorkloadResult(0)]);
         $manager->runEvents();
         $this->assertEquals($currently, $storage->getLastRuntime($event1));
         $this->assertFalse($_shouldRun->invoke($manager, $event1));

--- a/tests/library/CM/Clockwork/ManagerTest.php
+++ b/tests/library/CM/Clockwork/ManagerTest.php
@@ -47,7 +47,7 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
             $callbackCallCount++;
         });
 
-        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_WorkloadResult(0)]);
+        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_Result(0)]);
         $manager->runEvents();
         $this->assertSame(1, $callbackCallCount);
         $this->assertNull($lastRuntimeActual);
@@ -55,7 +55,7 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         // check if we get the correct lastRuntime
         $expectedLastRuntime = clone $currently;
         $currently->modify('10 seconds');
-        $process->mockMethod('listenForChildren')->set([2 => new CM_Process_WorkloadResult(0)]);
+        $process->mockMethod('listenForChildren')->set([2 => new CM_Process_Result(0)]);
         $manager->runEvents();
         $this->assertSame(2, $callbackCallCount);
         $this->assertSameTime($expectedLastRuntime, $lastRuntimeActual);
@@ -67,7 +67,7 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $expectedLastRuntime = clone $currently;
         $currently->modify('10 seconds');
         $secondCallbackCallCount = 0;
-        $process->mockMethod('listenForChildren')->set([3 => new CM_Process_WorkloadResult(0)]);
+        $process->mockMethod('listenForChildren')->set([3 => new CM_Process_Result(0)]);
         $manager->runEvents();
         $this->assertSame(1, $secondCallbackCallCount);
         $this->assertSame(3, $callbackCallCount);
@@ -76,17 +76,17 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         // check if error in event callback will not update the lastRuntime
         $expectedLastRuntime = clone $currently;
         $currently->modify('10 seconds');
-        $process->mockMethod('listenForChildren')->set([4 => new CM_Process_WorkloadResult(1)]);
+        $process->mockMethod('listenForChildren')->set([4 => new CM_Process_Result(1)]);
         $manager->runEvents();
         $this->assertSame(4, $callbackCallCount);
         $this->assertSameTime($expectedLastRuntime, $lastRuntimeActual);
 
-        $process->mockMethod('listenForChildren')->set([5 => new CM_Process_WorkloadResult(0)]);
+        $process->mockMethod('listenForChildren')->set([5 => new CM_Process_Result(0)]);
         $manager->runEvents();
         $this->assertSame(5, $callbackCallCount);
         $this->assertSameTime($expectedLastRuntime, $lastRuntimeActual);
 
-        $process->mockMethod('listenForChildren')->set([6 => new CM_Process_WorkloadResult(0)]);
+        $process->mockMethod('listenForChildren')->set([6 => new CM_Process_Result(0)]);
         $manager->runEvents();
         $this->assertSame(6, $callbackCallCount);
         $this->assertSameTime($currently, $lastRuntimeActual);
@@ -119,7 +119,7 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $this->assertTrue(CMTest_TH::callProtectedMethod($manager, '_isRunning', [$event2]));
 
         // event 2 finishes
-        $process->mockMethod('listenForChildren')->set([2 => new CM_Process_WorkloadResult(0)]);
+        $process->mockMethod('listenForChildren')->set([2 => new CM_Process_Result(0)]);
         $manager->runEvents();
         $this->assertSame(2, $forkMock->getCallCount());
         $this->assertTrue(CMTest_TH::callProtectedMethod($manager, '_isRunning', [$event1]));
@@ -133,8 +133,8 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
         $this->assertTrue(CMTest_TH::callProtectedMethod($manager, '_isRunning', [$event2]));
 
         // both events finish, event 2 finishes with an error
-        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_WorkloadResult(0),
-                                                        3 => new CM_Process_WorkloadResult(1)]);
+        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_Result(0),
+                                                        3 => new CM_Process_Result(1)]);
         $manager->runEvents();
 
         $this->assertFalse(CMTest_TH::callProtectedMethod($manager, '_isRunning', [$event1]));
@@ -191,7 +191,7 @@ class CM_Clockwork_ManagerTest extends CMTest_TestCase {
 
         $currently->modify('1 second');
         $this->assertTrue($_shouldRun->invoke($manager, $event1));
-        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_WorkloadResult(0)]);
+        $process->mockMethod('listenForChildren')->set([1 => new CM_Process_Result(0)]);
         $manager->runEvents();
         $this->assertEquals($currently, $storage->getLastRuntime($event1));
         $this->assertFalse($_shouldRun->invoke($manager, $event1));

--- a/tests/library/CM/Process/ResultTest.php
+++ b/tests/library/CM/Process/ResultTest.php
@@ -1,17 +1,17 @@
 <?php
 
-class CM_Process_WorkloadResultTest extends CMTest_TestCase {
+class CM_Process_ResultTest extends CMTest_TestCase {
 
     public function testConstructor() {
-        $result = new CM_Process_WorkloadResult();
+        $result = new CM_Process_Result();
         $this->assertSame(null, $result->getReturnCode());
 
-        $result = new CM_Process_WorkloadResult(0);
+        $result = new CM_Process_Result(0);
         $this->assertSame(0, $result->getReturnCode());
     }
 
     public function testSetReturnCode() {
-        $result = new CM_Process_WorkloadResult();
+        $result = new CM_Process_Result();
         $this->assertSame(null, $result->getReturnCode());
         $result->setReturnCode(0);
         $this->assertSame(0, $result->getReturnCode());
@@ -21,7 +21,7 @@ class CM_Process_WorkloadResultTest extends CMTest_TestCase {
     }
 
     public function testIsSuccess() {
-        $result = new CM_Process_WorkloadResult();
+        $result = new CM_Process_Result();
         $this->assertSame(false, $result->isSuccess());
 
         $result->setReturnCode(0);

--- a/tests/library/CM/Process/WorkloadResultTest.php
+++ b/tests/library/CM/Process/WorkloadResultTest.php
@@ -1,0 +1,33 @@
+<?php
+
+class CM_Process_WorkloadResultTest extends CMTest_TestCase {
+
+    public function testConstructor() {
+        $result = new CM_Process_WorkloadResult();
+        $this->assertSame(null, $result->getReturnCode());
+
+        $result = new CM_Process_WorkloadResult(0);
+        $this->assertSame(0, $result->getReturnCode());
+    }
+
+    public function testSetReturnCode() {
+        $result = new CM_Process_WorkloadResult();
+        $this->assertSame(null, $result->getReturnCode());
+        $result->setReturnCode(0);
+        $this->assertSame(0, $result->getReturnCode());
+
+        $result->setReturnCode(null);
+        $this->assertSame(null, $result->getReturnCode());
+    }
+
+    public function testIsSuccess() {
+        $result = new CM_Process_WorkloadResult();
+        $this->assertSame(false, $result->isSuccess());
+
+        $result->setReturnCode(0);
+        $this->assertSame(true, $result->isSuccess());
+
+        $result->setReturnCode(1);
+        $this->assertSame(false, $result->isSuccess());
+    }
+}

--- a/tests/library/CM/ProcessTest.php
+++ b/tests/library/CM/ProcessTest.php
@@ -127,12 +127,12 @@ class CM_ProcessTest extends CMTest_TestCase {
         usleep(500000);
         $responses = $process->listenForChildren();
         $this->assertCount(1, $responses);
-        $this->assertContainsOnlyInstancesOf('CM_Process_WorkloadResult', $responses);
+        $this->assertContainsOnlyInstancesOf('CM_Process_Result', $responses);
         $this->assertSame([1 => true], \Functional\invoke($responses, 'isSuccess'));
         usleep(1000000);
         $responses = $process->listenForChildren();
         $this->assertCount(1, $responses);
-        $this->assertContainsOnlyInstancesOf('CM_Process_WorkloadResult', $responses);
+        $this->assertContainsOnlyInstancesOf('CM_Process_Result', $responses);
         $this->assertSame([2 => true], \Functional\invoke($responses, 'isSuccess'));
     }
 

--- a/tests/library/CM/ProcessTest.php
+++ b/tests/library/CM/ProcessTest.php
@@ -44,12 +44,10 @@ class CM_ProcessTest extends CMTest_TestCase {
         $this->assertSame(0, $bindMock->getCallCount());
         $process->mockMethod('_hasForks')->set(true);
         $process->fork(function () {
-            return 0;
         });
         $this->assertSame(0, $bindMock->getCallCount());
         $process->mockMethod('_hasForks')->set(false);
         $process->fork(function () {
-            return 0;
         });
         $this->assertSame(1, $bindMock->getCallCount());
     }

--- a/tests/library/CM/ProcessTest.php
+++ b/tests/library/CM/ProcessTest.php
@@ -37,18 +37,19 @@ class CM_ProcessTest extends CMTest_TestCase {
         $forkHandlerMock = $process->mockMethod('_getForkHandler');
         $forkHandlerMock->set(function () {
             $mockForkHandler = $this->mockClass('CM_Process_ForkHandler')->newInstanceWithoutConstructor();
-            $mockForkHandler->mockMethod('runAndSendWorkload');
-            $mockForkHandler->mockMethod('closeIpcStream');
+            $mockForkHandler->mockMethod('runWorkload');
             return $mockForkHandler;
         });
 
         $this->assertSame(0, $bindMock->getCallCount());
         $process->mockMethod('_hasForks')->set(true);
         $process->fork(function () {
+            return 0;
         });
         $this->assertSame(0, $bindMock->getCallCount());
         $process->mockMethod('_hasForks')->set(false);
         $process->fork(function () {
+            return 0;
         });
         $this->assertSame(1, $bindMock->getCallCount());
     }
@@ -89,7 +90,8 @@ class CM_ProcessTest extends CMTest_TestCase {
         $parentOutput[] = 'Parent waiting for 250 ms...';
         usleep(250000);
         $parentOutput[] = 'Parent listening to children...';
-        $process->waitForChildren();
+        $workloadResultList = $process->waitForChildren();
+        $this->assertSame([1 => true, 2 => true, 3 => true, 4 => true, 5 => true], \Functional\invoke($workloadResultList, 'isSuccess'));
         $parentOutput[] = 'Parent terminated.';
         $childrenOutput = explode(PHP_EOL, $file->read());
 
@@ -120,79 +122,20 @@ class CM_ProcessTest extends CMTest_TestCase {
     public function testForkAndListenForChildren() {
         $process = CM_Process::getInstance();
         $process->fork(function () {
-            return 'foo';
         });
         $process->fork(function () {
             usleep(1000000);
-            return 'bar';
         });
         usleep(500000);
         $responses = $process->listenForChildren();
         $this->assertCount(1, $responses);
         $this->assertContainsOnlyInstancesOf('CM_Process_WorkloadResult', $responses);
-        $this->assertSame([1 => 'foo'], \Functional\invoke($responses, 'getResult'));
+        $this->assertSame([1 => true], \Functional\invoke($responses, 'isSuccess'));
         usleep(1000000);
         $responses = $process->listenForChildren();
         $this->assertCount(1, $responses);
         $this->assertContainsOnlyInstancesOf('CM_Process_WorkloadResult', $responses);
-        $this->assertSame([2 => 'bar'], \Functional\invoke($responses, 'getResult'));
-    }
-
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
-    public function testForkAndWaitForChildrenWithResults() {
-        $bootloader = CM_Bootloader::getInstance();
-        $exceptionHandlerBackup = $bootloader->getExceptionHandler();
-
-        /**
-         * Increase print-severity to make sure "child 3"'s exception output doesn't disturb phpunit
-         */
-        $exceptionHandler = new CM_ExceptionHandling_Handler_Cli();
-        $exceptionHandler->setPrintSeverityMin(CM_Exception::FATAL);
-        $exceptionHandler->setServiceManager($this->getServiceManager());
-
-        $bootloader->setExceptionHandler($exceptionHandler);
-
-        $process = CM_Process::getInstance();
-        $process->fork(function () {
-            usleep(100 * 1000);
-            return 'Child 1 finished';
-        });
-        $process->fork(function () {
-            usleep(50 * 1000);
-            return array('msg' => 'Child 2 finished');
-        });
-        $process->fork(function () {
-            usleep(150 * 1000);
-            throw new CM_Exception('Child 3 finished');
-        });
-        $process->fork(function (CM_Process_WorkloadResult $result) {
-            usleep(200 * 1000);
-            $result->setException(new CM_Exception('Child 4 finished'));
-        });
-
-        $workloadResultList = $process->waitForChildren();
-        $this->assertCount(4, $workloadResultList);
-
-        $this->assertSame('Child 1 finished', $workloadResultList[1]->getResult());
-        $this->assertSame(null, $workloadResultList[1]->getException());
-        $this->assertTrue($workloadResultList[1]->isSuccess());
-
-        $this->assertSame(array('msg' => 'Child 2 finished'), $workloadResultList[2]->getResult());
-        $this->assertSame(null, $workloadResultList[2]->getException());
-        $this->assertTrue($workloadResultList[2]->isSuccess());
-
-        $this->assertSame(null, $workloadResultList[3]->getResult());
-        $this->assertSame('Child 3 finished', $workloadResultList[3]->getException()->getMessage());
-        $this->assertFalse($workloadResultList[3]->isSuccess());
-
-        $this->assertSame(null, $workloadResultList[4]->getResult());
-        $this->assertSame('Child 4 finished', $workloadResultList[4]->getException()->getMessage());
-        $this->assertFalse($workloadResultList[4]->isSuccess());
-
-        $bootloader->setExceptionHandler($exceptionHandlerBackup);
+        $this->assertSame([2 => true], \Functional\invoke($responses, 'isSuccess'));
     }
 
     /**
@@ -218,17 +161,17 @@ class CM_ProcessTest extends CMTest_TestCase {
         $workloadResultList = $process->waitForChildren();
         $this->assertCount(4, $workloadResultList);
 
-        $this->assertSame('Child 1 finished', $workloadResultList[1]->getResult());
-        $this->assertSame(null, $workloadResultList[1]->getException());
+        $this->assertSame(true, $workloadResultList[1]->isSuccess());
+        $this->assertSame(0, $workloadResultList[1]->getReturnCode());
 
-        $this->assertSame(null, $workloadResultList[2]->getResult());
-        $this->assertSame('Received no data from IPC stream.', $workloadResultList[2]->getException()->getMessage());
+        $this->assertSame(true, $workloadResultList[2]->isSuccess());
+        $this->assertSame(0, $workloadResultList[2]->getReturnCode());
 
-        $this->assertSame(null, $workloadResultList[3]->getResult());
-        $this->assertSame('Received no data from IPC stream.', $workloadResultList[3]->getException()->getMessage());
+        $this->assertSame(false, $workloadResultList[3]->isSuccess());
+        $this->assertSame(null, $workloadResultList[3]->getReturnCode());
 
-        $this->assertSame(null, $workloadResultList[4]->getResult());
-        $this->assertSame('Received no data from IPC stream.', $workloadResultList[4]->getException()->getMessage());
+        $this->assertSame(false, $workloadResultList[4]->isSuccess());
+        $this->assertSame(null, $workloadResultList[4]->getReturnCode());
     }
 
     /**

--- a/tests/library/CM/Redis/ClientTest.php
+++ b/tests/library/CM/Redis/ClientTest.php
@@ -197,42 +197,6 @@ class CM_Redis_ClientTest extends CMTest_TestCase {
         $process = CM_Process::getInstance();
         $process->fork(function () {
             $redisClient = CM_Service_Manager::getInstance()->getRedis();
-            return $redisClient->subscribe('foo', function ($channel, $message) {
-                if ($message === 'test') {
-                    return null;
-                }
-                return [$channel, $message];
-            });
-        });
-
-        $clientCount = 0;
-        // use a timeout because there's no easy way to know when the forked process will subscribe to the channel...
-        for ($loopCount = 0; 0 === $clientCount; $loopCount++) {
-            $clientCount = $this->_client->publish('foo', 'test');
-            if ($loopCount > 40) {
-                $process->killChildren();
-                $this->fail('Failed to publish on a Redis subpub channel.');
-            }
-            usleep(50 * 1000);
-        }
-
-        $this->_client->publish('foo', 'bar');
-        $resultList = $process->waitForChildren();
-        $this->assertCount(1, $resultList);
-
-        foreach ($resultList as $result) {
-            $this->assertSame(['foo', 'bar'], $result->getResult());
-        }
-    }
-
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
-    public function testPubSubMultiple() {
-        $process = CM_Process::getInstance();
-        $process->fork(function () {
-            $redisClient = CM_Service_Manager::getInstance()->getRedis();
             $clientCallCount = 0;
             while (1 >= $clientCallCount) {
                 if (0 != $redisClient->publish('foo', 'bar' . $clientCallCount)) {


### PR DESCRIPTION
Currently when forking a child process, that process will communicate its success/failure status back to the parent process through an IPC stream.

Since we never send any "workload result" from a child to a parent process we could replace this IPC stream by just relying on the exit code of the child (0 = success, other = failure). This will simplify a lot of code.

@tomaszdurka agree?