### PR TITLE
Remove obsolete cross-browser code from CM_FormField_Text

### DIFF
--- a/library/CM/FormField/Text.js
+++ b/library/CM/FormField/Text.js
@@ -47,7 +47,6 @@ var CM_FormField_Text = CM_FormField_Abstract.extend({
   },
 
   enableTriggerChangeOnInput: function() {
-    // `propertychange` and `keyup` needed for IE9
-    this.getInput().on('input propertychange keyup', _.bind(this.triggerChange, this));
+    this.getInput().on('input', _.bind(this.triggerChange, this));
   }
 });


### PR DESCRIPTION
```js
  enableTriggerChangeOnInput: function() {
    // `propertychange` and `keyup` needed for IE9
    this.getInput().on('input propertychange keyup', _.bind(this.triggerChange, this));
  }
```