### PR TITLE
FB-99 Introduce service definitions

### DIFF
--- a/library/CM/Bootloader.php
+++ b/library/CM/Bootloader.php
@@ -195,7 +195,7 @@ class CM_Bootloader {
             'adapter' => new CM_File_Filesystem_Adapter_Local($this->getDirTmp())
         ]);
         foreach (CM_Config::get()->services as $serviceKey => $serviceDefinition) {
-            $serviceManager->registerWithArray($serviceKey, $serviceDefinition);
+            $serviceManager->registerDefinition($serviceKey, $serviceDefinition);
         }
     }
 

--- a/library/CM/Service/AbstractDefinition.php
+++ b/library/CM/Service/AbstractDefinition.php
@@ -1,0 +1,21 @@
+<?php
+
+abstract class CM_Service_AbstractDefinition {
+
+    /** @var string[] */
+    private $_subscriptions;
+
+    /**
+     * @param string $serviceName
+     */
+    public function subscribeTo($serviceName) {
+        $this->_subscriptions[] = $serviceName;
+    }
+
+    /**
+     * @param CM_Service_Manager $serviceManager
+     * @return mixed
+     */
+    abstract public function createInstance(CM_Service_Manager $serviceManager);
+    
+}

--- a/library/CM/Service/AbstractDefinition.php
+++ b/library/CM/Service/AbstractDefinition.php
@@ -30,6 +30,9 @@ abstract class CM_Service_AbstractDefinition {
     public function get(CM_Service_Manager $serviceManager) {
         if (null === $this->_instance) {
             $this->_instance = $this->createInstance($serviceManager);
+            if ($this->_instance instanceof CM_Service_ManagerAwareInterface) {
+                $this->_instance->setServiceManager($serviceManager);
+            }
             $this->trigger('create', $this->_instance);
         }
         return $this->_instance;

--- a/library/CM/Service/AbstractDefinition.php
+++ b/library/CM/Service/AbstractDefinition.php
@@ -2,20 +2,53 @@
 
 abstract class CM_Service_AbstractDefinition {
 
-    /** @var string[] */
-    private $_subscriptions;
+    use CM_EventHandler_EventHandlerTrait;
 
-    /**
-     * @param string $serviceName
-     */
-    public function subscribeTo($serviceName) {
-        $this->_subscriptions[] = $serviceName;
-    }
+    /** @var mixed|null */
+    private $_instance;
 
     /**
      * @param CM_Service_Manager $serviceManager
      * @return mixed
      */
     abstract public function createInstance(CM_Service_Manager $serviceManager);
-    
+
+    /**
+     * @param callable $callback
+     */
+    public function onCreate(callable $callback) {
+        $this->bind('create', $callback);
+        if ($this->hasInstance()) {
+            $callback($this->_instance);
+        }
+    }
+
+    /**
+     * @param CM_Service_Manager $serviceManager
+     * @return mixed
+     */
+    public function get(CM_Service_Manager $serviceManager) {
+        if (null === $this->_instance) {
+            $this->_instance = $this->createInstance($serviceManager);
+            $this->trigger('create', $this->_instance);
+        }
+        return $this->_instance;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasInstance() {
+        return null !== $this->_instance;
+    }
+
+    public function resetInstance() {
+        $this->_instance = null;
+    }
+
+    /**
+     * @param CM_Service_Manager $serviceManager
+     */
+    public function register(CM_Service_Manager $serviceManager) {
+    }
 }

--- a/library/CM/Service/AbstractNoInstanceDefinition.php
+++ b/library/CM/Service/AbstractNoInstanceDefinition.php
@@ -1,0 +1,9 @@
+<?php
+
+class CM_Service_AbstractNoInstanceDefinition extends CM_Service_AbstractDefinition {
+
+    public function createInstance(CM_Service_Manager $serviceManager) {
+        return null;
+    }
+
+}

--- a/library/CM/Service/AbstractNoInstanceDefinition.php
+++ b/library/CM/Service/AbstractNoInstanceDefinition.php
@@ -1,6 +1,6 @@
 <?php
 
-class CM_Service_AbstractNoInstanceDefinition extends CM_Service_AbstractDefinition {
+abstract class CM_Service_AbstractNoInstanceDefinition extends CM_Service_AbstractDefinition {
 
     public function createInstance(CM_Service_Manager $serviceManager) {
         return null;

--- a/library/CM/Service/ConfigDefinition.php
+++ b/library/CM/Service/ConfigDefinition.php
@@ -70,12 +70,4 @@ class CM_Service_ConfigDefinition extends CM_Service_AbstractDefinition {
             ]);
         }
     }
-
-    public function serialize() {
-        return $this->_config;
-    }
-
-    public function unserialize($serialized) {
-        $this->_config = $serialized;
-    }
 }

--- a/library/CM/Service/ConfigDefinition.php
+++ b/library/CM/Service/ConfigDefinition.php
@@ -1,0 +1,81 @@
+<?php
+
+class CM_Service_ConfigDefinition extends CM_Service_AbstractDefinition {
+
+    /** @var array */
+    private $_config;
+
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config) {
+        $class = (string) $config['class'];
+        $arguments = [];
+        if (isset($config['arguments'])) {
+            $arguments = (array) $config['arguments'];
+        }
+        $method = null;
+        if (isset($config['method'])) {
+            $methodName = (string) $config['method']['name'];
+            $methodArguments = [];
+            if (isset($config['method']['arguments'])) {
+                $methodArguments = (array) $config['method']['arguments'];
+            }
+            $method = ['name' => $methodName, 'arguments' => $methodArguments];
+        }
+
+        $this->_config = [
+            'class'     => $class,
+            'arguments' => $arguments,
+            'method'    => $method,
+        ];
+    }
+
+    public function createInstance(CM_Service_Manager $serviceManager) {
+        $config = $this->_config;
+        $reflection = new ReflectionClass($config['class']);
+
+        $arguments = $config['arguments'];
+        if ($constructor = $reflection->getConstructor()) {
+            $arguments = $this->_matchNamedArgs($constructor, $arguments);
+        }
+        $instance = $reflection->newInstanceArgs($arguments);
+
+        if ($instance instanceof CM_Service_ManagerAwareInterface) {
+            $instance->setServiceManager($serviceManager);
+        }
+
+        if (null !== $config['method']) {
+            $method = $reflection->getMethod($config['method']['name']);
+            $methodArguments = $this->_matchNamedArgs($method, $config['method']['arguments']);
+            $instance = $method->invokeArgs($instance, $methodArguments);
+        }
+
+        return $instance;
+    }
+
+    /**
+     * @param ReflectionMethod $method
+     * @param array            $arguments
+     * @throws CM_Exception_Invalid
+     * @return array
+     */
+    protected function _matchNamedArgs(ReflectionMethod $method, array $arguments) {
+        $namedArgs = new CM_Util_NamedArgs();
+        try {
+            return $namedArgs->matchNamedArgs($method, $arguments);
+        } catch (CM_Exception_Invalid $e) {
+            throw new CM_Exception_Invalid('Cannot match arguments for service', null, [
+                'originalExceptionMessage' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    public function serialize() {
+        return $this->_config;
+    }
+
+    public function unserialize($serialized) {
+        $this->_config = $serialized;
+    }
+}

--- a/library/CM/Service/InstanceWrapperDefinition.php
+++ b/library/CM/Service/InstanceWrapperDefinition.php
@@ -1,0 +1,19 @@
+<?php
+
+class CM_Service_InstanceWrapperDefinition extends CM_Service_AbstractDefinition {
+
+    /** @var mixed */
+    private $_instance;
+
+    /**
+     * @param mixed $instance
+     */
+    public function __construct($instance) {
+        $this->_instance = $instance;
+    }
+
+    public function createInstance(CM_Service_Manager $serviceManager) {
+        return $this->_instance;
+    }
+
+}


### PR DESCRIPTION
*This is continuation of the research day topic.*

Instead of using quite stubborn way of defining services via configuration array I propose to configure them with Definition objects. 

- This will convert all the factory objects we have into service definition files. 
- It will also allow to depend services on each other without instantiating them.
- There is small overhead for creating object instead of array items. 

*Still able to use old-style config arrays.*

Example:
```php
    $config->services['mysql'] = new CM_Mysql_ServiceDefinition('localhost', 3306);
    
    $config->services['logger'] = new CM_Logger_ServiceDefinition([
        'mysql' => $config->services['mysql'],
    ]);
```