### PR TITLE
Always use the language in URLs

### DIFF
--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -205,8 +205,8 @@ var CM_App = CM_Class_Abstract.extend({
     if (type && path) {
       var urlParts = [];
       urlParts.push(type);
-      if (cm.options.urlLanguage) {
-        urlParts.push(cm.options.urlLanguage.abbreviation);
+      if (cm.options.language) {
+        urlParts.push(cm.options.language.abbreviation);
       }
       urlParts.push(cm.getSiteId());
       urlParts.push(cm.options.deployVersion);
@@ -246,8 +246,8 @@ var CM_App = CM_Class_Abstract.extend({
    */
   getUrlAjax: function(type) {
     var path = '/' + type;
-    if (cm.options.urlLanguage) {
-      path += '/' + cm.options.urlLanguage.abbreviation;
+    if (cm.options.language) {
+      path += '/' + cm.options.language.abbreviation;
     }
     return this.getUrl(path);
   },

--- a/library/CM/Frontend/Environment.php
+++ b/library/CM/Frontend/Environment.php
@@ -114,7 +114,16 @@ class CM_Frontend_Environment extends CM_Class_Abstract {
      * @return CM_Model_Language|null
      */
     public function getLanguage() {
-        return $this->_language;
+        $language = $this->_language;
+        if (null === $language) {
+            if ($viewer = $this->getViewer()) {
+                $language = $viewer->getLanguage();
+            }
+            if (null === $language) {
+                $language = CM_Model_Language::findDefault();
+            }
+        }
+        return $language;
     }
 
     /**

--- a/library/CM/Frontend/Render.php
+++ b/library/CM/Frontend/Render.php
@@ -10,9 +10,6 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
     /** @var NumberFormatter */
     private $_formatterCurrency;
 
-    /** @var bool */
-    private $_languageRewrite;
-
     /** @var CM_Menu[] */
     private $_menuList = array();
 
@@ -24,15 +21,14 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
 
     /**
      * @param CM_Frontend_Environment|null $environment
-     * @param boolean|null                 $languageRewrite
      * @param CM_Service_Manager|null      $serviceManager
+     * @internal param bool|null $languageRewrite
      */
-    public function __construct(CM_Frontend_Environment $environment = null, $languageRewrite = null, CM_Service_Manager $serviceManager = null) {
+    public function __construct(CM_Frontend_Environment $environment = null, CM_Service_Manager $serviceManager = null) {
         if (!$environment) {
             $environment = new CM_Frontend_Environment();
         }
         $this->_environment = $environment;
-        $this->_languageRewrite = (bool) $languageRewrite;
         if (null === $serviceManager) {
             $serviceManager = CM_Service_Manager::getInstance();
         }
@@ -228,11 +224,10 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
         /** @var CM_Page_Abstract $pageClassName */
         $path = $pageClassName::getPath($params);
 
-        $languageRewrite = $this->getLanguageRewrite() || $language;
         if (!$language) {
             $language = $this->getLanguage();
         }
-        if ($languageRewrite && $language) {
+        if ($language) {
             $path = '/' . $language->getAbbreviation() . $path;
         }
         return $this->getUrl($path, $site);
@@ -343,29 +338,10 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
     }
 
     /**
-     * @param bool|null $fallbackToDefault
      * @return CM_Model_Language|null
      */
-    public function getLanguage($fallbackToDefault = null) {
-        $language = $this->getEnvironment()->getLanguage();
-
-        if (null === $language && $fallbackToDefault) {
-            if ($viewer = $this->getViewer()) {
-                $language = $viewer->getLanguage();
-            }
-            if (null === $language) {
-                $language = CM_Model_Language::findDefault();
-            }
-        }
-
-        return $language;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getLanguageRewrite() {
-        return $this->_languageRewrite;
+    public function getLanguage() {
+        return $this->getEnvironment()->getLanguage();
     }
 
     /**
@@ -376,7 +352,7 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
     public function getTranslation($key, array $params = null) {
         $params = (array) $params;
         $translation = $key;
-        if ($language = $this->getLanguage(true)) {
+        if ($language = $this->getLanguage()) {
             $translation = $language->getTranslation($key, array_keys($params));
         }
         $translation = $this->_parseVariables($translation, $params);

--- a/library/CM/Frontend/Render.php
+++ b/library/CM/Frontend/Render.php
@@ -22,7 +22,6 @@ class CM_Frontend_Render extends CM_Class_Abstract implements CM_Service_Manager
     /**
      * @param CM_Frontend_Environment|null $environment
      * @param CM_Service_Manager|null      $serviceManager
-     * @internal param bool|null $languageRewrite
      */
     public function __construct(CM_Frontend_Environment $environment = null, CM_Service_Manager $serviceManager = null) {
         if (!$environment) {

--- a/library/CM/Http/Response/Abstract.php
+++ b/library/CM/Http/Response/Abstract.php
@@ -114,7 +114,7 @@ abstract class CM_Http_Response_Abstract extends CM_Class_Abstract implements CM
     public function createRender() {
         $languageRewrite = !$this->getViewer() && $this->getRequest()->getLanguageUrl();
         $environment = $this->getEnvironment();
-        return new CM_Frontend_Render($environment, $languageRewrite, $this->getServiceManager());
+        return new CM_Frontend_Render($environment, $this->getServiceManager());
     }
 
     /**

--- a/library/CM/Http/Response/Page.php
+++ b/library/CM/Http/Response/Page.php
@@ -73,11 +73,6 @@ class CM_Http_Response_Page extends CM_Http_Response_Abstract {
             $path = CM_Util::link($this->_request->getPath(), $this->_request->getQuery());
             $this->redirectUrl($render->getUrl($path, $this->_site));
         }
-        if ($this->_request->getLanguageUrl() && $this->getViewer()) {
-            $path = CM_Util::link($this->_request->getPath(), $this->_request->getQuery());
-            $this->redirectUrl($render->getUrl($path, $this->_site));
-            $this->_request->setLanguageUrl(null);
-        }
         if (!$this->getRedirectUrl()) {
             $html = $this->_processPageLoop($this->getRequest());
             $this->_setContent($html);

--- a/library/CM/RenderAdapter/Document.php
+++ b/library/CM/RenderAdapter/Document.php
@@ -99,9 +99,8 @@ class CM_RenderAdapter_Document extends CM_RenderAdapter_Abstract {
         $options['urlCdn'] = $this->getRender()->getSite()->getUrlCdn();
         $options['urlUserContentList'] = $serviceManager->getUserContent()->getUrlList();
         $options['urlServiceWorker'] = $this->getRender()->getUrlServiceWorker();
-        if ($this->getRender()->getLanguageRewrite()) {
-            $options['urlLanguage'] = $this->getRender()->getLanguage();
-        }
+        $options['urlLanguage'] = $this->getRender()->getLanguage();
+
         $options['debug'] = CM_Bootloader::getInstance()->isDebug();
         $options['stream'] = $serviceManager->getStreamMessage()->getClientOptions();
         if ($viewer = $this->getRender()->getViewer()) {

--- a/library/CM/RenderAdapter/Document.php
+++ b/library/CM/RenderAdapter/Document.php
@@ -99,7 +99,7 @@ class CM_RenderAdapter_Document extends CM_RenderAdapter_Abstract {
         $options['urlCdn'] = $this->getRender()->getSite()->getUrlCdn();
         $options['urlUserContentList'] = $serviceManager->getUserContent()->getUrlList();
         $options['urlServiceWorker'] = $this->getRender()->getUrlServiceWorker();
-        $options['urlLanguage'] = $this->getRender()->getLanguage();
+        $options['language'] = $this->getRender()->getLanguage();
 
         $options['debug'] = CM_Bootloader::getInstance()->isDebug();
         $options['stream'] = $serviceManager->getStreamMessage()->getClientOptions();

--- a/tests/library/CM/Frontend/EnvironmentTest.php
+++ b/tests/library/CM/Frontend/EnvironmentTest.php
@@ -2,6 +2,7 @@
 
 class CM_Frontend_EnvironmentTest extends CMTest_TestCase {
 
+
     public function tearDown() {
         CMTest_TH::clearEnv();
     }
@@ -55,5 +56,11 @@ class CM_Frontend_EnvironmentTest extends CMTest_TestCase {
         $this->assertFalse($environment->hasViewer());
         $environment = new CM_Frontend_Environment(null, CM_Model_User::createStatic());
         $this->assertTrue($environment->hasViewer());
+    }
+
+    public function testDefaultLanguage() {
+        $language = CM_Model_Language::create('English', 'en', true);
+        $environment = new CM_Frontend_Environment();
+        $this->assertEquals($language, $environment->getLanguage());
     }
 }

--- a/tests/library/CM/Frontend/RenderTest.php
+++ b/tests/library/CM/Frontend/RenderTest.php
@@ -2,9 +2,13 @@
 
 class CM_Frontend_RenderTest extends CMTest_TestCase {
 
+    /** @var CM_Model_Language */
+    private $_languageDefault;
+
     protected function setUp() {
         CM_Config::get()->CM_Site_Abstract->url = 'http://www.default.dev';
         CM_Config::get()->CM_Site_Abstract->urlCdn = 'http://cdn.default.dev';
+        $this->_languageDefault = CMTest_TH::createLanguage('en');
     }
 
     public function tearDown() {
@@ -27,13 +31,13 @@ class CM_Frontend_RenderTest extends CMTest_TestCase {
         $render = new CM_Frontend_Render();
         $page = $this->getMockForAbstractClass('CM_Page_Abstract', array(), 'CM_Page_Foo_Bar_FooBar', false);
 
-        $this->assertSame('http://www.default.dev/foo/bar/foo-bar',
+        $this->assertSame('http://www.default.dev/en/foo/bar/foo-bar',
             $render->getUrlPage('CM_Page_Foo_Bar_FooBar'));
-        $this->assertSame('http://www.default.dev/foo/bar/foo-bar',
+        $this->assertSame('http://www.default.dev/en/foo/bar/foo-bar',
             $render->getUrlPage($page));
-        $this->assertSame('http://www.default.dev/foo/bar/foo-bar?userId=15&foo=bar',
+        $this->assertSame('http://www.default.dev/en/foo/bar/foo-bar?userId=15&foo=bar',
             $render->getUrlPage('CM_Page_Foo_Bar_FooBar', array('userId' => 15, 'foo' => 'bar')));
-        $this->assertSame('http://www.default.dev/foo/bar/foo-bar?userId=15&foo=bar',
+        $this->assertSame('http://www.default.dev/en/foo/bar/foo-bar?userId=15&foo=bar',
             $render->getUrlPage($page, array('userId' => 15, 'foo' => 'bar')));
     }
 
@@ -61,41 +65,23 @@ class CM_Frontend_RenderTest extends CMTest_TestCase {
         ));
         $renderSite = new CM_Frontend_Render(new CM_Frontend_Environment($site));
 
-        $this->assertSame('http://www.test.dev/foo/bar/foo-bar',
+        $this->assertSame('http://www.test.dev/en/foo/bar/foo-bar',
             $render->getUrlPage('CM_Page_Foo_Bar_FooBar', null, $site));
-        $this->assertSame('http://www.test.dev/foo/bar/foo-bar',
+        $this->assertSame('http://www.test.dev/en/foo/bar/foo-bar',
             $render->getUrlPage($page, null, $site));
-        $this->assertSame('http://www.test.dev/foo/bar/foo-bar?userId=15&foo=bar',
+        $this->assertSame('http://www.test.dev/en/foo/bar/foo-bar?userId=15&foo=bar',
             $render->getUrlPage('CM_Page_Foo_Bar_FooBar', array('userId' => 15, 'foo' => 'bar'), $site));
-        $this->assertSame('http://www.test.dev/foo/bar/foo-bar?userId=15&foo=bar',
+        $this->assertSame('http://www.test.dev/en/foo/bar/foo-bar?userId=15&foo=bar',
             $render->getUrlPage($page, array('userId' => 15, 'foo' => 'bar'), $site));
 
-        $this->assertSame('http://www.test.dev/foo/bar/foo-bar',
+        $this->assertSame('http://www.test.dev/en/foo/bar/foo-bar',
             $renderSite->getUrlPage('CM_Page_Foo_Bar_FooBar'));
-        $this->assertSame('http://www.test.dev/foo/bar/foo-bar',
+        $this->assertSame('http://www.test.dev/en/foo/bar/foo-bar',
             $renderSite->getUrlPage($page));
-        $this->assertSame('http://www.test.dev/foo/bar/foo-bar?userId=15&foo=bar',
+        $this->assertSame('http://www.test.dev/en/foo/bar/foo-bar?userId=15&foo=bar',
             $renderSite->getUrlPage('CM_Page_Foo_Bar_FooBar', array('userId' => 15, 'foo' => 'bar')));
-        $this->assertSame('http://www.test.dev/foo/bar/foo-bar?userId=15&foo=bar',
+        $this->assertSame('http://www.test.dev/en/foo/bar/foo-bar?userId=15&foo=bar',
             $renderSite->getUrlPage($page, array('userId' => 15, 'foo' => 'bar')));
-    }
-
-    public function testGetUrlPageLanguageRewrite() {
-        $page = $this->getMockForAbstractClass('CM_Page_Abstract', array(), 'CM_Page_Test', false);
-        $baseUrl = 'http://www.default.dev';
-
-        $render = new CM_Frontend_Render();
-        $this->assertSame($baseUrl . '/test', $render->getUrlPage($page));
-        $render = new CM_Frontend_Render(null, true); // This should never happen in application, but lets test it
-        $this->assertSame($baseUrl . '/test', $render->getUrlPage($page));
-
-        $language = CMTest_TH::createLanguage('en');
-
-        $environment = new CM_Frontend_Environment(null, null, $language);
-        $render = new CM_Frontend_Render($environment);
-        $this->assertSame($baseUrl . '/test', $render->getUrlPage($page));
-        $render = new CM_Frontend_Render($environment, true);
-        $this->assertSame($baseUrl . '/en/test', $render->getUrlPage($page));
     }
 
     public function testGetUrlResource() {
@@ -106,9 +92,10 @@ class CM_Frontend_RenderTest extends CMTest_TestCase {
         $this->assertSame('http://cdn.default.dev', $render->getUrlResource('layout'));
         $this->assertSame('http://cdn.default.dev', $render->getUrlResource(null, 'foo/bar.jpg'));
         $this->assertSame(
-            'http://cdn.default.dev/layout/' . $siteType . '/' . $deployVersion . '/foo/bar.jpg', $render->getUrlResource('layout', 'foo/bar.jpg'));
-        $this->assertSame('http://cdn.default.dev/layout/' . $siteType . '/' . $deployVersion . '/0', $render->getUrlResource('layout', '0'));
-        $this->assertSame('http://cdn.default.dev/0/' . $siteType . '/' . $deployVersion . '/foo.jpg', $render->getUrlResource('0', 'foo.jpg'));
+            'http://cdn.default.dev/layout/en/' . $siteType . '/' . $deployVersion .
+            '/foo/bar.jpg', $render->getUrlResource('layout', 'foo/bar.jpg'));
+        $this->assertSame('http://cdn.default.dev/layout/en/' . $siteType . '/' . $deployVersion . '/0', $render->getUrlResource('layout', '0'));
+        $this->assertSame('http://cdn.default.dev/0/en/' . $siteType . '/' . $deployVersion . '/foo.jpg', $render->getUrlResource('0', 'foo.jpg'));
     }
 
     public function testGetUrlResourceSameOrigin() {
@@ -116,7 +103,7 @@ class CM_Frontend_RenderTest extends CMTest_TestCase {
         $siteType = CM_Site_Abstract::factory()->getType();
         $deployVersion = CM_App::getInstance()->getDeployVersion();
         $this->assertSame(
-            'http://www.default.dev/layout/' . $siteType . '/' . $deployVersion . '/foo.jpg',
+            'http://www.default.dev/layout/en/' . $siteType . '/' . $deployVersion . '/foo.jpg',
             $render->getUrlResource('layout', 'foo.jpg', ['sameOrigin' => true])
         );
     }
@@ -130,7 +117,7 @@ class CM_Frontend_RenderTest extends CMTest_TestCase {
         $render = new CM_Frontend_Render(new CM_Frontend_Environment($site));
         $deployVersion = CM_App::getInstance()->getDeployVersion();
         $this->assertSame(
-            'http://www.default.dev/layout/' . $site->getType() . '/' . $deployVersion .
+            'http://www.default.dev/layout/en/' . $site->getType() . '/' . $deployVersion .
             '/foo.jpg', $render->getUrlResource('layout', 'foo.jpg')
         );
     }
@@ -140,7 +127,7 @@ class CM_Frontend_RenderTest extends CMTest_TestCase {
         $site = $this->getMockSite('CM_Site_Abstract', null, ['urlCdn' => 'http://cdn.other.com']);
         $siteType = $site->getType();
         $deployVersion = CM_App::getInstance()->getDeployVersion();
-        $this->assertSame('http://cdn.other.com/layout/' . $siteType . '/' . $deployVersion . '/foo/bar.jpg',
+        $this->assertSame('http://cdn.other.com/layout/en/' . $siteType . '/' . $deployVersion . '/foo/bar.jpg',
             $render->getUrlResource('layout', 'foo/bar.jpg', null, $site));
     }
 
@@ -171,17 +158,14 @@ class CM_Frontend_RenderTest extends CMTest_TestCase {
 
     public function testGetLanguage() {
         $render = new CM_Frontend_Render();
-
-        $this->assertNull($render->getLanguage());
-        $this->assertNull($render->getLanguage(true));
+        $this->assertEquals($this->_languageDefault, $render->getLanguage());
     }
 
     public function testGetLanguageFromDefaultLanguage() {
         $language = CM_Model_Language::create('Test language', 'foo', true);
         $render = new CM_Frontend_Render();
 
-        $this->assertNull($render->getLanguage());
-        $this->assertEquals($language, $render->getLanguage(true));
+        $this->assertEquals($this->_languageDefault, $render->getLanguage());
     }
 
     public function testGetLanguageEnvironmentHasLanguage() {
@@ -190,7 +174,6 @@ class CM_Frontend_RenderTest extends CMTest_TestCase {
         $render = new CM_Frontend_Render($environment);
 
         $this->assertSame($language, $render->getLanguage());
-        $this->assertSame($language, $render->getLanguage(true));
     }
 
     public function testGetLanguageViewerHasLanguage() {
@@ -200,8 +183,7 @@ class CM_Frontend_RenderTest extends CMTest_TestCase {
         $environment = new CM_Frontend_Environment(null, $viewer);
         $render = new CM_Frontend_Render($environment);
 
-        $this->assertNull($render->getLanguage());
-        $this->assertEquals($language, $render->getLanguage(true));
+        $this->assertEquals($language, $render->getLanguage());
     }
 
     public function testGetTranslation() {

--- a/tests/library/CM/Http/Response/PageTest.php
+++ b/tests/library/CM/Http/Response/PageTest.php
@@ -15,33 +15,6 @@ class CM_Http_Response_PageTest extends CMTest_TestCase {
         $this->assertContains('Location: ' . $response->getSite()->getUrl() . '/mock11?count=2', $response->getHeaders());
     }
 
-    public function testProcessLanguageRedirect() {
-        CMTest_TH::createLanguage('en');
-        $viewer = CMTest_TH::createUser();
-        $site = CM_Site_Abstract::factory();
-        $request = new CM_Http_Request_Get('/en/mock5', ['host' => $site->getHost()], null, $viewer);
-        $response = CM_Http_Response_Page::createFromRequest($request, $site, $this->getServiceManager());
-
-        $response->process();
-        $this->assertContains('Location: ' . $site->getUrl() . '/mock5', $response->getHeaders());
-    }
-
-    public function testProcessLanguageRedirect_parameter() {
-        CMTest_TH::createLanguage('en');
-        $viewer = CMTest_TH::createUser();
-        $location = CMTest_TH::createLocation();
-        $locationEncoded = CM_Params::encode($location, true);
-        $query = http_build_query(['location' => $locationEncoded]);
-
-        $site = CM_Site_Abstract::factory();
-        $request = new CM_Http_Request_Get('/en/mock5?' . $query, ['host' => $site->getHost()], null, $viewer);
-        $response = CM_Http_Response_Page::createFromRequest($request, $site, $this->getServiceManager());
-
-        $response->process();
-        $siteUrl = $response->getSite()->getUrl();
-        $this->assertContains('Location: ' . $siteUrl . '/mock5?' . $query, $response->getHeaders());
-    }
-
     public function testProcessLanguageNoRedirect() {
         $language = CMTest_TH::createLanguage('en');
         $site = CM_Site_Abstract::factory();

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -194,7 +194,7 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
         $this->assertSame($site1->getUrl() . CM_Page_View_Ajax_Test_Mock::getPath(), $responseDecoded['success']['data']['redirectExternal']);
     }
 
-    public function testLoadPageRedirectLanguage() {
+    public function testLoadPageNotRedirectLanguage() {
         $site = $this->getMockSite(null, null, ['url' => 'http://my-site.com']);
         CMTest_TH::createLanguage('en');
         $viewer = CMTest_TH::createUser();
@@ -211,7 +211,7 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
 
         $this->assertViewResponseSuccess($response);
         $responseDecoded = CM_Params::jsonDecode($response->getContent());
-        $this->assertSame($site->getUrl() . CM_Page_View_Ajax_Test_Mock::getPath(), $responseDecoded['success']['data']['url']);
+        $this->assertSame($site->getUrl() . '/en' . CM_Page_View_Ajax_Test_Mock::getPath(), $responseDecoded['success']['data']['url']);
     }
 
     public function testLoadPageTracking() {

--- a/tests/library/CM/Mail/MailableTest.php
+++ b/tests/library/CM/Mail/MailableTest.php
@@ -58,7 +58,7 @@ class CM_Mail_MailableTest extends CMTest_TestCase {
 
         $nodeLink = $nodeList->find('a');
         $this->assertSame(1, $nodeLink->count());
-        $this->assertSame('http://www.foo.com/example', $nodeLink->getAttribute('href'));
+        $this->assertSame('http://www.foo.com/foo/example', $nodeLink->getAttribute('href'));
         $this->assertSame('Example Page', $nodeLink->getText());
         $this->assertContains('border-style:solid;', $nodeLink->getAttribute('style'));
     }

--- a/tests/library/CM/View/DocumentTest.php
+++ b/tests/library/CM/View/DocumentTest.php
@@ -2,6 +2,17 @@
 
 class CM_View_DocumentTest extends CMTest_TestCase {
 
+    /** @var CM_Model_Language */
+    private $_languageDefault;
+
+    protected function setUp() {
+        $this->_languageDefault = CMTest_TH::createLanguage('en');
+    }
+
+    public function tearDown() {
+        CMTest_TH::clearEnv();
+    }
+
     public function testRender() {
         $site = $this->getMockSite('CM_Site_Abstract', null, [
             'url'  => 'http://www.my-website.net',
@@ -36,7 +47,7 @@ class CM_View_DocumentTest extends CMTest_TestCase {
     public function testTrackingGuest() {
         $siteMock = $this->getMockSite('CM_Site_Abstract', null, array('url' => 'http://www.example.com'));
         $environment = new CM_Frontend_Environment($siteMock);
-        $render = new CM_Frontend_Render($environment, null, $this->_getServiceManager('ga123', 'km123'));
+        $render = new CM_Frontend_Render($environment, $this->_getServiceManager('ga123', 'km123'));
         $this->getMockForAbstractClass('CM_Layout_Abstract', array(), 'CM_Layout_Default');
         $pageMock = $this->getMockForAbstractClass('CM_Page_Abstract', array(), 'CM_Page_Mock' . uniqid());
         /** @var CM_Page_Abstract $pageMock */
@@ -61,7 +72,7 @@ class CM_View_DocumentTest extends CMTest_TestCase {
         $viewerMock->expects($this->any())->method('getLanguage')->will($this->returnValue(null));
         /** @var CM_Model_User $viewerMock */
         $environment = new CM_Frontend_Environment($site, $viewerMock);
-        $render = new CM_Frontend_Render($environment, null, $this->_getServiceManager('ga123', 'km123'));
+        $render = new CM_Frontend_Render($environment, $this->_getServiceManager('ga123', 'km123'));
         $this->getMockForAbstractClass('CM_Layout_Abstract', array(), 'CM_Layout_Default');
         $pageMock = $this->getMockForAbstractClass('CM_Page_Abstract', array(), 'CM_Page_Mock' . uniqid());
         /** @var CM_Page_Abstract $pageMock */
@@ -78,19 +89,19 @@ class CM_View_DocumentTest extends CMTest_TestCase {
 
     public function testLanguageAlternatives() {
         $site = $this->getMockSite('CM_Site_Abstract', null, array('url' => 'http://www.example.com'));
-        $language1 = CMTest_TH::createLanguage('en');
+        $language1 = CMTest_TH::createLanguage('fr');
         $language2 = CMTest_TH::createLanguage('de');
 
         $environment = new CM_Frontend_Environment($site, null, $language2, null, true);
-        $render = new CM_Frontend_Render($environment, true);
+        $render = new CM_Frontend_Render($environment);
 
         $this->getMockForAbstractClass('CM_Layout_Abstract', array(), 'CM_Layout_Default');
         $page = new CM_Page_Example();
         $renderAdapter = new CM_RenderAdapter_Document($render, $page);
         $html = $renderAdapter->fetch();
 
-        $this->assertContains('<link rel="alternate" href="http://www.example.com/example" hreflang="x-default">', $html);
-        $this->assertContains('<link rel="alternate" href="http://www.example.com/en/example" hreflang="en">', $html);
+        $this->assertContains('<link rel="alternate" href="http://www.example.com/en/example" hreflang="x-default">', $html);
+        $this->assertContains('<link rel="alternate" href="http://www.example.com/fr/example" hreflang="fr">', $html);
         $this->assertContains('<link rel="alternate" href="http://www.example.com/de/example" hreflang="de">', $html);
     }
 


### PR DESCRIPTION
- make the language always available on env, from the url, the user pref or a default one 
- use the language in all URLs
- support edge case, when there's no language defined in `cm_model_language` (in tests only) -> language abbreviation will not be added to URLs