### PR TITLE
Allow to pass metaInfo to client exception

### DIFF
--- a/library/CM/App.js
+++ b/library/CM/App.js
@@ -942,7 +942,7 @@ var CM_App = CM_Class_Abstract.extend({
             cm.router.forceReload();
           }
           if (response.error) {
-            reject(new (CM_Exception.factory(response.error.type))(response.error.msg, response.error.isPublic));
+            reject(new (CM_Exception.factory(response.error.type))(response.error.msg, response.error.isPublic, response.error.metaInfo));
           } else {
             resolve(cm.factory.create(response.success));
           }

--- a/library/CM/Exception.php
+++ b/library/CM/Exception.php
@@ -34,6 +34,19 @@ class CM_Exception extends Exception {
 
     /**
      * @param CM_Frontend_Render $render
+     * @return array
+     */
+    public function getClientData(CM_Frontend_Render $render) {
+        return [
+            'type'     => get_class($this),
+            'msg'      => $this->getMessagePublic($render),
+            'isPublic' => $this->isPublic(),
+            'metaInfo' => [],
+        ];
+    }
+
+    /**
+     * @param CM_Frontend_Render $render
      * @return string
      */
     public function getMessagePublic(CM_Frontend_Render $render) {

--- a/library/CM/Http/Response/View/Abstract.php
+++ b/library/CM/Http/Response/View/Abstract.php
@@ -184,7 +184,7 @@ abstract class CM_Http_Response_View_Abstract extends CM_Http_Response_Abstract 
         $this->_runWithCatching(function () use (&$output) {
             $output = $this->_processView($output);
         }, function (CM_Exception $e, array $errorOptions) use (&$output) {
-            $output['error'] = array('type' => get_class($e), 'msg' => $e->getMessagePublic($this->getRender()), 'isPublic' => $e->isPublic());
+            $output['error'] = $e->getClientData($this->getRender());
         });
         $output['deployVersion'] = CM_App::getInstance()->getDeployVersion();
 

--- a/tests/library/CM/ExceptionTest.php
+++ b/tests/library/CM/ExceptionTest.php
@@ -4,7 +4,7 @@ class CM_ExceptionTest extends CMTest_TestCase {
 
     public function testConstructor() {
         $user = CMTest_TH::createUser();
-        $metaInfo = array('meta' => 'foo', 'user' => $user);
+        $metaInfo = ['meta' => 'foo', 'user' => $user];
         $severity = CM_Exception::ERROR;
         $exception = new CM_Exception('foo', $severity, $metaInfo, [
             'messagePublic' => new CM_I18n_Phrase('foo {$bar}', ['bar' => 'foo']),
@@ -43,5 +43,21 @@ class CM_ExceptionTest extends CMTest_TestCase {
             $this->assertSame('Invalid severity', $e->getMessage());
             $this->assertSame(['severity' => '1'], $e->getMetaInfo());
         }
+    }
+
+    public function testGetClientData() {
+        $render = new CM_Frontend_Render();
+        $exception = new CM_Exception('foo', null, ['foo' => 'bar'], [
+            'messagePublic' => new CM_I18n_Phrase('foo {$bar}', ['bar' => 'foo']),
+        ]);
+
+        $expectedData = [
+            'type'     => get_class($exception),
+            'msg'      => $exception->getMessagePublic($render),
+            'isPublic' => $exception->isPublic(),
+            'metaInfo' => [],
+        ];
+
+        $this->assertSame($expectedData, $exception->getClientData($render));
     }
 }


### PR DESCRIPTION
This is in order to be able to pass params to the client using metaInfo when needed. Currently results in empty object.