### PR TITLE
add primary key to `cm_action` table

### DIFF
--- a/resources/db/structure.sql
+++ b/resources/db/structure.sql
@@ -4,6 +4,7 @@ DROP TABLE IF EXISTS `cm_action`;
 
 
 CREATE TABLE `cm_action` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `actorId` int(10) unsigned DEFAULT NULL,
   `ip` int(10) unsigned DEFAULT NULL,
   `verb` tinyint(3) DEFAULT NULL,
@@ -12,6 +13,7 @@ CREATE TABLE `cm_action` (
   `createStamp` int(10) unsigned NOT NULL,
   `count` int(10) unsigned DEFAULT '1',
   `interval` int(10) unsigned NOT NULL DEFAULT '1',
+  PRIMARY KEY (`id`),
   KEY `actorId` (`actorId`),
   KEY `ip` (`ip`),
   KEY `action` (`verb`),

--- a/resources/db/update/79.php
+++ b/resources/db/update/79.php
@@ -1,6 +1,5 @@
 <?php
 
-return;
 //pt-online-schema-change doesn't work here
 
 if (!CM_Db_Db::existsColumn('cm_action', 'id')) {

--- a/resources/db/update/79.php
+++ b/resources/db/update/79.php
@@ -1,0 +1,8 @@
+<?php
+
+return;
+//pt-online-schema-change doesn't work here
+
+if (!CM_Db_Db::existsColumn('cm_action', 'id')) {
+    CM_Db_Db::exec("ALTER TABLE `cm_action` ADD COLUMN `id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST;");
+}


### PR DESCRIPTION
pt-online-schema-change does not work with tables without primary or unique keys