### PR TITLE
Invalid request method: PROPFIND

### DIFF
--- a/library/CM/Http/Request/Abstract.php
+++ b/library/CM/Http/Request/Abstract.php
@@ -685,7 +685,7 @@ abstract class CM_Http_Request_Abstract {
         if ($method === 'options') {
             return new CM_Http_Request_Options($uri, $headers, $server);
         }
-        throw new CM_Exception_Invalid('Invalid request method', null, ['method' => $method]);
+        throw new CM_Exception_Invalid('Invalid request method', CM_Exception::WARN, ['method' => $method]);
     }
 
     /**


### PR DESCRIPTION
We get HTTP requests with method `PROPFIND`.
This should be treated as a warning, because it's a result of invalid/unsupported input.

```
#0 /home/example/releases/20170116132117/vendor/cargomedia/cm/library/CM/Http/Request/Abstract.php(688): {throw}
#1 /home/example/releases/20170116132117/vendor/cargomedia/cm/library/CM/Http/Request/Abstract.php(715): CM_Http_Request_Abstract->factory('PROPFIND', '/', [], [], '')
#2 /home/example/releases/20170116132117/public/index.php(8): CM_Http_Request_Abstract->factoryFromGlobals()
#3 /home/example/releases/20170116132117/vendor/cargomedia/cm/library/CM/Bootloader.php(163): {closure}()
#4 /home/example/releases/20170116132117/public/index.php(11): CM_Bootloader->execute(Closure)
#5 /home/example/serve/public/index.php(0): {main}
```