### PR TITLE
Fix CM_View_Abstract.replaceWithHtml

### DIFF
--- a/library/CM/View/Abstract.js
+++ b/library/CM/View/Abstract.js
@@ -226,14 +226,8 @@ var CM_View_Abstract = Backbone.View.extend({
    * @param {jQuery} $html
    */
   replaceWithHtml: function($html) {
-    var $parent = this.$el.parent();
-    var $next = this.$el.next();
-    cm.window.appendHidden(this.$el);
-    if ($next.length) {
-      $next.before($html);
-    } else {
-      $parent.append($html);
-    }
+    var parent = this.el.parentNode;
+    parent.replaceChild($html[0], this.el);
     this.remove();
   },
 

--- a/library/CM/View/Abstract.js
+++ b/library/CM/View/Abstract.js
@@ -226,7 +226,9 @@ var CM_View_Abstract = Backbone.View.extend({
    * @param {jQuery} $html
    */
   replaceWithHtml: function($html) {
-    this.$el.replaceWith($html);
+    var $parent = this.$el.parent();
+    cm.window.appendHidden(this.$el);
+    $parent.append($html);
     this.remove();
   },
 

--- a/library/CM/View/Abstract.js
+++ b/library/CM/View/Abstract.js
@@ -227,8 +227,13 @@ var CM_View_Abstract = Backbone.View.extend({
    */
   replaceWithHtml: function($html) {
     var $parent = this.$el.parent();
+    var $next = this.$el.next();
     cm.window.appendHidden(this.$el);
-    $parent.append($html);
+    if ($next.length) {
+      $next.before($html);
+    } else {
+      $parent.append($html);
+    }
     this.remove();
   },
 


### PR DESCRIPTION
There is a problem that events are not triggered on `$el` that was replaced. Consider this example:
```html
<head></head>
<body>
  <div class="container">
    <ul class="list">
      <li></li>
      <li></li>
      <li></li>
    </ul>
  </div>
  <script src="./client-vendor/after-body/10-jquery/jquery.js"></script>
  <script src="./client-vendor/after-body/20-underscore/underscore.js"></script>
  <script>
    $(document).ready(function() {
      $('li').on('hello', function() {
        console.log('hello');
      });
      var $ul = $('ul');
      $ul.replaceWith('<p>new content</p>');
      $ul.trigger('hello');
    });
  </script>
</body>
```

`hello` event is not triggered. Hence `this.remove();` from `replaceWithHtml` does not trigger any destruction events. Working on it now.