### PR TITLE
Media.js: don't set "crossOrigin" by default

### DIFF
--- a/client-vendor/source/cm/media.js
+++ b/client-vendor/source/cm/media.js
@@ -12,14 +12,12 @@ var Media = Event.extend({
    * @param {Object} [options]
    * @param {Boolean} [options.loop=false]
    * @param {Boolean} [options.autoplay=false]
-   * @param {String} [options.crossOrigin='anonymous']
    */
   constructor: function(element, options) {
     this._element = element;
     this._options = _.defaults(options || {}, {
       loop: false,
-      autoplay: false,
-      crossOrigin: 'anonymous'
+      autoplay: false
     });
 
     this._sources = [];

--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -507,12 +507,11 @@ var CM_App = CM_Class_Abstract.extend({
      * @param {Object} [options]
      * @param {Boolean} [options.loop=false]
      * @param {Boolean} [options.autoplay=false]
-     * @param {String} [options.crossOrigin='anonymous']
      * @return {Audio}
      */
     createAudio: function(sourceList, options) {
       sourceList = _.isString(sourceList) ? [sourceList] : sourceList;
-      var audio = new cm.lib.Media.Audio(options);
+      var audio = new cm.lib.Media.Audio();
       audio.setOptions(options);
       audio.setSources(sourceList);
       return audio;


### PR DESCRIPTION
Currently we set `crossOrigin` to `anyonymous` when creating new audio or video elements in media.js:
```
    this._options = _.defaults(options || {}, {
      loop: false,
      autoplay: false,
      crossOrigin: 'anonymous'
    });
```

This is useful only when we want to use the created media in a `<canvas>`:
> CORS-enabled resources can be reused in the <canvas> element without being tainted. 
https://developer.mozilla.org/en/docs/Web/HTML/Element/video#Attributes

In all other cases it's better not to set the attribute, otherwise the elements gets tainted (when CORS doesn't match), and can't be played.

I would suggest to *not* set `crossOrigin` by default, and pass it in those cases where we use the element in a `<canvas>`. @zazabe wdyt?