### PR TITLE
Don't fully decode parameters when queueing delayed jobs

### DIFF
--- a/library/CM/Elasticsearch/Type/Abstract.php
+++ b/library/CM/Elasticsearch/Type/Abstract.php
@@ -284,10 +284,10 @@ abstract class CM_Elasticsearch_Type_Abstract extends CM_Class_Abstract implemen
             return;
         }
         $job = new CM_Elasticsearch_UpdateDocumentJob();
-        $job->queue(array(
+        $job->queue(CM_Params::factory([
             'indexClassName' => get_called_class(),
             'id'             => static::getIdForItem($item),
-        ));
+        ], false));
     }
 
     /**

--- a/library/CM/EventHandler/EventHandler.php
+++ b/library/CM/EventHandler/EventHandler.php
@@ -15,7 +15,7 @@ final class CM_EventHandler_EventHandler {
         $this->bind($event, function (array $jobParams = null) use ($job, $defaultJobParams) {
             $jobParams = (array) $jobParams;
             $jobParams = array_merge($defaultJobParams, $jobParams);
-            $job->queue($jobParams);
+            $job->queue(CM_Params::factory($jobParams), false);
         });
     }
 }

--- a/library/CM/Jobdistribution/DelayedQueue.php
+++ b/library/CM/Jobdistribution/DelayedQueue.php
@@ -43,7 +43,7 @@ class CM_Jobdistribution_DelayedQueue implements CM_Service_ManagerAwareInterfac
         while ($row = $result->fetch()) {
             $job = $this->_instantiateJob($row['className']);
             if ($job) {
-                $job->queue(CM_Params::decode($row['params'], true));
+                $job->queue(CM_Util::jsonDecode($row['params']));
             }
         }
         CM_Db_Db::delete('cm_jobdistribution_delayedqueue', '`executeAt` <= ' . $executeAtMax);

--- a/library/CM/Jobdistribution/DelayedQueue.php
+++ b/library/CM/Jobdistribution/DelayedQueue.php
@@ -43,7 +43,7 @@ class CM_Jobdistribution_DelayedQueue implements CM_Service_ManagerAwareInterfac
         while ($row = $result->fetch()) {
             $job = $this->_instantiateJob($row['className']);
             if ($job) {
-                $job->queue(CM_Util::jsonDecode($row['params']));
+                $job->queue(CM_Params::factory(CM_Util::jsonDecode($row['params']), true));
             }
         }
         CM_Db_Db::delete('cm_jobdistribution_delayedqueue', '`executeAt` <= ' . $executeAtMax);

--- a/library/CM/Jobdistribution/Job/Noop.php
+++ b/library/CM/Jobdistribution/Job/Noop.php
@@ -3,5 +3,8 @@
 class CM_Jobdistribution_Job_Noop extends CM_Jobdistribution_Job_Abstract {
 
     protected function _execute(CM_Params $params) {
+        (new CM_File(DIR_ROOT . 'log.txt'))->appendLine(var_export($params->getParamsEncoded(), true));
+        $user = $params->getPhoto('photo');
+        (new CM_File(DIR_ROOT . 'log.txt'))->appendLine(CM_Util::jsonEncode($user->toArray()));
     }
 }

--- a/library/CM/Mail/Mailable.php
+++ b/library/CM/Mail/Mailable.php
@@ -87,7 +87,7 @@ class CM_Mail_Mailable extends CM_View_Abstract implements CM_Typed {
             $params['recipient'] = $recipient;
             $params['mailType'] = $this->getType();
         }
-        $job->queue($params);
+        $job->queue(CM_Params::factory($params, false));
     }
 
     /**

--- a/library/CM/Params.php
+++ b/library/CM/Params.php
@@ -23,6 +23,15 @@ class CM_Params extends CM_Class_Abstract implements CM_Debug_DebugInfoInterface
     }
 
     /**
+     * @return boolean
+     */
+    public function isFullyEncoded() {
+        return \Functional\none($this->_params, function($param) {
+            return null === $param['encoded'];
+        });
+    }
+
+    /**
      * @param string     $key
      * @param mixed|null $default
      * @return mixed

--- a/library/CMService/GoogleAnalytics/MeasurementProtocol/Client.php
+++ b/library/CMService/GoogleAnalytics/MeasurementProtocol/Client.php
@@ -69,7 +69,7 @@ class CMService_GoogleAnalytics_MeasurementProtocol_Client {
      */
     protected function _queueHit(array $parameterList) {
         $job = new CMService_GoogleAnalytics_MeasurementProtocol_SendHitJob();
-        $job->queue($parameterList);
+        $job->queue(CM_Params::factory($parameterList, false));
     }
 
     /**

--- a/library/CMService/KissMetrics/Client.php
+++ b/library/CMService/KissMetrics/Client.php
@@ -89,12 +89,12 @@ EOF;
             $this->setUserId($actor->getId());
         }
         $trackEventJob = new CMService_KissMetrics_TrackEventJob();
-        $trackEventJob->queue(array(
+        $trackEventJob->queue(CM_Params::factory([
             'code'         => $this->_getCode(),
             'identityList' => $this->_getIdentityList(),
             'eventName'    => $action->getLabel(),
             'propertyList' => $action->getTrackingPropertyList(),
-        ));
+        ], false));
     }
 
     /**
@@ -156,11 +156,11 @@ EOF;
                 break;
         }
         $trackEventJob = new CMService_KissMetrics_TrackPropertyListJob();
-        $trackEventJob->queue(array(
+        $trackEventJob->queue(CM_Params::factory([
             'code'         => $this->_getCode(),
             'identityList' => $this->_getIdentityList(),
-            'propertyList' => array('Splittest ' . $nameSplittest => $nameVariation),
-        ));
+            'propertyList' => ['Splittest ' . $nameSplittest => $nameVariation],
+        ]), false);
     }
 
     /**

--- a/tests/library/CM/Jobdistribution/DelayedQueueTest.php
+++ b/tests/library/CM/Jobdistribution/DelayedQueueTest.php
@@ -11,13 +11,20 @@ class CM_JobDistribution_DelayedQueueTest extends CMTest_TestCase {
         $job = $this->mockObject('CM_Jobdistribution_Job_Abstract');
         $params1 = ['foo' => 12, 'bar' => 13];
         $params2 = ['foo' => 12, 'bar' => CMTest_TH::createUser()];
+        $params3 = [];
+        $userDeleted = CMTest_TH::createUser();
+        $params4 = ['bar' => $userDeleted];
+        $params4Expected = CM_Params::encode($params4);
         /** @var \Mocka\FunctionMock $queueMethod */
         $queueMethod = $job->mockMethod('queue')
             ->at(0, function (array $params) use ($params1) {
                 $this->assertEquals($params1, $params);
             })
             ->at(1, function (array $params) use ($params2) {
-                $this->assertEquals($params2, $params);
+                $this->assertEquals(CM_Params::encode($params2), $params);
+            })
+            ->at(2, function (array $params) use ($params4Expected) {
+                $this->assertEquals($params4Expected, $params);
             });
 
         /** @var CM_Jobdistribution_DelayedQueue|\Mocka\AbstractClassTrait $delayedQueue */
@@ -32,12 +39,18 @@ class CM_JobDistribution_DelayedQueueTest extends CMTest_TestCase {
                 $this->assertSame(get_class($job), $className);
                 return $job;
             })
-            ->at(2, null);
+            ->at(2, null)
+            ->at(3, function ($className) use ($job) {
+                $this->assertSame(get_class($job), $className);
+                return $job;
+            });
 
         $delayedQueue->addJob($job, $params2, 3);
         $delayedQueue->addJob($job, $params1, 2);
-        $delayedQueue->addJob($job, [], 4);
+        $delayedQueue->addJob($job, $params3, 4);
+        $delayedQueue->addJob($job, $params4, 4);
 
+        $userDeleted->delete();
         $delayedQueue->queueOutstanding();
         $this->assertSame(0, $queueMethod->getCallCount());
 
@@ -47,9 +60,9 @@ class CM_JobDistribution_DelayedQueueTest extends CMTest_TestCase {
 
         CMTest_TH::timeForward(2);
         $delayedQueue->queueOutstanding();
-        $this->assertSame(2, $queueMethod->getCallCount());
+        $this->assertSame(3, $queueMethod->getCallCount());
 
-        $this->assertSame(3, $instantiateMethod->getCallCount());
+        $this->assertSame(4, $instantiateMethod->getCallCount());
     }
 
     public function testCancelJob() {
@@ -62,7 +75,7 @@ class CM_JobDistribution_DelayedQueueTest extends CMTest_TestCase {
         $params2 = ['foo' => 2, 'bar' => $user];
 
         $queueExecMethod = $jobToExec->mockMethod('queue')->set(function (array $params) use ($params1) {
-            $this->assertEquals($params1, $params);
+            $this->assertEquals(CM_Params::encode($params1), $params);
         });
         $queueCancelMethod = $jobToCancel->mockMethod('queue');
         /** @var CM_Jobdistribution_DelayedQueue|\Mocka\AbstractClassTrait $delayedQueue */

--- a/tests/library/CM/Jobdistribution/DelayedQueueTest.php
+++ b/tests/library/CM/Jobdistribution/DelayedQueueTest.php
@@ -17,14 +17,14 @@ class CM_JobDistribution_DelayedQueueTest extends CMTest_TestCase {
         $params4Expected = CM_Params::encode($params4);
         /** @var \Mocka\FunctionMock $queueMethod */
         $queueMethod = $job->mockMethod('queue')
-            ->at(0, function (array $params) use ($params1) {
-                $this->assertEquals($params1, $params);
+            ->at(0, function (CM_Params $params) use ($params1) {
+                $this->assertEquals($params1, $params->getParamsDecoded());
             })
-            ->at(1, function (array $params) use ($params2) {
-                $this->assertEquals(CM_Params::encode($params2), $params);
+            ->at(1, function (CM_Params $params) use ($params2) {
+                $this->assertEquals($params2, $params->getParamsDecoded());
             })
-            ->at(2, function (array $params) use ($params4Expected) {
-                $this->assertEquals($params4Expected, $params);
+            ->at(2, function (CM_Params $params) use ($params4Expected) {
+                $this->assertEquals($params4Expected, $params->getParamsEncoded());
             });
 
         /** @var CM_Jobdistribution_DelayedQueue|\Mocka\AbstractClassTrait $delayedQueue */
@@ -74,8 +74,8 @@ class CM_JobDistribution_DelayedQueueTest extends CMTest_TestCase {
         $params1 = ['foo' => 1, 'bar' => $user];
         $params2 = ['foo' => 2, 'bar' => $user];
 
-        $queueExecMethod = $jobToExec->mockMethod('queue')->set(function (array $params) use ($params1) {
-            $this->assertEquals(CM_Params::encode($params1), $params);
+        $queueExecMethod = $jobToExec->mockMethod('queue')->set(function (CM_Params $params) use ($params1) {
+            $this->assertEquals(CM_Params::encode($params1), $params->getParamsEncoded());
         });
         $queueCancelMethod = $jobToCancel->mockMethod('queue');
         /** @var CM_Jobdistribution_DelayedQueue|\Mocka\AbstractClassTrait $delayedQueue */

--- a/tests/library/CM/User/OfflineJobTest.php
+++ b/tests/library/CM/User/OfflineJobTest.php
@@ -13,12 +13,12 @@ class CM_User_OfflineJobTest extends CMTest_TestCase {
 
         $job = new CM_User_OfflineJob();
         $this->assertSame(true, $user->getOnline());
-        $job->run(['user' => $user]);
+        $job->run(CM_Params::factory(['user' => $user], false));
         CMTest_TH::reinstantiateModel($user);
         $this->assertSame(true, $user->getOnline());
 
         $userChannel->delete();
-        $job->run(['user' => $user]);
+        $job->run(CM_Params::factory(['user' => $user], false));
         CMTest_TH::reinstantiateModel($user);
         $this->assertSame(false, $user->getOnline());
     }


### PR DESCRIPTION
fixes https://github.com/cargomedia/sk/issues/4547

Instead of fully decoding and thereby implicitly instantiating ArrayConvertibles, they should just be jsonDecoded and passed to the job in their array-form.
Exceptions will be thrown at job-execution inside the worker as it is with non-delayed jobs.