### PR TITLE
Follow-up: #2527. Allow to pass metaInfo to client exception.

### DIFF
--- a/library/CM/Http/Response/RPC.php
+++ b/library/CM/Http/Response/RPC.php
@@ -3,7 +3,7 @@
 class CM_Http_Response_RPC extends CM_Http_Response_Abstract {
 
     protected function _process() {
-        $output = array();
+        $output = [];
         $this->_runWithCatching(function () use (&$output) {
             $query = CM_Params::factory($this->_request->getQuery());
 
@@ -15,9 +15,9 @@ class CM_Http_Response_RPC extends CM_Http_Response_Abstract {
             $function = $matches['function'];
             $params = $query->getArray('params');
 
-            $output['success'] = array('result' => call_user_func_array(array($class, 'rpc_' . $function), $params));
+            $output['success'] = ['result' => call_user_func_array([$class, 'rpc_' . $function], $params)];
         }, function (CM_Exception $e) use (&$output) {
-            $output['error'] = array('type' => get_class($e), 'msg' => $e->getMessagePublic($this->getRender()), 'isPublic' => $e->isPublic());
+            $output['error'] = $e->getClientData($this->getRender());
         });
 
         $output['deployVersion'] = CM_App::getInstance()->getDeployVersion();

--- a/tests/library/CM/Http/Response/RPCTest.php
+++ b/tests/library/CM/Http/Response/RPCTest.php
@@ -40,6 +40,7 @@ class CM_Http_Response_RPCTest extends CMTest_TestCase {
             'type'     => 'CM_Exception_Invalid',
             'msg'      => 'bar',
             'isPublic' => true,
+            'metaInfo' => [],
         ], $responseData['error']);
 
         $request->mockMethod('getQuery')->set(function () {
@@ -53,7 +54,8 @@ class CM_Http_Response_RPCTest extends CMTest_TestCase {
         $this->assertSame([
             'type'     => 'CM_Exception_Nonexistent',
             'msg'      => 'Internal server error',
-            'isPublic' => false
+            'isPublic' => false,
+            'metaInfo' => [],
         ], $responseData['error']);
     }
 
@@ -69,6 +71,7 @@ class CM_Http_Response_RPCTest extends CMTest_TestCase {
             'type'     => 'CM_Exception_InvalidParam',
             'msg'      => 'Internal server error',
             'isPublic' => false,
+            'metaInfo' => [],
         ], $responseData['error']);
     }
 
@@ -84,6 +87,7 @@ class CM_Http_Response_RPCTest extends CMTest_TestCase {
             'type'     => 'CM_Exception_InvalidParam',
             'msg'      => 'Internal server error',
             'isPublic' => false,
+            'metaInfo' => [],
         ], $responseData['error']);
     }
 


### PR DESCRIPTION
Using `getClientData()` in `CM_Http_Response_RPC` as well.