### PR TITLE
Revert "pass page to layout-constructor when switching layouts on ajax-page-load"

### DIFF
--- a/library/CM/Http/Response/View/Abstract.php
+++ b/library/CM/Http/Response/View/Abstract.php
@@ -104,7 +104,7 @@ abstract class CM_Http_Response_View_Abstract extends CM_Http_Response_Abstract 
         $layoutRendering = null;
         $layoutClass = $page->getLayout($this->getRender()->getEnvironment());
         if ($layoutClass !== $currentLayoutClass) {
-            $layout = new $layoutClass(['page' => $page]);
+            $layout = new $layoutClass();
             $layoutRendering = $this->_getComponentRendering($layout);
         }
 


### PR DESCRIPTION
Reverting commit 4bb677bba9900c5fcf4d03f88c1ec59b133b7796 (https://github.com/cargomedia/cm/pull/2463)
Problem discovered in: https://github.com/cargomedia/sk/issues/4332

Not passing the `$page` to the layout that is rendered on the server was done intentionally.
The client will stitch the page rendering and the layout together.

We should fix https://github.com/cargomedia/sk/issues/4274 differently - by *not* accessing the `$page` variable in layout templates.

@zazabe @alexispeter