### PR TITLE
refactor site mocking

### DIFF
--- a/tests/helpers/CMTest/library/CMTest/TestCase.php
+++ b/tests/helpers/CMTest/library/CMTest/TestCase.php
@@ -86,9 +86,8 @@ abstract class CMTest_TestCase extends PHPUnit_Framework_TestCase implements CM_
         );
         $configuration = array_merge($defaultConfiguration, (array) $configuration);
 
-        $mockClassname = $classname . '_Mock' . $type . '_' . uniqid();
-        $site = $this->getMockForAbstractClass($classname, array(), $mockClassname, true, true, true, $methods);
-        $siteClassName = get_class($site);
+        $siteClassName = $classname . '_Mock' . $type . '_' . uniqid();
+
         $config->CM_Site_Abstract->types[$type] = $siteClassName;
         $config->$siteClassName = new stdClass;
         $config->$siteClassName->type = $type;
@@ -97,6 +96,7 @@ abstract class CMTest_TestCase extends PHPUnit_Framework_TestCase implements CM_
         }
         $config->CM_Class_Abstract->typesMaxValue = $type;
 
+        $site = $this->getMockForAbstractClass($classname, array(), $siteClassName, true, true, true, $methods);
         return $site;
     }
 


### PR DESCRIPTION
The idea is to register the type before `getMockForAbstractClass()` call. So type will be available in `CM_Class_Abstact::__constructor` . It's needed for https://github.com/cargomedia/cm/pull/2428