### PR TITLE
Make sure events "foatbox-open" and "-close" don't bubble

### DIFF
--- a/client-vendor/after-body/jquery.floatbox/jquery.floatbox.js
+++ b/client-vendor/after-body/jquery.floatbox/jquery.floatbox.js
@@ -96,7 +96,7 @@
       this.$floatbox.trap();
 
       this.$layer.data('floatbox', this);
-      $element.trigger('floatbox-open');
+      $element.triggerHandler('floatbox-open');
     },
     close: function() {
       if (!this.options.closable) {
@@ -106,7 +106,7 @@
       if (this.$parent.length) {
         this.$parent.append($element);
       }
-      this.$floatbox.trigger('floatbox-close');
+      this.$floatbox.triggerHandler('floatbox-close');
       this.$layer.remove();
       $viewport.children('.floatbox-layer:last').addClass('active');
       if (lastFocusedElement) {
@@ -122,7 +122,7 @@
         $body.css({top: 0, left: 0});
       }
       $(window).off('resize.floatbox', this.windowResizeCallback);
-      $element.trigger('floatbox-close');
+      $element.triggerHandler('floatbox-close');
 
       this.$parent = null;
       this.$floatbox = null;


### PR DESCRIPTION
Addressing https://github.com/cargomedia/sk/issues/4534 

jQuery's `trigger()` triggers a native event on the DOM that bubbles up through the element hierarchy. We usually bind on specific elements about these events. So if a floatbox *inside* such an element is opened/closed we wrongly assume the outer floatbox got opened/closed.

The function `triggerHandler()` only triggers jQuery-internal handlers, and thus doesn't bubble.


@christopheschwyzer please review/test