### PR TITLE
Use different client/server side component reload methods

### DIFF
--- a/library/CM/Component/Abstract.js
+++ b/library/CM/Component/Abstract.js
@@ -80,10 +80,23 @@ var CM_Component_Abstract = CM_View_Abstract.extend({
   },
 
   /**
+   * @param {Object} [params]
+   * @param {Object} [options]
    * @return Promise
    */
-  reload: function(params) {
-    return this.reloadComponent(params);
+  reload: function(params, options) {
+    options = _.defaults(options || {}, {
+      'modal': true,
+      'method': 'reloadComponent'
+    });
+    params = params || {};
+    return this
+      .try(function() {
+        return this.ajax(options.method, params, options);
+      })
+      .then(function(response) {
+        return this._replaceView(response);
+      });
   },
 
   /**

--- a/library/CM/Component/Abstract.js
+++ b/library/CM/Component/Abstract.js
@@ -83,7 +83,7 @@ var CM_Component_Abstract = CM_View_Abstract.extend({
    * @return Promise
    */
   reload: function(params) {
-    return this.ajaxModal('reloadComponent', params);
+    return this.reloadComponent(params);
   },
 
   /**

--- a/library/CM/Component/Abstract.php
+++ b/library/CM/Component/Abstract.php
@@ -15,4 +15,8 @@ abstract class CM_Component_Abstract extends CM_View_Abstract implements CM_View
     protected function _checkViewer(CM_Frontend_Environment $environment) {
         $environment->getViewer(true);
     }
+
+    public function ajax_reloadComponent(CM_Params $params, CM_Frontend_JavascriptContainer_View $handler, CM_Http_Response_View_Ajax $response) {
+        return $response->loadComponent(static::class, $this->getParams()->merge($params));
+    }
 }

--- a/library/CM/Component/Abstract.php
+++ b/library/CM/Component/Abstract.php
@@ -17,8 +17,11 @@ abstract class CM_Component_Abstract extends CM_View_Abstract implements CM_View
     }
 
     public function ajax_reloadComponent(CM_Params $params, CM_Frontend_JavascriptContainer_View $handler, CM_Http_Response_View_Ajax $response) {
-        foreach ($this->getParams()->getParamsDecoded() as $key => $value) {
-            $params->set($key, $value);
+        $componentParams = $this->getParams();
+        foreach ($componentParams->getParamNames() as $key) {
+            if (!$params->has($key)) {
+                $params->set($key, $componentParams->get($key));
+            }
         }
         return $response->loadComponent(static::class, $params);
     }

--- a/library/CM/Component/Abstract.php
+++ b/library/CM/Component/Abstract.php
@@ -17,6 +17,9 @@ abstract class CM_Component_Abstract extends CM_View_Abstract implements CM_View
     }
 
     public function ajax_reloadComponent(CM_Params $params, CM_Frontend_JavascriptContainer_View $handler, CM_Http_Response_View_Ajax $response) {
-        $response->reloadComponent($params->getParamsDecoded());
+        foreach ($this->getParams()->getParamsDecoded() as $key => $value) {
+            $params->set($key, $value);
+        }
+        return $response->loadComponent(static::class, $params);
     }
 }

--- a/library/CM/Component/Abstract.php
+++ b/library/CM/Component/Abstract.php
@@ -15,14 +15,4 @@ abstract class CM_Component_Abstract extends CM_View_Abstract implements CM_View
     protected function _checkViewer(CM_Frontend_Environment $environment) {
         $environment->getViewer(true);
     }
-
-    public function ajax_reloadComponent(CM_Params $params, CM_Frontend_JavascriptContainer_View $handler, CM_Http_Response_View_Ajax $response) {
-        $componentParams = $this->getParams();
-        foreach ($componentParams->getParamNames() as $key) {
-            if (!$params->has($key)) {
-                $params->set($key, $componentParams->get($key));
-            }
-        }
-        return $response->loadComponent(static::class, $params);
-    }
 }

--- a/library/CM/Frontend/GlobalResponse.php
+++ b/library/CM/Frontend/GlobalResponse.php
@@ -191,7 +191,7 @@ class CM_Frontend_GlobalResponse {
         $view = $viewResponse->getView();
         $code = $reference . ' = new ' . get_class($view) . '({';
         $code .= 'el:$("#' . $viewResponse->getAutoId() . '").get(0),';
-        $code .= 'params:' . CM_Params::jsonEncode($view->getParams()->getParamsEncoded());
+        $code .= 'params:' . CM_Util::jsonEncode($view->getParams()->getParamsEncoded());
         if (!$node->isRoot()) {
             $code .= ',parent: cm.views["' . $node->getParent()->getValue()->getAutoId() . '"]';
         }

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -53,10 +53,7 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
      * @return CM_Params
      */
     public function merge(CM_Params $params) {
-        $new = static::factory([]);
-        foreach ($this->getParamsDecoded() as $key => $value) {
-            $new->set($key, $value);
-        }
+        $new = static::factory($this->getParamsDecoded(), false);
         foreach ($params->getParamsDecoded() as $key => $value) {
             $new->set($key, $value);
         }

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -49,6 +49,21 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
     }
 
     /**
+     * @param CM_Params $params
+     * @return CM_Params
+     */
+    public function merge(CM_Params $params) {
+        $new = static::factory([]);
+        foreach ($this->getParamsDecoded() as $key => $value) {
+            $new->set($key, $value);
+        }
+        foreach ($params->getParamsDecoded() as $key => $value) {
+            $new->set($key, $value);
+        }
+        return $new;
+    }
+
+    /**
      * @return array
      */
     public function getParamsDecoded() {

--- a/library/CM/View/Abstract.js
+++ b/library/CM/View/Abstract.js
@@ -297,26 +297,6 @@ var CM_View_Abstract = Backbone.View.extend({
   },
 
   /**
-   * @param {Object} [params]
-   * @param {Object} [options]
-   * @return Promise
-   */
-  reloadComponent: function(params, options) {
-    options = _.defaults(options || {}, {
-      'modal': true,
-      'method': 'reloadComponent'
-    });
-    params = params || {};
-    return this
-      .try(function() {
-        return this.ajax(options.method, params, options);
-      })
-      .then(function(response) {
-        return this._replaceView(response);
-      });
-  },
-
-  /**
    * @param {String} className
    * @param {Object} [params]
    * @param {Object} [options]

--- a/library/CM/View/Abstract.php
+++ b/library/CM/View/Abstract.php
@@ -23,10 +23,6 @@ abstract class CM_View_Abstract extends CM_Class_Abstract {
         return $this->_params;
     }
 
-    public function ajax_reloadComponent(CM_Params $params, CM_Frontend_JavascriptContainer_View $handler, CM_Http_Response_View_Ajax $response) {
-        return $response->loadComponent(static::class, $this->getParams()->merge($params));
-    }
-
     public function ajax_loadComponent(CM_Params $params, CM_Frontend_JavascriptContainer_View $handler, CM_Http_Response_View_Ajax $response) {
         $className = $params->getString('className');
         $params->remove('className');

--- a/library/CM/View/Abstract.php
+++ b/library/CM/View/Abstract.php
@@ -23,6 +23,10 @@ abstract class CM_View_Abstract extends CM_Class_Abstract {
         return $this->_params;
     }
 
+    public function ajax_reloadComponent(CM_Params $params, CM_Frontend_JavascriptContainer_View $handler, CM_Http_Response_View_Ajax $response) {
+        return $response->loadComponent(static::class, $this->getParams()->merge($params));
+    }
+
     public function ajax_loadComponent(CM_Params $params, CM_Frontend_JavascriptContainer_View $handler, CM_Http_Response_View_Ajax $response) {
         $className = $params->getString('className');
         $params->remove('className');

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -288,7 +288,7 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
 
         $jsonResponse = CM_Util::jsonDecode($response->getContent());
 
-        // can't get the autoId from the globalResponse because of https://github.com/cargomedia/cm/blob/master/library/CM/Http/Response/View/Abstract.php#L135
+        // no better way to get the autoId because Response::_getComponentRendering() creates a new Render instance
         $autoId = $jsonResponse['success']['data']['autoId'];
         $js = sprintf('cm.views["%s"] = new CM_Component_Notfound({el:$("#%s").get(0),params:{"foo":"bar"}});', $autoId, $autoId);
         $html = sprintf("<div id=\"%s\" class=\"CM_Component_Notfound CM_Component_Abstract CM_View_Abstract\">Sorry, this page was not found. It has been removed or never existed.\n</div>", $autoId);
@@ -312,9 +312,9 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
 
         $jsonResponse = CM_Util::jsonDecode($response->getContent());
 
-        // can't get the autoId from the globalResponse because of https://github.com/cargomedia/cm/blob/master/library/CM/Http/Response/View/Abstract.php#L135
+        // no better way to get the autoId because Response::_getComponentRendering() creates a new Render instance
         $autoId = $jsonResponse['success']['data']['autoId'];
-        $js = sprintf('cm.views["%s"] = new CM_Component_Mock({el:$("#%s").get(0),params:{"foz":"toto","entity":{"_class":"CM_Model_Entity_Mock2","_type":123,"_id":{"id":"1"},"id":1,"path":null},"foo":"bar"}});', $autoId, $autoId);
+        $js = sprintf('cm.views["%s"] = new CM_Component_Mock({el:$("#%s").get(0),params:{"entity":{"_class":"CM_Model_Entity_Mock2","_type":123,"_id":{"id":"1"},"id":1,"path":null},"foo":"bar","foz":"toto"}});', $autoId, $autoId);
         $html = sprintf("<div id=\"%s\" class=\"CM_Component_Mock CM_Component_Notfound CM_Component_Abstract CM_View_Abstract\">Sorry, this page was not found. It has been removed or never existed.\n</div>", $autoId);
         $this->assertSame($js, $jsonResponse['success']['data']['js']);
         $this->assertSame($html, $jsonResponse['success']['data']['html']);

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -303,9 +303,9 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
         $config->CM_Model_Entity_Mock2 = new stdClass();
         $config->CM_Model_Entity_Mock2->type = CM_Model_Entity_Mock2::getTypeStatic();
 
-        $component = new CM_Component_Mock();
+        $component = new CM_Component_Mock(['entity' => $entity, 'foo' => 'bar', 'foz' => 'baz']);
         $viewResponse = new CM_Frontend_ViewResponse($component);
-        $request = $this->createRequestAjax($component, 'reloadComponent', ['entity' => $entity], $viewResponse);
+        $request = $this->createRequestAjax($component, 'reloadComponent', ['foz' => 'toto'], $viewResponse);
         /** @var CM_Http_Response_View_Abstract $response */
         $response = $this->processRequest($request);
         $this->assertViewResponseSuccess($response);
@@ -314,7 +314,7 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
 
         // can't get the autoId from the globalResponse because of https://github.com/cargomedia/cm/blob/master/library/CM/Http/Response/View/Abstract.php#L135
         $autoId = $jsonResponse['success']['data']['autoId'];
-        $js = sprintf('cm.views["%s"] = new CM_Component_Mock({el:$("#%s").get(0),params:{"entity":{"id":1,"path":null}}});', $autoId, $autoId);
+        $js = sprintf('cm.views["%s"] = new CM_Component_Mock({el:$("#%s").get(0),params:{"foz":"toto","entity":{"_class":"CM_Model_Entity_Mock2","_type":123,"_id":{"id":"1"},"id":1,"path":null},"foo":"bar"}});', $autoId, $autoId);
         $html = sprintf("<div id=\"%s\" class=\"CM_Component_Mock CM_Component_Notfound CM_Component_Abstract CM_View_Abstract\">Sorry, this page was not found. It has been removed or never existed.\n</div>", $autoId);
         $this->assertSame($js, $jsonResponse['success']['data']['js']);
         $this->assertSame($html, $jsonResponse['success']['data']['html']);

--- a/tests/library/CM/Http/Response/View/AbstractTest.php
+++ b/tests/library/CM/Http/Response/View/AbstractTest.php
@@ -282,21 +282,18 @@ class CM_Http_Response_View_AbstractTest extends CMTest_TestCase {
         $component = new CM_Component_Notfound([]);
         $viewResponse = new CM_Frontend_ViewResponse($component);
         $request = $this->createRequestAjax($component, 'reloadComponent', ['foo' => 'bar'], $viewResponse);
+        /** @var CM_Http_Response_View_Abstract $response */
         $response = $this->processRequest($request);
         $this->assertViewResponseSuccess($response);
 
-        $frontend = $response->getRender()->getGlobalResponse();
-        $oldAutoId = $viewResponse->getAutoId();
-        $newAutoId = $frontend->getTreeRoot()->getValue()->getAutoId();
+        $jsonResponse = CM_Util::jsonDecode($response->getContent());
 
-        $expected = <<<EOL
-cm.window.appendHidden("<div id=\\"$newAutoId\\" class=\\"CM_Component_Notfound CM_Component_Abstract CM_View_Abstract\\">Sorry, this page was not found. It has been removed or never existed.\\n<\/div>");
-cm.views["$newAutoId"] = new CM_Component_Notfound({el:$("#$newAutoId").get(0),params:{"foo":"bar"}});
-cm.views["$oldAutoId"].getParent().registerChild(cm.views["$newAutoId"]);
-cm.views["$oldAutoId"].replaceWithHtml(cm.views["$newAutoId"].\$el);
-cm.views["$newAutoId"]._ready();
-EOL;
-        $this->assertSame($expected, $frontend->getJs());
+        // can't get the autoId from the globalResponse because of https://github.com/cargomedia/cm/blob/master/library/CM/Http/Response/View/Abstract.php#L135
+        $autoId = $jsonResponse['success']['data']['autoId'];
+        $js = sprintf('cm.views["%s"] = new CM_Component_Notfound({el:$("#%s").get(0),params:{"foo":"bar"}});', $autoId, $autoId);
+        $html = sprintf("<div id=\"%s\" class=\"CM_Component_Notfound CM_Component_Abstract CM_View_Abstract\">Sorry, this page was not found. It has been removed or never existed.\n</div>", $autoId);
+        $this->assertSame($js, $jsonResponse['success']['data']['js']);
+        $this->assertSame($html, $jsonResponse['success']['data']['html']);
     }
 
     public function testReloadComponentAdditionalParams() {
@@ -309,21 +306,18 @@ EOL;
         $component = new CM_Component_Mock();
         $viewResponse = new CM_Frontend_ViewResponse($component);
         $request = $this->createRequestAjax($component, 'reloadComponent', ['entity' => $entity], $viewResponse);
+        /** @var CM_Http_Response_View_Abstract $response */
         $response = $this->processRequest($request);
-
         $this->assertViewResponseSuccess($response);
-        $frontend = $response->getRender()->getGlobalResponse();
-        $oldAutoId = $viewResponse->getAutoId();
-        $newAutoId = $frontend->getTreeRoot()->getValue()->getAutoId();
 
-        $expected = <<<EOL
-cm.window.appendHidden("<div id=\\"$newAutoId\\" class=\\"CM_Component_Mock CM_Component_Notfound CM_Component_Abstract CM_View_Abstract\\">Sorry, this page was not found. It has been removed or never existed.\\n<\/div>");
-cm.views["$newAutoId"] = new CM_Component_Mock({el:$("#$newAutoId").get(0),params:{"entity":{"_class":"CM_Model_Entity_Mock2","_type":123,"_id":{"id":"1"},"id":1,"path":null}}});
-cm.views["$oldAutoId"].getParent().registerChild(cm.views["$newAutoId"]);
-cm.views["$oldAutoId"].replaceWithHtml(cm.views["$newAutoId"].\$el);
-cm.views["$newAutoId"]._ready();
-EOL;
-        $this->assertSame($expected, $frontend->getJs());
+        $jsonResponse = CM_Util::jsonDecode($response->getContent());
+
+        // can't get the autoId from the globalResponse because of https://github.com/cargomedia/cm/blob/master/library/CM/Http/Response/View/Abstract.php#L135
+        $autoId = $jsonResponse['success']['data']['autoId'];
+        $js = sprintf('cm.views["%s"] = new CM_Component_Mock({el:$("#%s").get(0),params:{"entity":{"id":1,"path":null}}});', $autoId, $autoId);
+        $html = sprintf("<div id=\"%s\" class=\"CM_Component_Mock CM_Component_Notfound CM_Component_Abstract CM_View_Abstract\">Sorry, this page was not found. It has been removed or never existed.\n</div>", $autoId);
+        $this->assertSame($js, $jsonResponse['success']['data']['js']);
+        $this->assertSame($html, $jsonResponse['success']['data']['html']);
     }
 
     public function testLoadComponent() {

--- a/tests/library/CM/ParamsTest.php
+++ b/tests/library/CM/ParamsTest.php
@@ -2,6 +2,44 @@
 
 class CM_ParamsTest extends CMTest_TestCase {
 
+    public function testMerge() {
+        $text = "Foo Bar, Bar Foo";
+        $notText = new stdClass();
+
+        $object1 = $this->mockInterface('CM_ArrayConvertible')->newInstance();
+        $toArrayMethod = $object1->mockMethod('toArray')->set([
+            'val' => 1,
+        ]);
+        $object2 = $this->mockInterface('CM_ArrayConvertible')->newInstance();
+        $toArrayMethod = $object2->mockMethod('toArray')->set([
+            'val' => 2,
+        ]);
+
+        $params1 = new CM_Params(['foo' => 1, 'bar' => 'text', 'object1' => $object1]);
+        $params2 = new CM_Params(['foz' => 2, 'bar' => 'other', 'object2' => $object2]);
+
+        $this->assertEquals([
+            'foo'     => 1,
+            'bar'     => 'other',
+            'foz'     => 2,
+            'object1' => [
+                '_class' => get_class($object1),
+                'val'    => 1,
+            ],
+            'object2' => [
+                '_class' => get_class($object2),
+                'val'    => 2,
+            ],
+        ], $params1->merge($params2)->getParamsEncoded());
+        $this->assertEquals([
+            'foo'     => 1,
+            'bar'     => 'other',
+            'foz'     => 2,
+            'object1' => $object1,
+            'object2' => $object2,
+        ], $params1->merge($params2)->getParamsDecoded());
+    }
+
     public function testHas() {
         $params = new CM_Params(array('1' => 0, '2' => 'ababa', '3' => new stdClass(), '4' => null, '5' => false));
 
@@ -391,7 +429,7 @@ class CM_ParamsTest extends CMTest_TestCase {
         $this->assertEquals($location, $params->getLocation('location'));
         $this->assertEquals($location, $params->getLocation('locationParameters'));
 
-        /** @var CM_Exception_InvalidParam  $exception */
+        /** @var CM_Exception_InvalidParam $exception */
         $exception = $this->catchException(function () use ($params) {
             $params->getLocation('insufficientParameters');
             $this->fail('Instantiating location with insufficient parameters');


### PR DESCRIPTION
- with the current `reloadComponent`, there's no simple method to get the reloaded component after a `reload()` on the client side
- Allows to redefine some properties after a component reload, ie:
```js
var CM_Component_Foo = CM_Component_Abstract.extend({
  _bar: null,
  // ...
  reload: function() {
    return this
      .try(function() {
        return CM_Component_Abstract.prototype.reload.apply(this, arguments);
      })
      .then(function(newComponent) {
        newComponent._bar = this._bar;
        return newComponent;
      });
  }
});
```