### PR TITLE
Use standard "ResponsePage::process()" also for "Embed" response

### DIFF
--- a/library/CM/Http/Response/Page/Embed.php
+++ b/library/CM/Http/Response/Page/Embed.php
@@ -26,10 +26,6 @@ class CM_Http_Response_Page_Embed extends CM_Http_Response_Page {
         return $renderAdapterPage->fetch();
     }
 
-    protected function _process() {
-        $this->_processContentOrRedirect();
-    }
-
     public static function createFromRequest(CM_Http_Request_Abstract $request, CM_Site_Abstract $site, CM_Service_Manager $serviceManager) {
         return null;
     }


### PR DESCRIPTION
Addressing https://github.com/cargomedia/sk/issues/3264

Instead of a custom `_process()` implementation for the *embed* page response (ajax navigation), we'll use the standard one:
```php
    protected function _process() {
        $this->setHeaderDisableCache();
        $this->_site->preprocessPageResponse($this);
        $this->_processContentOrRedirect();
        if ($redirectUrl = $this->getRedirectUrl()) {
            $this->setRedirectHeader($redirectUrl);
        }
    }
```

Those headers that are set on the response will be ignored silently by `loadPage()`.
But the call to `preprocessPageResponse()` is important, as the Site might decide to redirect the user elsewhere.

@fauvel please review