### PR TITLE
Log non UTF request variables

### DIFF
--- a/library/CM/Http/Request/Abstract.php
+++ b/library/CM/Http/Request/Abstract.php
@@ -63,7 +63,14 @@ abstract class CM_Http_Request_Abstract {
             }
             $this->_server = array_change_key_case($server);
         }
-        $uri = CM_Util::sanitizeUtf((string) $uri);
+        $uri = (string) $uri;
+        if (!mb_check_encoding($uri, 'UTF-8')) {
+            $logger = CM_Service_Manager::getInstance()->getLogger();
+            $context = new CM_Log_Context();
+            $context->setExtra(['originalUri' => unpack('H*', $uri)[1]]);
+            $logger->warning('Non utf-8 uri', $context);
+        } // TODO remove after investigation
+        $uri = CM_Util::sanitizeUtf($uri);
         $this->setUri($uri);
 
         if ($sessionId = $this->getCookie('sessionId')) {

--- a/library/CM/Http/Request/Abstract.php
+++ b/library/CM/Http/Request/Abstract.php
@@ -64,13 +64,20 @@ abstract class CM_Http_Request_Abstract {
             $this->_server = array_change_key_case($server);
         }
         $uri = (string) $uri;
-        if (!mb_check_encoding($uri, 'UTF-8')) {
+        $originalUri = $uri;
+        $uri = CM_Util::sanitizeUtf($uri);
+
+        try {
+            CM_Util::jsonEncode($uri);
+        } catch (CM_Exception_Invalid $e) {
             $logger = CM_Service_Manager::getInstance()->getLogger();
             $context = new CM_Log_Context();
-            $context->setExtra(['originalUri' => unpack('H*', $uri)[1]]);
+            $context->setExtra([
+                'originalUri'  => unpack('H*', $originalUri)[1],
+                'sanitizedUri' => unpack('H*', $uri)[1],
+            ]);
             $logger->warning('Non utf-8 uri', $context);
         } // TODO remove after investigation
-        $uri = CM_Util::sanitizeUtf($uri);
         $this->setUri($uri);
 
         if ($sessionId = $this->getCookie('sessionId')) {


### PR DESCRIPTION
followup https://github.com/cargomedia/cm/issues/2482

There's a new case :(
```
    [sanitizedFields] => Array
        (
            [code] => 434d5f5574696c2d3e6a736f6e456e636f646528272f702f4e30656d69313030394e30656d6920e75f5fe4b8aae4babae8b55f2e2e2e272c204e554c4c29
            [value] => 272f702f4e30656d69313030394e30656d6920e75f5fe4b8aae4babae8b55fe65f5f202d204675636b626f6f6b27
        )
```

Sanitizing the string *again* makes it work.
I would suggest that we detect this case and log it, *before* sanitizing it.
wdyt?
Could you add the debug code?