### PR TITLE
Avoid migration script execution after an app setup

### DIFF
--- a/library/CM/Db/SetupScript.php
+++ b/library/CM/Db/SetupScript.php
@@ -15,6 +15,7 @@ class CM_Db_SetupScript extends CM_Provision_Script_Abstract implements CM_Provi
             CM_Db_Db::runDump($databaseName, $dump);
         }
         $this->_setInitialVersion();
+        $this->_setInitialMigrationScripts();
     }
 
     public function unload(CM_OutputStream_Interface $output) {
@@ -53,6 +54,20 @@ class CM_Db_SetupScript extends CM_Provision_Script_Abstract implements CM_Provi
                 return max($initial, (int) $filename);
             }, 0);
             $app->setVersion($version, $namespace);
+        }
+    }
+
+    private function _setInitialMigrationScripts() {
+        $modules = CM_Bootloader::getInstance()->getModules();
+        $manager = new CM_Migration_Manager($this->getServiceManager(), $modules);
+        $loader = $manager->getLoader();
+        foreach ($loader->getRunnerList() as $runner) {
+            $name = $runner->getName();
+            $record = CM_Migration_Model::findByName($name);
+            if (!$record) {
+                $record = CM_Migration_Model::create($name);
+            }
+            $record->setExecutedAt(new DateTime());
         }
     }
 }

--- a/library/CM/Migration/Cli.php
+++ b/library/CM/Migration/Cli.php
@@ -4,10 +4,12 @@ class CM_Migration_Cli extends CM_Cli_Runnable_Abstract {
 
     /**
      * @param string|null $name
+     * @throws CM_Exception_Invalid
      */
     public function run($name = null) {
-        $paths = $this->_getMigrationPaths();
-        $loader = new CM_Migration_Loader($this->getServiceManager(), $paths);
+        $modules = CM_Bootloader::getInstance()->getModules();
+        $manager = new CM_Migration_Manager($this->getServiceManager(), $modules);
+        $loader = $manager->getLoader();
         if (null === $name) {
             foreach ($loader->getRunnerList() as $runner) {
                 if ($runner->shouldBeLoaded()) {
@@ -53,26 +55,6 @@ class CM_Migration_Cli extends CM_Cli_Runnable_Abstract {
         }
         $output->writeln("…");
         $runner->load($output);
-    }
-
-    /**
-     * @return array
-     */
-    protected function _getMigrationPaths() {
-        $paths = [];
-        foreach (CM_Bootloader::getInstance()->getModules() as $moduleName) {
-            $paths[] = $this->_getMigrationPathByModule($moduleName);
-        }
-        return $paths;
-    }
-
-    /**
-     * @param string|null $moduleName
-     * @return string
-     */
-    protected function _getMigrationPathByModule($moduleName = null) {
-        $modulePath = null !== $moduleName ? CM_Util::getModulePath((string) $moduleName) : DIR_ROOT;
-        return join(DIRECTORY_SEPARATOR, [$modulePath, 'resources', 'migration']);
     }
 
     public static function getPackageName() {

--- a/library/CM/Migration/Manager.php
+++ b/library/CM/Migration/Manager.php
@@ -1,0 +1,47 @@
+<?php
+
+class CM_Migration_Manager implements CM_Service_ManagerAwareInterface {
+
+    use CM_Service_ManagerAwareTrait;
+
+    /** @var string[] */
+    private $_modules;
+
+    /**
+     * @param CM_Service_Manager $serviceManager
+     * @param string[]           $modules
+     */
+    public function __construct(CM_Service_Manager $serviceManager, array $modules) {
+        $this->setServiceManager($serviceManager);
+        $this->_modules = $modules;
+    }
+
+    /**
+     * @return CM_Migration_Loader
+     */
+    public function getLoader() {
+        return new CM_Migration_Loader($this->getServiceManager(), $this->_getMigrationPaths());
+    }
+
+    /**
+     * @return array
+     */
+    protected function _getMigrationPaths() {
+        $paths = [
+            $this->_getMigrationPathByModule(),
+        ];
+        foreach ($this->_modules as $moduleName) {
+            $paths[] = $this->_getMigrationPathByModule($moduleName);
+        }
+        return $paths;
+    }
+
+    /**
+     * @param string|null $moduleName
+     * @return string
+     */
+    protected function _getMigrationPathByModule($moduleName = null) {
+        $modulePath = null !== $moduleName ? CM_Util::getModulePath((string) $moduleName) : DIR_ROOT;
+        return join(DIRECTORY_SEPARATOR, [$modulePath, 'resources', 'migration']);
+    }
+}


### PR DESCRIPTION
Part of https://github.com/cargomedia/cm/issues/2403

same than with db updates currently, see https://github.com/cargomedia/cm/blob/master/library/CM/Db/SetupScript.php#L47